### PR TITLE
feat: disable deploy on serve mode in vite

### DIFF
--- a/libs/vite-plugin-zephyr/src/lib/internal/extract/extract_vite_assets_map.ts
+++ b/libs/vite-plugin-zephyr/src/lib/internal/extract/extract_vite_assets_map.ts
@@ -8,12 +8,10 @@ import {
 import type { OutputAsset, OutputChunk } from 'rollup';
 import { loadStaticAssets } from './load_static_assets';
 import type { ZephyrInternalOptions } from '../types/zephyr-internal-options';
-import { ze_log } from 'zephyr-agent';
 export async function extract_vite_assets_map(
   zephyr_engine: ZephyrEngine,
   vite_internal_options: ZephyrInternalOptions
 ): Promise<ZeBuildAssetsMap> {
-  ze_log('extracting assets map...');
   const application_uid = zephyr_engine.application_uid;
   const assets = await loadStaticAssets(vite_internal_options);
   const partialAssetMap = await getPartialAssetMap(application_uid);

--- a/libs/vite-plugin-zephyr/src/lib/internal/extract/extract_vite_assets_map.ts
+++ b/libs/vite-plugin-zephyr/src/lib/internal/extract/extract_vite_assets_map.ts
@@ -8,11 +8,12 @@ import {
 import type { OutputAsset, OutputChunk } from 'rollup';
 import { loadStaticAssets } from './load_static_assets';
 import type { ZephyrInternalOptions } from '../types/zephyr-internal-options';
-
+import { ze_log } from 'zephyr-agent';
 export async function extract_vite_assets_map(
   zephyr_engine: ZephyrEngine,
   vite_internal_options: ZephyrInternalOptions
 ): Promise<ZeBuildAssetsMap> {
+  ze_log('extracting assets map...');
   const application_uid = zephyr_engine.application_uid;
   const assets = await loadStaticAssets(vite_internal_options);
   const partialAssetMap = await getPartialAssetMap(application_uid);

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
@@ -37,6 +37,9 @@ function zephyrPlugin(): Plugin {
 
     configResolved: async (config: ResolvedConfig) => {
       root = config.root;
+
+      if (config.command === 'serve') return;
+
       zephyr_defer_create({
         builder: 'vite',
         context: config.root,


### PR DESCRIPTION
### What's added in this PR?

Currently we don't deploy during vite's serve mode. This PR disable authentication and request for new build id

#### Screenshots

N/A 

### What's the issues or discussion related to this PR ?

Pending discussion

### What are the steps to test this PR?

run `p --filter react-vite-ts run dev` and it should not shows authentication prompt and request for new build id 

### Documentation update for this PR (if applicable)?

N/A 

### (Optional) What's left to be done for this PR?

Potentially we should enable deploy during serve mode but the logic needed to be changed into other hooks . 

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
