### PR TITLE
fix: adjust remote replacement conditions

### DIFF
--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -196,13 +196,8 @@ export class ZephyrEngine {
         name: app_name,
       });
 
-      if (should_not_replace_remote(dep.version)) {
-        return {
-          name: dep.name,
-          version: dep.version,
-          platform,
-        } as ZeResolvedDependency;
-      }
+      // if default url is url - set as default, if not use app remote_host as default
+      // if default url is not url - send it as a semver to deps resolution
 
       const tuple = await ZeUtils.PromiseTuple(
         resolve_remote_dependency({
@@ -381,16 +376,6 @@ export class ZephyrEngine {
 
     await this.build_finished();
   }
-}
-
-// Identify situations when remote URL should not be replaced
-// - Version URL is fixed to a deployed remote
-// - Version URL contains old promise syntax
-function should_not_replace_remote(version_url: string) {
-  if (version_url.includes('https://')) return true;
-  if (version_url.startsWith('promise new Promise')) return true;
-
-  return false;
 }
 
 function mut_zephyr_app_uid(ze: ZephyrEngine): void {

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -196,11 +196,7 @@ export class ZephyrEngine {
         name: app_name,
       });
 
-      // if default url is url - set as default, if not use app remote_host as default
-      // if default url is not url - send it as a semver to deps resolution
-      // if dep.version is a valid url from production (something start with https://) skip resolving but return the url to allow custom environment
-
-      if (dep.version.startsWith('https://') || !dep.version.includes('localhost')) {
+      if (should_not_replace_remote(dep.version)) {
         return {
           name: dep.name,
           version: dep.version,
@@ -385,6 +381,16 @@ export class ZephyrEngine {
 
     await this.build_finished();
   }
+}
+
+// Identify situations when remote URL should not be replaced
+// - Version URL is fixed to a deployed remote
+// - Version URL contains old promise syntax
+function should_not_replace_remote(version_url: string) {
+  if (version_url.includes('https://')) return true;
+  if (version_url.startsWith('promise new Promise')) return true;
+
+  return false;
 }
 
 function mut_zephyr_app_uid(ze: ZephyrEngine): void {

--- a/libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts
@@ -47,7 +47,9 @@ export function mutWebpackFederatedRemotesConfig<Compiler>(
       }
 
       // todo: this is a version with named export logic, we should take this into account later
-      const [v_app] = remote_version.includes('@') ? remote_version.split('@') : [];
+      const [v_app] = remote_version.includes('@')
+        ? remote_version.split('@')
+        : [remote_name];
 
       ze_log(`v_app: ${v_app}`);
       if (v_app) {

--- a/libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts
@@ -26,10 +26,8 @@ export function mutWebpackFederatedRemotesConfig<Compiler>(
       return;
     }
 
-    const library_type =
-      (remotesConfig.library?.type ?? zephyr_engine.builder === 'repack')
-        ? 'var'
-        : 'self';
+    const library_type = remotesConfig.library?.type ?? 'var';
+
     ze_log(`Library type: ${library_type}`);
 
     Object.entries(remotes).map((remote) => {


### PR DESCRIPTION
### What's added in this PR?

When testing an example that contained [external-remotes-plugin](https://www.npmjs.com/package/external-remotes-plugin) that has the following remote format `remote1: remote1[remote1url]/remoteEntry.js`, the example was not getting the URL replaced by our Zephyr delegates.

This aims to fix it and also add the condition to not replace in the case of another `promise new Promise` syntax.

#### Screenshots

> _If applicable, add some screenshots of the expected behavior._

### What's the issues or discussion related to this PR ?

> _Provide some background information related to this PR, including issues or task. Prior to this PR what's the behavior that wasn't expected._

> _If there wasn't discussion related to this PR, you can include the reasoning behind this PR of why you did it._

### What are the steps to test this PR?

> _To help reviewer and tester to understand what's needed_

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [ ] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [ ] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
