### PR TITLE
fix: no unused vars error lint override

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
       "files": ["*.ts", "*.tsx"],
       "extends": ["plugin:@nx/typescript"],
       "rules": {
+        "@typescript-eslint/no-unused-vars": "error",
         "@typescript-eslint/no-extra-semi": "error",
         "no-extra-semi": "off"
       }

--- a/examples/react-micro-frontends/apps/team-blue/src/app/team-blue-basket.tsx
+++ b/examples/react-micro-frontends/apps/team-blue/src/app/team-blue-basket.tsx
@@ -11,9 +11,7 @@ const state: { count: number } = {
 };
 
 export default function BlueBasket({ id }: { id: string }) {
-  const [classname, setClassname] = useState(
-    state.count === 0 ? 'empty' : 'filled'
-  );
+  const [classname] = useState(state.count === 0 ? 'empty' : 'filled');
   const [count, setCount] = useState(state.count);
 
   useEffect(() => {

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
@@ -18,11 +18,11 @@ export function withZephyr(_options?: VitePluginZephyrOptions): Plugin[] {
   if (mfConfig) {
     plugins.push(...(federation(mfConfig) as Plugin[]));
   }
-  plugins.push(zephyrPlugin(_options));
+  plugins.push(zephyrPlugin());
   return plugins;
 }
 
-function zephyrPlugin(_options?: VitePluginZephyrOptions): Plugin {
+function zephyrPlugin(): Plugin {
   const { zephyr_engine_defer, zephyr_defer_create } = ZephyrEngine.defer_create();
 
   let resolve_vite_internal_options: (value: ZephyrInternalOptions) => void;

--- a/libs/zephyr-agent/src/lib/errors/zephyr-error.ts
+++ b/libs/zephyr-agent/src/lib/errors/zephyr-error.ts
@@ -89,8 +89,8 @@ export class ZephyrError<
     if (opts) {
       const { cause, data, ...template } = opts;
       this.template = template;
-      this.data = opts.data;
-      this.cause = opts.cause;
+      this.data = data;
+      this.cause = cause;
     }
 
     // Simpler stack traces in VIte

--- a/libs/zephyr-repack-plugin/src/lib/utils/ze-util-verification.ts
+++ b/libs/zephyr-repack-plugin/src/lib/utils/ze-util-verification.ts
@@ -1,4 +1,3 @@
-``; // import { UploadProviderType } from '../../../../zephyr-agent/src/lib/node-persist/upload-provider-options';
 import { ZeErrors, ZephyrError } from 'zephyr-agent';
 import { ZephyrEngine } from 'zephyr-agent';
 

--- a/libs/zephyr-repack-plugin/src/lib/utils/ze-util-verification.ts
+++ b/libs/zephyr-repack-plugin/src/lib/utils/ze-util-verification.ts
@@ -1,4 +1,4 @@
-// import { UploadProviderType } from '../../../../zephyr-agent/src/lib/node-persist/upload-provider-options';
+``; // import { UploadProviderType } from '../../../../zephyr-agent/src/lib/node-persist/upload-provider-options';
 import { ZeErrors, ZephyrError } from 'zephyr-agent';
 import { ZephyrEngine } from 'zephyr-agent';
 
@@ -32,7 +32,7 @@ export async function verify_mf_fastly_config(
 ) {
   if (!mf_configs) return;
 
-  const platform = (await zephyr_engine.application_configuration).PLATFORM;
+  await zephyr_engine.application_configuration;
 
   for (const mf_config of mf_configs) {
     const mfConfig = mf_config.config;

--- a/libs/zephyr-xpack-internal/src/federation-dashboard-legacy/utils/federation-dashboard-plugin/FederationDashboardPlugin.ts
+++ b/libs/zephyr-xpack-internal/src/federation-dashboard-legacy/utils/federation-dashboard-plugin/FederationDashboardPlugin.ts
@@ -584,7 +584,7 @@ export class FederationDashboardPlugin {
     return { remote_bundle_name: this.FederationPluginOptions.bundle_name };
   }
 
-  async postDashboardData(dashData: any): Promise<
+  async postDashboardData(): Promise<
     | {
         value: ZeUploadBuildStats;
       }

--- a/libs/zephyr-xpack-internal/src/xpack-extract/extract-federated-dependency-pairs.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/extract-federated-dependency-pairs.ts
@@ -4,7 +4,6 @@ import {
   readPackageJson,
 } from 'zephyr-agent';
 
-import { iterateFederationConfig } from './iterate-federation-config';
 import { XFederatedRemotesConfig, XPackConfiguration } from '../xpack.types';
 import { iterateFederatedRemoteConfig } from './iterate-federated-remote-config';
 


### PR DESCRIPTION
### What's added in this PR?

Override lint rule to show error on `no-unused-vars`.
Requested by @valorkin 

#### Screenshots

> _If applicable, add some screenshots of the expected behavior._

### What's the issues or discussion related to this PR ?

> _Provide some background information related to this PR, including issues or task. Prior to this PR what's the behavior that wasn't expected._

> _If there wasn't discussion related to this PR, you can include the reasoning behind this PR of why you did it._

### What are the steps to test this PR?

> _To help reviewer and tester to understand what's needed_

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [ ] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [ ] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
