### PR TITLE
feat: add support for new Nx Module Federation plugin system

### DIFF
--- a/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
@@ -1,5 +1,5 @@
 import isCI from 'is-ci';
-import cp from 'node:child_process';
+import { exec as node_exec } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { promisify } from 'node:util';
 import type { ZephyrPluginOptions } from 'zephyr-edge-contract';
@@ -8,7 +8,7 @@ import { ze_log } from '../logging';
 import { hasSecretToken } from '../node-persist/secret-token';
 import { getGitProviderInfo } from './git-provider-utils';
 
-const exec = promisify(cp.exec);
+const exec = promisify(node_exec);
 
 export interface ZeGitInfo {
   app: Pick<ZephyrPluginOptions['app'], 'org' | 'project'>;
@@ -19,8 +19,9 @@ export interface ZeGitInfo {
 export async function getGitInfo(): Promise<ZeGitInfo> {
   const hasToken = hasSecretToken();
 
-  const { name, email, remoteOrigin, branch, commit, tags, stdout } =
-    await loadGitInfo(hasToken);
+  const { name, email, remoteOrigin, branch, commit, tags, stdout } = await loadGitInfo(
+    hasToken
+  );
 
   if (!hasToken && (!name || !email)) {
     throw new ZephyrError(ZeErrors.ERR_NO_GIT_USERNAME_EMAIL, {

--- a/libs/zephyr-xpack-internal/src/federation-dashboard-legacy/get-build-stats.ts
+++ b/libs/zephyr-xpack-internal/src/federation-dashboard-legacy/get-build-stats.ts
@@ -1,8 +1,9 @@
-import type { ZephyrBuildStats } from 'zephyr-edge-contract';
-import { FederationDashboardPlugin } from './utils/federation-dashboard-plugin/FederationDashboardPlugin';
 import type { ZephyrEngine } from 'zephyr-agent';
 import { ze_log, ZeErrors, ZephyrError } from 'zephyr-agent';
+import type { ZephyrBuildStats } from 'zephyr-edge-contract';
+import { extractFederatedConfig } from '../xpack-extract/extract-federation-config';
 import type { ModuleFederationPlugin, XStats, XStatsCompilation } from '../xpack.types';
+import { FederationDashboardPlugin } from './utils/federation-dashboard-plugin/FederationDashboardPlugin';
 
 interface KnownAgentProps {
   stats: XStats;
@@ -62,7 +63,9 @@ export async function getBuildStats<ZephyrAgentProps extends KnownAgentProps>({
     ? pluginOptions.mfConfig[0]
     : pluginOptions.mfConfig;
 
-  const { name, filename, remotes } = mfConfig?._options || mfConfig?.config || {};
+  const { name, filename, remotes } = mfConfig
+    ? extractFederatedConfig(mfConfig) ?? {}
+    : {};
 
   const data_overrides = {
     id: application_uid,

--- a/libs/zephyr-xpack-internal/src/xpack-extract/extract-federated-dependency-pairs.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/extract-federated-dependency-pairs.ts
@@ -18,7 +18,10 @@ export function extractFederatedDependencyPairs(
 
   iterateFederatedRemoteConfig(config, (remotesConfig: XFederatedRemotesConfig) => {
     if (!remotesConfig?.remotes) return;
-    Object.entries(remotesConfig.remotes).map(([remote_name, remote_version]) => {
+
+    const remoteEntries = parseRemotesAsEntries(remotesConfig.remotes);
+
+    remoteEntries.forEach(([remote_name, remote_version]) => {
       depsPairs.push({
         name: remote_name,
         version: remote_version,
@@ -29,4 +32,33 @@ export function extractFederatedDependencyPairs(
   return depsPairs
     .flat()
     .filter((dep): dep is ZeDependencyPair => is_zephyr_dependency_pair(dep));
+}
+
+/** Returns an Array of [remote_name, remote_version] */
+export function parseRemotesAsEntries(
+  remotes: XFederatedRemotesConfig['remotes']
+): [string, string][] {
+  if (!remotes) return [];
+
+  const remotePairs: [string, string][] = [];
+  const remoteEntries = Array.isArray(remotes) ? remotes : Object.entries(remotes);
+
+  remoteEntries.map((remote) => {
+    if (Array.isArray(remote)) {
+      // Case where remotes are declared as:
+      // Record<remote_name: string, remote_version: string | RemotesConfig>
+      // e.g. ['remote_name', { url: 'remote_url' }]
+      remotePairs.push([remote[0], JSON.stringify(remote[1])]);
+    } else if (typeof remote === 'string') {
+      // Case where remotes are declared as string (Nx's default remotes)
+      remotePairs.push([remote, remote]);
+    } else {
+      // Fallback case where remotes are nested RemotesConfig objects
+      Object.entries(remote).forEach(([name, version]) => {
+        remotePairs.push([name, JSON.stringify(version)]);
+      });
+    }
+  });
+
+  return remotePairs;
 }

--- a/libs/zephyr-xpack-internal/src/xpack-extract/extract-federation-config.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/extract-federation-config.ts
@@ -1,4 +1,4 @@
-import { ModuleFederationPlugin, XFederatedRemotesConfig } from '../xpack.types';
+import type { ModuleFederationPlugin, XFederatedRemotesConfig } from '../xpack.types';
 
 export function extractFederatedConfig(
   plugin: ModuleFederationPlugin

--- a/libs/zephyr-xpack-internal/src/xpack-extract/extract-federation-config.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/extract-federation-config.ts
@@ -1,0 +1,20 @@
+import { ModuleFederationPlugin, XFederatedRemotesConfig } from '../xpack.types';
+
+export function extractFederatedConfig(
+  plugin: ModuleFederationPlugin
+): XFederatedRemotesConfig | undefined {
+  if (!plugin) return undefined;
+  if (plugin._options) {
+    // NxModuleFederationPlugin support
+    if ('config' in plugin._options) {
+      plugin._options.config.filename ??= 'remoteEntry.js';
+      return plugin._options.config;
+    }
+    // Webpack & Enhanced ModuleFederationPlugin support
+    return plugin._options;
+  } else if (plugin.config) {
+    // Repack support
+    return plugin.config;
+  }
+  return undefined;
+}

--- a/libs/zephyr-xpack-internal/src/xpack-extract/index.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/index.ts
@@ -2,7 +2,11 @@ export {
   createMfRuntimeCode,
   xpack_delegate_module_template,
 } from './create-mf-runtime-code';
-export { extractFederatedDependencyPairs } from './extract-federated-dependency-pairs';
+export {
+  extractFederatedDependencyPairs,
+  parseRemotesAsEntries,
+} from './extract-federated-dependency-pairs';
+export { extractFederatedConfig } from './extract-federation-config';
 export { isModuleFederationPlugin } from './is-module-federation-plugin';
 export { iterateFederationConfig } from './iterate-federation-config';
 export { makeCopyOfModuleFederationOptions } from './make-copy-of-module-federation-options';

--- a/libs/zephyr-xpack-internal/src/xpack-extract/iterate-federated-remote-config.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/iterate-federated-remote-config.ts
@@ -1,6 +1,7 @@
-import { isModuleFederationPlugin } from './is-module-federation-plugin';
+import { logFn, ze_log } from 'zephyr-agent';
 import type { XFederatedRemotesConfig, XPackConfiguration } from '../xpack.types';
-import { ze_log } from 'zephyr-agent';
+import { extractFederatedConfig } from './extract-federation-config';
+import { isModuleFederationPlugin } from './is-module-federation-plugin';
 
 export function iterateFederatedRemoteConfig<Compiler, K = XFederatedRemotesConfig>(
   config: XPackConfiguration<Compiler>,
@@ -15,11 +16,17 @@ export function iterateFederatedRemoteConfig<Compiler, K = XFederatedRemotesConf
     if (!isModuleFederationPlugin(plugin)) {
       continue;
     }
-    if (plugin._options) {
-      results.push(for_remote(plugin._options));
-    } else if (plugin.config) {
-      results.push(for_remote(plugin.config));
+
+    const federatedConfig = extractFederatedConfig(plugin);
+
+    if (!federatedConfig) {
+      logFn(
+        'warn',
+        `No federated config found for plugin: ${plugin.constructor.name}, skipping...`
+      );
+      continue;
     }
+    results.push(for_remote(federatedConfig));
   }
   ze_log('iterateFederatedRemoteConfig.results', results);
 

--- a/libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts
@@ -1,8 +1,8 @@
-import { type ZeResolvedDependency } from 'zephyr-agent';
-import { createMfRuntimeCode, xpack_delegate_module_template } from './index';
-import { ze_log } from 'zephyr-agent';
-import type { XPackConfiguration } from '../xpack.types';
 import type { ZephyrEngine } from 'zephyr-agent';
+import { ze_log, type ZeResolvedDependency } from 'zephyr-agent';
+import type { XPackConfiguration } from '../xpack.types';
+import { parseRemotesAsEntries } from './extract-federated-dependency-pairs';
+import { createMfRuntimeCode, xpack_delegate_module_template } from './index';
 import { iterateFederatedRemoteConfig } from './iterate-federated-remote-config';
 
 export function mutWebpackFederatedRemotesConfig<Compiler>(
@@ -30,7 +30,9 @@ export function mutWebpackFederatedRemotesConfig<Compiler>(
 
     ze_log(`Library type: ${library_type}`);
 
-    Object.entries(remotes).map((remote) => {
+    const remoteEntries = parseRemotesAsEntries(remotes);
+
+    remoteEntries.forEach((remote) => {
       const [remote_name, remote_version] = remote;
       const resolved_dep = resolvedDependencyPairs.find(
         (dep) => dep.name === remote_name && dep.version === remote_version
@@ -40,7 +42,11 @@ export function mutWebpackFederatedRemotesConfig<Compiler>(
 
       if (!resolved_dep) {
         ze_log(
-          `Resolved dependency pair not found for remote: ${JSON.stringify(remote, null, 2)}`,
+          `Resolved dependency pair not found for remote: ${JSON.stringify(
+            remote,
+            null,
+            2
+          )}`,
           'skipping...'
         );
         return;
@@ -59,17 +65,22 @@ export function mutWebpackFederatedRemotesConfig<Compiler>(
 
       resolved_dep.library_type = library_type;
       resolved_dep.name = remote_name;
-      // @ts-expect-error - TS7053: Element implicitly has an any type because expression of type string can't be used to index type RemotesObject | (string | RemotesObject)[]
-      // No index signature with a parameter of type string was found on type RemotesObject | (string | RemotesObject)[]
-      if (remotes[remote_name]) {
-        // @ts-expect-error - read above
-        remotes[remote_name] = createMfRuntimeCode(
-          zephyr_engine,
-          resolved_dep,
-          delegate_module_template
-        );
-        ze_log(`Setting runtime code for remote: ${remotes}`);
+      const runtimeCode = createMfRuntimeCode(
+        zephyr_engine,
+        resolved_dep,
+        delegate_module_template
+      );
+
+      if (Array.isArray(remotes)) {
+        const remoteIndex = remotes.indexOf(remote_name);
+        if (remoteIndex === -1) return;
+        // @ts-expect-error - Nx's ModuleFederationPlugin has different remote types
+        remotes.splice(remoteIndex, 1, [remote_name, runtimeCode]);
+        return;
       }
+
+      remotes[remote_name] = runtimeCode;
     });
+    ze_log(`Set runtime code for remotes: ${remotes}`);
   });
 }

--- a/libs/zephyr-xpack-internal/src/xpack.types.ts
+++ b/libs/zephyr-xpack-internal/src/xpack.types.ts
@@ -36,7 +36,7 @@ export interface XFederatedRemotesConfig {
 export interface ModuleFederationPlugin {
   apply: (compiler: unknown) => void;
   /** For Webpack/Rspack */
-  _options?: XFederatedRemotesConfig;
+  _options?: XFederatedRemotesConfig | { config: XFederatedRemotesConfig };
   /** Repack specific for now until Repack change how the config should be exposed */
   config?: XFederatedRemotesConfig;
 }


### PR DESCRIPTION
### What's added in this PR?

New Nx MF plugin system requires us to parse their plugin in order to extract remotes.
Then we need to replace with our zephyr_delagates (`promise new Promise` runtime code);

#### Screenshots

![image (8)](https://github.com/user-attachments/assets/c8d86b9c-c56a-41a2-be42-19028d50a917)

### What's the issues or discussion related to this PR ?

> _Provide some background information related to this PR, including issues or task. Prior to this PR what's the behavior that wasn't expected._

> _If there wasn't discussion related to this PR, you can include the reasoning behind this PR of why you did it._

### What are the steps to test this PR?

I will be adding the example on another PR that contains these changes.
It will be added here for reference.

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [X] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [X] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
