### PR TITLE
feat: Capture git tags in the git key of snapshot data

### DIFF
--- a/examples/vite-react-ts/package.json
+++ b/examples/vite-react-ts/package.json
@@ -8,7 +8,6 @@
     "prebuild": "nx build vite-plugin-zephyr",
     "build": "tsc && vite build",
     "build-watch": "tsc && vite build --watch",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
@@ -69,7 +69,7 @@ async function loadGitInfo(hasSecretToken: boolean) {
     // Parse tags - if multiple tags point to HEAD, they'll be on separate lines
     const tags = tagsOutput ? tagsOutput.split('\n').filter(Boolean) : [];
 
-    const gitData = {
+    return {
       name,
       email,
       remoteOrigin,
@@ -78,7 +78,6 @@ async function loadGitInfo(hasSecretToken: boolean) {
       tags,
       stdout,
     };
-    return gitData;
   } catch (cause: unknown) {
     const error = cause as Error & { stderr?: string };
     throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {

--- a/libs/zephyr-edge-contract/src/lib/plugin-options/zephyr-webpack-plugin-options.ts
+++ b/libs/zephyr-edge-contract/src/lib/plugin-options/zephyr-webpack-plugin-options.ts
@@ -21,6 +21,7 @@ export interface ZephyrPluginOptions {
     email: string;
     branch: string;
     commit: string;
+    tags?: string[];
   };
   mfConfig?: {
     name: string;

--- a/libs/zephyr-edge-contract/src/lib/snapshot.ts
+++ b/libs/zephyr-edge-contract/src/lib/snapshot.ts
@@ -20,6 +20,7 @@ export interface Snapshot {
     email?: string;
     branch: string;
     commit: string;
+    tags?: string[];
   };
   // zephyr user
   creator: {

--- a/libs/zephyr-edge-contract/src/lib/zephyr-build-stats.ts
+++ b/libs/zephyr-edge-contract/src/lib/zephyr-build-stats.ts
@@ -93,6 +93,14 @@ export interface ZephyrBuildStats {
      * @requires To build a successfully through Zephyr user must have this field
      */
     commit: string;
+
+    /**
+     * Git tags that point to the current commit, retrieved using `git tag --points-at
+     * HEAD`
+     *
+     * @optional This field will be an empty array if no tags point to the current commit
+     */
+    tags?: string[];
   };
   context: {
     username?: string;


### PR DESCRIPTION
### What's added in this PR?

We now capture the git tags in the snapshot data when the users runs a build if there are any. If not we default to an empty array

#### Screenshots
![image](https://github.com/user-attachments/assets/6b5a7055-e916-443d-b620-6f7a1667777c)

### What's the issues or discussion related to this PR ?

Customer request github tags as a condition for zephry tags

### What are the steps to test this PR?

Run a build with this version of the plug and view the git information in the snapshot. You should see an empty tag array.
Add a tag to your current branch `git tag -a "tag_to_test" -m "tag message optional property"
Run a build since the tag has been added and you should see an array with the `tag_to_test` string in it.

### Documentation update for this PR (if applicable)?

We could document how to use tags in github and tags in zephyr to manage your devops flow.

### (Optional) What's left to be done for this PR?

Add tags as a condition to match on in zephyr cloud IO

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
