### PR TITLE
fix: retry fetch on 500 status codes

### DIFF
--- a/libs/parcel-reporter-zephyr/src/lib/on-build-success.ts
+++ b/libs/parcel-reporter-zephyr/src/lib/on-build-success.ts
@@ -1,7 +1,7 @@
 import type { BuildSuccessEvent } from '@parcel/types';
-import path from 'path';
-import { getAssetsMap, type ParcelOutputAsset } from './get-assets-map';
-import { logFn, zeBuildDashData, ZephyrError, type ZephyrEngine } from 'zephyr-agent';
+import path from 'node:path';
+import { type ZephyrEngine, ZephyrError, logFn, zeBuildDashData } from 'zephyr-agent';
+import { type ParcelOutputAsset, getAssetsMap } from './get-assets-map';
 
 const assets = new Map<string, ParcelOutputAsset>();
 

--- a/libs/zephyr-agent/src/lib/http/fetch-with-retries.ts
+++ b/libs/zephyr-agent/src/lib/http/fetch-with-retries.ts
@@ -5,7 +5,7 @@ export async function fetchWithRetries(
   options: RequestInit = {},
   retries = 3
 ): Promise<Response> {
-  for (let r = 0; r < retries; r++) {
+  for (let retry = 0; retry < retries; retry++) {
     const response = await fetch(url, options).catch(
       (error) => ({ ok: false, error }) as const
     );

--- a/libs/zephyr-agent/src/lib/http/fetch-with-retries.ts
+++ b/libs/zephyr-agent/src/lib/http/fetch-with-retries.ts
@@ -4,34 +4,42 @@ export async function fetchWithRetries(
   url: URL,
   options: RequestInit = {},
   retries = 3
-): Promise<Response | undefined> {
-  for (let attempt = 1; attempt <= retries; attempt++) {
-    let response: Response | undefined;
+): Promise<Response> {
+  for (let r = 0; r < retries; r++) {
+    const response = await fetch(url, options).catch(
+      (error) => ({ ok: false, error }) as const
+    );
 
-    try {
-      response = await fetch(url, options);
-    } catch (error: any) {
-      // Network failure, retry until attempts are exhausted
-      if (error?.code === 'EPIPE' || error?.message?.includes('network')) {
+    if (response.ok) {
+      return response;
+    }
+
+    // Network failure, retry until attempts are exhausted
+    if ('error' in response) {
+      if (
+        response.error?.code === 'EPIPE' ||
+        response.error?.message?.includes('network')
+      ) {
         continue;
       }
 
       throw new ZephyrError(ZeErrors.ERR_UNKNOWN, {
         message: 'Unknown error occurred',
-        cause: error,
+        cause: response.error,
       });
     }
 
-    if (!response.ok) {
-      throw new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
-        status: response.status,
-        url: url.toString(),
-        content: await response.text(),
-        method: options.method?.toUpperCase() ?? 'GET',
-      });
+    // Retry on server failures
+    if (response.status >= 500) {
+      continue;
     }
 
-    return response;
+    throw new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
+      status: response.status,
+      url: url.toString(),
+      content: await response.text(),
+      method: options.method?.toUpperCase() ?? 'GET',
+    });
   }
 
   throw new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {

--- a/libs/zephyr-agent/src/lib/http/ze-http-request.ts
+++ b/libs/zephyr-agent/src/lib/http/ze-http-request.ts
@@ -108,15 +108,6 @@ export class ZeHttpRequest<T = void> implements PromiseLike<HttpResponse<T>> {
         body: this.#data,
       });
 
-      if (!response) {
-        throw new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
-          content: 'No response found',
-          method: this.#options.method?.toUpperCase() ?? 'GET',
-          url: this.#url.toString(),
-          status: -1,
-        });
-      }
-
       const resText = await response.text();
 
       if (response.status === 401) {


### PR DESCRIPTION
### What's added in this PR?

Pr #97 introduced a bug where 500 status codes from workers would not be retried as previously. This PR simply fixes this regression.

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
