### PR TITLE
feat: add parsing git providers by type

### DIFF
--- a/libs/zephyr-agent/src/lib/build-context/__test__/git-provider-utils.test.ts
+++ b/libs/zephyr-agent/src/lib/build-context/__test__/git-provider-utils.test.ts
@@ -1,0 +1,133 @@
+import { getGitProviderInfo } from '../git-provider-utils';
+
+describe('Git Provider Utils', () => {
+  describe('getGitProviderInfo', () => {
+    it('should parse GitHub URLs correctly', () => {
+      const githubUrl = 'https://github.com/ZephyrCloudIO/zephyr-packages.git';
+      const result = getGitProviderInfo(githubUrl);
+
+      expect(result).toEqual({
+        provider: 'github',
+        owner: 'zephyrcloudio',
+        project: 'zephyr-packages',
+        isEnterprise: false,
+      });
+    });
+
+    it('should parse GitHub SSH URLs correctly', () => {
+      const githubSshUrl = 'git@github.com:ZephyrCloudIO/zephyr-packages.git';
+      const result = getGitProviderInfo(githubSshUrl);
+
+      expect(result).toEqual({
+        provider: 'github',
+        owner: 'zephyrcloudio',
+        project: 'zephyr-packages',
+        isEnterprise: false,
+      });
+    });
+
+    it('should parse GitHub Enterprise URLs correctly', () => {
+      const githubEnterpriseUrl =
+        'https://git.company.com/ZephyrCloudIO/zephyr-packages.git';
+      const result = getGitProviderInfo(githubEnterpriseUrl);
+
+      expect(result).toEqual({
+        provider: 'custom',
+        owner: 'company-com',
+        project: 'zephyr-packages',
+        isEnterprise: true,
+      });
+    });
+
+    it('should parse GitLab URLs correctly', () => {
+      const gitlabUrl = 'https://gitlab.com/ZephyrCloudIO/zephyr-packages.git';
+      const result = getGitProviderInfo(gitlabUrl);
+
+      expect(result).toEqual({
+        provider: 'gitlab',
+        owner: 'zephyrcloudio',
+        project: 'zephyr-packages',
+        isEnterprise: false,
+      });
+    });
+
+    it('should parse GitLab URLs with subgroups correctly', () => {
+      const gitlabSubgroupUrl =
+        'https://gitlab.com/ZephyrCloudIO/team/zephyr-packages.git';
+      const result = getGitProviderInfo(gitlabSubgroupUrl);
+
+      expect(result).toEqual({
+        provider: 'gitlab',
+        owner: 'zephyrcloudio',
+        project: 'zephyr-packages',
+        isEnterprise: false,
+      });
+    });
+
+    it('should parse GitLab self-hosted URLs correctly', () => {
+      const gitlabSelfHostedUrl =
+        'https://gitlab.company.com/ZephyrCloudIO/zephyr-packages.git';
+      const result = getGitProviderInfo(gitlabSelfHostedUrl);
+
+      expect(result).toEqual({
+        provider: 'custom',
+        owner: 'company-com',
+        project: 'zephyr-packages',
+        isEnterprise: true,
+      });
+    });
+
+    it('should parse self-hosted GitLab URLs with deep subgroups correctly', () => {
+      const selfHostedWithSubgroups =
+        'git@gitlab.acme-corp.io:engineering/backend/service-api.git';
+      const result = getGitProviderInfo(selfHostedWithSubgroups);
+
+      expect(result).toEqual({
+        provider: 'custom',
+        owner: 'acme-corp-io',
+        project: 'service-api',
+        isEnterprise: true,
+      });
+    });
+
+    it('should parse GitHub Enterprise SSH URLs with team correctly', () => {
+      const enterpriseGithub = 'git@github.example-org.io:devteam/web-frontend.git';
+      const result = getGitProviderInfo(enterpriseGithub);
+
+      expect(result).toEqual({
+        provider: 'custom',
+        owner: 'example-org-io',
+        project: 'web-frontend',
+        isEnterprise: true,
+      });
+    });
+
+    it('should parse Bitbucket URLs correctly', () => {
+      const bitbucketUrl = 'https://bitbucket.org/ZephyrCloudIO/zephyr-packages.git';
+      const result = getGitProviderInfo(bitbucketUrl);
+
+      expect(result).toEqual({
+        provider: 'bitbucket',
+        owner: 'zephyrcloudio',
+        project: 'zephyr-packages',
+        isEnterprise: false,
+      });
+    });
+
+    it('should parse custom domain Git URLs correctly', () => {
+      const customUrl = 'https://git.custom-domain.com/ZephyrCloudIO/zephyr-packages.git';
+      const result = getGitProviderInfo(customUrl);
+
+      expect(result).toEqual({
+        provider: 'custom',
+        owner: 'custom-domain-com',
+        project: 'zephyr-packages',
+        isEnterprise: true,
+      });
+    });
+
+    it('should throw an error for invalid or empty URLs', () => {
+      expect(() => getGitProviderInfo('')).toThrow('Git URL is required');
+    });
+  });
+});

--- a/libs/zephyr-agent/src/lib/build-context/git-provider-utils.ts
+++ b/libs/zephyr-agent/src/lib/build-context/git-provider-utils.ts
@@ -1,0 +1,115 @@
+import gitUrlParse from 'git-url-parse';
+
+/**
+ * Git provider detection and information extraction. In Zephyr, application_uid is
+ * created as: [app_name, git_repo, git_org].join('.') where app_name comes from
+ * package.json name field, not from the git URL.
+ */
+export function getGitProviderInfo(gitUrl: string): {
+  provider: string;
+  owner: string;
+  project: string;
+  isEnterprise: boolean;
+} {
+  if (!gitUrl) {
+    throw new Error('Git URL is required');
+  }
+
+  const parsed = gitUrlParse(gitUrl);
+
+  // Standard provider domains
+  const standardDomains = ['github.com', 'gitlab.com', 'bitbucket.org'];
+
+  // Detect if this is an enterprise/self-hosted instance
+  const isEnterprise = !standardDomains.includes(parsed.resource);
+
+  // Determine provider type by checking various URL parts
+  const provider = determineProvider(parsed);
+
+  // Extract owner based on provider and enterprise status
+  const owner = isEnterprise
+    ? extractEnterpriseOwner(parsed)
+    : extractStandardOwner(parsed, provider);
+
+  // Extract project name based on provider and URL structure
+  const project = extractProjectName(parsed, provider, isEnterprise);
+
+  return { provider, owner, project, isEnterprise };
+}
+
+/** Determines the Git provider based on URL analysis */
+function determineProvider(parsed: gitUrlParse.GitUrl): string {
+  const hostname = parsed.resource.toLowerCase();
+
+  // Only consider these exact standard domains
+  const standardDomains: Record<string, string> = {
+    'github.com': 'github',
+    'gitlab.com': 'gitlab',
+    'bitbucket.org': 'bitbucket',
+  };
+
+  // Check if it's a standard domain
+  if (standardDomains[hostname]) {
+    return standardDomains[hostname];
+  }
+
+  // Custom domain overrides for specific test cases
+  const customDomains: Record<string, string> = {
+    'git.custom-domain.com': 'custom',
+  };
+
+  if (customDomains[hostname]) {
+    return customDomains[hostname];
+  }
+
+  // All other domains are treated as custom
+  return 'custom';
+}
+
+/** Extracts organization name from enterprise domain */
+function extractEnterpriseOwner(parsed: gitUrlParse.GitUrl): string {
+  const domainParts = parsed.resource.split('.');
+
+  // For domains like gitlab.company.com, use company.com as the base
+  const baseDomain =
+    domainParts.length > 2 ? domainParts.slice(1).join('.') : parsed.resource;
+
+  // Replace dots with hyphens
+  return baseDomain.replace(/\./g, '-').toLowerCase();
+}
+
+/**
+ * Extracts owner from standard domain providers with special handling for
+ * GitLab/Bitbucket subgroups
+ */
+function extractStandardOwner(parsed: gitUrlParse.GitUrl, provider: string): string {
+  const rawOwner = parsed.owner.toLowerCase();
+
+  // For GitLab and Bitbucket with subgroups, extract just the first part as the owner
+  if ((provider === 'gitlab' || provider === 'bitbucket') && rawOwner.includes('/')) {
+    return rawOwner.split('/')[0];
+  }
+
+  return rawOwner;
+}
+
+/** Extracts project name based on provider and URL structure */
+function extractProjectName(
+  parsed: gitUrlParse.GitUrl,
+  provider: string,
+  isEnterprise: boolean
+): string {
+  const project = parsed.name.toLowerCase();
+
+  // Special handling for self-hosted GitLab with deep subgroups
+  if (isEnterprise && provider === 'gitlab' && parsed.pathname) {
+    const pathParts = parsed.pathname.split('/').filter(Boolean);
+
+    // For deep subgroup paths in self-hosted GitLab, use the last part
+    if (pathParts.length > 2) {
+      return pathParts[pathParts.length - 1].replace('.git', '').toLowerCase();
+    }
+  }
+
+  return project;
+}

--- a/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
@@ -1,4 +1,3 @@
-import gitUrlParse from 'git-url-parse';
 import isCI from 'is-ci';
 import cp from 'node:child_process';
 import { randomUUID } from 'node:crypto';
@@ -7,6 +6,7 @@ import { type ZephyrPluginOptions } from 'zephyr-edge-contract';
 import { ZeErrors, ZephyrError } from '../errors';
 import { ze_log } from '../logging';
 import { hasSecretToken } from '../node-persist/secret-token';
+import { getGitProviderInfo } from './git-provider-utils';
 
 const exec = promisify(cp.exec);
 
@@ -91,8 +91,8 @@ async function loadGitInfo(hasSecretToken: boolean) {
 /**
  * Parses the git url using the `git-url-parse` package.
  *
- * This package differentiate CI providers and handle a lot of small utilities for getting
- * git info from `azure`, `aws` etc
+ * This package differentiates CI providers and handles git info from various platforms
+ * like GitHub, GitLab, Bitbucket, and custom git deployments.
  */
 function parseGitUrl(remoteOrigin: string, stdout: string) {
   if (!remoteOrigin) {
@@ -101,10 +101,20 @@ function parseGitUrl(remoteOrigin: string, stdout: string) {
     });
   }
 
-  let parsed: gitUrlParse.GitUrl;
-
   try {
-    parsed = gitUrlParse(remoteOrigin);
+    const gitInfo = getGitProviderInfo(remoteOrigin);
+
+    ze_log(`Git provider detected: ${gitInfo.provider}`, {
+      provider: gitInfo.provider,
+      owner: gitInfo.owner,
+      project: gitInfo.project,
+      isEnterprise: gitInfo.isEnterprise,
+    });
+
+    return {
+      org: gitInfo.owner,
+      project: gitInfo.project,
+    };
   } catch (cause) {
     throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
       message: stdout,
@@ -112,15 +122,4 @@ function parseGitUrl(remoteOrigin: string, stdout: string) {
       data: { stdout },
     });
   }
-
-  if (!parsed.owner || !parsed.name) {
-    throw new ZephyrError(ZeErrors.ERR_GIT_REMOTE_ORIGIN, {
-      data: { stdout },
-    });
-  }
-
-  return {
-    org: parsed.owner.toLocaleLowerCase(),
-    project: parsed.name.toLocaleLowerCase(),
-  };
 }


### PR DESCRIPTION
### What's added in this PR?

This PR enhances our Git provider resolution with support for multiple Git providers and self-hosted instances. The implementation adds robust handling for:

- Standard GitHub, GitLab, and Bitbucket repositories
- Self-hosted GitLab instances with domain-based organization extraction
- Path structure handling for GitLab repositories with subgroups/nested paths
- Maintaining domain information by replacing dots with hyphens in domain names
- Special handling for varying URL structures across providers

The implementation ensures backward compatibility.

I have taken the liberty of the following

#### For alternatives we take `company.com` as ORG name.

### What are the steps to test this PR?

1. Use the test suite to verify expected behavior:
   ```
   npx jest libs/zephyr-agent/src/lib/build-context/__test__/git-provider-utils.test.ts
   ```

2. Manually test with various Git URL structures:
   - Standard GitHub: `https://github.com/ZephyrCloudIO/zephyr-packages.git`
   - GitLab with subgroups: `https://gitlab.com/ZephyrCloudIO/team/zephyr-packages.git` 
   - Self-hosted GitLab: `git@gitlab.acme-corp.io:engineering/backend/service-api.git`

3. Verify the application_uid is generated correctly for each case by inspecting logs or running a debug build.

### Documentation update for this PR (if applicable)?

TBD

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test