### PR TITLE
feat: add logs when ZE_SECRET_TOKEN found

### DIFF
--- a/libs/zephyr-agent/src/lib/auth/login.ts
+++ b/libs/zephyr-agent/src/lib/auth/login.ts
@@ -24,6 +24,7 @@ export async function checkAuth(): Promise<string> {
   const secret_token = getSecretToken();
 
   if (secret_token) {
+    logFn('debug', 'Token found in environment. Using secret token for authentication.');
     return secret_token;
   }
 


### PR DESCRIPTION
### What's added in this PR?

Not having a log for when deploying with a Zephyr token makes missing it quite easy and lose debugging time to it. 

Adding a log makes sense.

#### Screenshots

![CleanShot 2025-02-25 at 11 11 41](https://github.com/user-attachments/assets/c96bee8e-3b6e-4304-9455-43aef9b662e4)

### What are the steps to test this PR?

1. See screenshot above.
2. Add environment via CLI or exporting it to CLI.
3. Build a sample app and see the log is there.

### Documentation update for this PR (if applicable)?

https://github.com/ZephyrCloudIO/zephyr-documentation/pull/80

### (Required) Pre-PR/Merge checklist

- [X] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [X] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [X] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [X] I have/will run tests, or ask for help to add test
