### PR TITLE
fix: add app uid to remotes on build stats

### DIFF
--- a/libs/zephyr-xpack-internal/src/federation-dashboard-legacy/get-build-stats.ts
+++ b/libs/zephyr-xpack-internal/src/federation-dashboard-legacy/get-build-stats.ts
@@ -1,7 +1,6 @@
 import type { ZephyrEngine } from 'zephyr-agent';
 import { ze_log, ZeErrors, ZephyrError } from 'zephyr-agent';
 import type { ZephyrBuildStats } from 'zephyr-edge-contract';
-import { parseRemotesAsEntries } from '../xpack-extract';
 import { extractFederatedConfig } from '../xpack-extract/extract-federation-config';
 import type { ModuleFederationPlugin, XStats, XStatsCompilation } from '../xpack.types';
 import { FederationDashboardPlugin } from './utils/federation-dashboard-plugin/FederationDashboardPlugin';
@@ -33,9 +32,10 @@ export async function getBuildStats<ZephyrAgentProps extends KnownAgentProps>({
   DELIMITER?: string;
 }): Promise<ZephyrBuildStats> {
   ze_log('get build stats started. create federation dashboard plugin');
-  const app = pluginOptions.zephyr_engine.applicationProperties;
-  const { git } = pluginOptions.zephyr_engine.gitProperties;
-  const { isCI } = pluginOptions.zephyr_engine.env;
+  const ze_engine = pluginOptions.zephyr_engine;
+  const app = ze_engine.applicationProperties;
+  const { git } = ze_engine.gitProperties;
+  const { isCI } = ze_engine.env;
   const dashboardPlugin = new FederationDashboardPlugin({
     app,
     git,
@@ -55,18 +55,17 @@ export async function getBuildStats<ZephyrAgentProps extends KnownAgentProps>({
     throw new ZephyrError(ZeErrors.ERR_CONVERT_GRAPH_TO_DASHBOARD);
   }
 
-  const version = await pluginOptions.zephyr_engine.snapshotId;
-  const application_uid = pluginOptions.zephyr_engine.application_uid;
-  const buildId = await pluginOptions.zephyr_engine.build_id;
+  const version = await ze_engine.snapshotId;
+  const application_uid = ze_engine.application_uid;
+  const buildId = await ze_engine.build_id;
 
   // todo: add support for multiple federation configs
   const mfConfig = Array.isArray(pluginOptions.mfConfig)
     ? pluginOptions.mfConfig[0]
     : pluginOptions.mfConfig;
 
-  const { name, filename, remotes } = mfConfig
-    ? (extractFederatedConfig(mfConfig) ?? {})
-    : {};
+  const { name, filename } = mfConfig ? (extractFederatedConfig(mfConfig) ?? {}) : {};
+  const remotes = ze_engine.federated_dependencies;
 
   const data_overrides = {
     id: application_uid,
@@ -79,7 +78,7 @@ export async function getBuildStats<ZephyrAgentProps extends KnownAgentProps>({
     version,
     git,
     remote: filename,
-    remotes: parseRemotesAsEntries(remotes).map(([remote_name]) => remote_name),
+    remotes: remotes?.map(({ application_uid }) => application_uid) ?? [],
     context: { isCI },
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1385,31 +1385,6 @@ importers:
         specifier: catalog:typescript
         version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.13)(typescript@5.8.2)))(typescript@5.8.2)
 
-  libs/zephyr-rsbuild-plugin:
-    dependencies:
-      tslib:
-        specifier: catalog:typescript
-        version: 2.8.1
-      zephyr-agent:
-        specifier: workspace:*
-        version: link:../zephyr-agent
-    devDependencies:
-      '@types/is-ci':
-        specifier: catalog:typescript
-        version: 3.0.4
-      '@types/jest':
-        specifier: catalog:typescript
-        version: 29.5.14
-      '@types/node-persist':
-        specifier: catalog:typescript
-        version: 3.1.8
-      '@typescript-eslint/eslint-plugin':
-        specifier: catalog:eslint
-        version: 8.27.0(@typescript-eslint/parser@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
-      ts-jest:
-        specifier: catalog:typescript
-        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.13)(typescript@5.8.2)))(typescript@5.8.2)
-
   libs/zephyr-rspack-plugin:
     dependencies:
       '@module-federation/automatic-vendor-federation':


### PR DESCRIPTION
### What's added in this PR?

For resolved remotes outside of the same repository/project we're missing the project and org on the description.
This ensures that the remote appears on the side panel when checking the host.

#### Screenshots

> _If applicable, add some screenshots of the expected behavior._

### What's the issues or discussion related to this PR ?

> _Provide some background information related to this PR, including issues or task. Prior to this PR what's the behavior that wasn't expected._

> _If there wasn't discussion related to this PR, you can include the reasoning behind this PR of why you did it._

### What are the steps to test this PR?

When building a Module Federation app with remotes across different repositories (or organizations), the remote must appear on the Side Panel.

https://github.com/ZephyrCloudIO/zephyr-documentation/pull/115
This PR above has documentation on how to achieve Poly Repo deployment with Zephyr.

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [X] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [X] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
