### PR TITLE
fix: provenance for canary release workflow

### DIFF
--- a/.github/workflows/on_canary_release.yml
+++ b/.github/workflows/on_canary_release.yml
@@ -2,6 +2,9 @@ name: On Canary Release
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What's added in this PR?

We added provenance for releases but canary workflow was missing id-token write permissions.

#### Screenshots

![image](https://github.com/user-attachments/assets/e7190703-8337-446a-af48-b90fe9d42e2c)

### What's the issues or discussion related to this PR ?

https://github.com/ZephyrCloudIO/zephyr-packages/actions/runs/14740765019/job/41377921414

### What are the steps to test this PR?

Canary release on this branch must be working.

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [ ] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
