### PR TITLE
fix: use provenance for main release too

### DIFF
--- a/.github/workflows/on_pre_release.yml
+++ b/.github/workflows/on_pre_release.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Build packages
-        run: pnpm dlx nx run-many -t build --projects="libs/*"
+        run: pnpm build
       - name: Publish package on NPM 📦
         run: pnpm ze-publish --tag=next

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Build packages
-        run: pnpm dlx nx run-many -t build --projects="libs/*"
-      - name: Release libraries
-        run: pnpm dlx nx run-many -t release --projects="libs/*"
+        run: pnpm build
+      - name: Publish package on NPM 📦
+        run: pnpm ze-publish


### PR DESCRIPTION
### What's added in this PR?

Because our release and pre-release GitHub actions were not using `package.json` scripts but using their own, even after https://github.com/ZephyrCloudIO/zephyr-packages/pull/87, only prerelease would publish with provenance.

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
