### PR TITLE
feat: add resolution for latest and documentation on error

### DIFF
--- a/libs/zephyr-agent/src/lib/build-context/__test__/ze-util-parse-ze-dependencies.test.ts
+++ b/libs/zephyr-agent/src/lib/build-context/__test__/ze-util-parse-ze-dependencies.test.ts
@@ -125,4 +125,40 @@ describe('parseZeDependency', () => {
       app_uid: 'local-name',
     });
   });
+
+  it('should parse wildcard version', () => {
+    // Act
+    const result = parseZeDependency('my-app', '*');
+
+    // Assert
+    expect(result).toEqual({
+      version: '*',
+      registry: 'zephyr',
+      app_uid: 'my-app',
+    });
+  });
+
+  it('should parse zephyr with wildcard version', () => {
+    // Act
+    const result = parseZeDependency('my-app', 'zephyr:*');
+
+    // Assert
+    expect(result).toEqual({
+      version: '*',
+      registry: 'zephyr',
+      app_uid: 'my-app',
+    });
+  });
+
+  it('should parse remote app with wildcard', () => {
+    // Act
+    const result = parseZeDependency('local-name', 'zephyr:remote-app@*');
+
+    // Assert
+    expect(result).toEqual({
+      version: '*',
+      registry: 'zephyr',
+      app_uid: 'remote-app',
+    });
+  });
 });

--- a/libs/zephyr-agent/src/lib/build-context/ze-util-parse-ze-dependencies.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-parse-ze-dependencies.ts
@@ -5,6 +5,7 @@
  * - Standard semver: "^1.0.0"
  * - Zephyr remote with tag: "zephyr:remote_app_uid@latest"
  * - Zephyr with semver: "zephyr:^1.0.0"
+ * - Wildcard version: "*" (resolves to latest available version)
  *
  * @param ze_dependencies - Object with dependency name as key and version/reference as
  *   value

--- a/libs/zephyr-agent/src/lib/errors/codes.ts
+++ b/libs/zephyr-agent/src/lib/errors/codes.ts
@@ -181,9 +181,9 @@ Please make sure you are logged in with the correct Zephyr account.
    */
   ERR_INVALID_MF_CONFIG: {
     id: '023',
-    message: `Library name {{library_name}} must be a valid identifier when using "var" as library type in Module Federation configuration. Either use a valid identifier (e. g. {base_identifier}) or use a different library type (e. g. type: 'global', which assign a property on the global scope instead of declaring a variable). To see a list of valid identifiers, please refer to: 
-- Mozilla's documentation on identifiers: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers 
-- the list of Module Federation's available library type: https://github.com/module-federation/core/blob/ae5ee1eedad4565774ea82e30b3d0df7c9921c58/webpack/declarations/WebpackOptions.d.ts#L112 
+    message: `Library name {{library_name}} must be a valid identifier when using "var" as library type in Module Federation configuration. Either use a valid identifier (e. g. {base_identifier}) or use a different library type (e. g. type: 'global', which assign a property on the global scope instead of declaring a variable). To see a list of valid identifiers, please refer to:
+- Mozilla's documentation on identifiers: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers
+- The list of Module Federation's available library type: https://github.com/module-federation/core/blob/ae5ee1eedad4565774ea82e30b3d0df7c9921c58/webpack/declarations/WebpackOptions.d.ts#L112
 
 You can change the library name to CamelCase to avoid this error.`,
     kind: 'build',
@@ -191,10 +191,10 @@ You can change the library name to CamelCase to avoid this error.`,
 
   ERR_INVALID_APP_ID: {
     id: '024',
-    message: `Invalid application_uid: {{application_uid}}. Your application_uid is a combination of: 
+    message: `Invalid application_uid: {{application_uid}}. Your application_uid is a combination of:
 - git organization name
 - git user name
-- name in package.json (They should be the same in your Module Federation configuration if there is any). 
+- name in package.json (They should be the same in your Module Federation configuration if there is any).
 Please make sure you have set them correctly in your package.json and git repository. The application_uid will be used to assign subdomain for your application. Read more about the standard of what characters are allowed in domain names in IETF: https://datatracker.ietf.org/doc/html/rfc1035#:~:text=The%20labels%20must%20follow%20the%20rules%20for%20ARPANET%20host%20names.%20%20They%20must%0Astart%20with%20a%20letter%2C%20end%20with%20a%20letter%20or%20digit%2C%20and%20have%20as%20interior%0Acharacters%20only%20letters%2C%20digits%2C%20and%20hyphen.%20%20There%20are%20also%20some%0Arestrictions%20on%20the%20length.%20%20Labels%20must%20be%2063%20characters%20or%20less.`,
     kind: 'build',
   },
@@ -419,12 +419,32 @@ Please check your network connection and try again.
   ERR_RESOLVE_REMOTES: {
     id: '001',
     message: `
-Please build {{ appUid }} with Zephyr first or add as Unmanaged applications.
+Failed to resolve remote dependency: {{ appUid }} version {{ version }}
 
-Note: you can read application uid as follows:
-- {{ appName }} - project.json 'name' field of remote application
-- {{ projectName }} - git repository name
-- {{ orgName }} - git organization name
+WHY THIS FAILED:
+- The remote application '{{ appName }}' has not been built with Zephyr yet
+- The specified version '{{ version }}' does not exist
+- You don't have access to this application
+- The application exists but no environment has been created
+
+HOW TO FIX:
+1. Ensure the remote application is built with Zephyr first
+2. For newly created applications, create an environment:
+   - Go to https://app.zephyr-cloud.io
+   - Navigate to your application
+   - Create a new environment (e.g., "development" or "production")
+3. Check that the version exists by visiting the dashboard
+4. Verify you have access to {{ orgName }}/{{ projectName }}/{{ appName }}
+5. If you need any version, use "*" as the version in zephyr:dependencies
+
+EXPECTED BEHAVIOR:
+- Remote applications must be built and deployed before they can be consumed
+- Applications must have at least one environment created
+- Version must match an existing build (use "*" for latest)
+- You must have read access to the remote application
+
+Application UID format: [app_name].[project_name].[org_name]
+Example: "my-remote.my-project.my-org"
 
 `,
     kind: 'config',
@@ -433,15 +453,33 @@ Note: you can read application uid as follows:
   ERR_CANNOT_RESOLVE_APP_NAME_WITH_VERSION: {
     id: '003',
     message: `
-Is the remote application being built? We are not able to find your remote application based on application_uid and remote name in configuration.
-Note that we typically map your remote based on below values
+Failed to resolve remote application with version {{ version }}
 
-- git username
+WHY THIS FAILED:
+- Network error while trying to resolve the dependency
+- Zephyr API is temporarily unavailable
+- Application naming mismatch in configuration
+
+HOW TO FIX:
+1. Check your network connection
+2. If using "*" version, ensure at least one version exists
+3. Ensure the application has an environment created in the dashboard
+
+EXPECTED BEHAVIOR:
+- Remote application must have at least one deployed version
+- Application must have at least one environment
+
+Application naming is based on:
+- git organization/username
 - git repository name
 - name in package.json
-- name in micro-frontend configuration.
 
-We have a complete checklist for Micro-Frontend application configuration here: https://docs.zephyr-cloud.io/how-to/mf-guide
+For debugging, check:
+- Your ~/.zephyr folder for cached tokens
+- Network proxy settings if behind corporate firewall
+- API status at https://status.zephyr-cloud.io
+
+Documentation: https://docs.zephyr-cloud.io/how-to/mf-guide
       `,
     kind: 'config',
   },

--- a/libs/zephyr-agent/src/zephyr-engine/__test__/resolve_remote_dependency.test.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/__test__/resolve_remote_dependency.test.ts
@@ -38,7 +38,12 @@ describe('libs/zephyr-agent/src/zephyr-engine/resolve_remote_dependency.ts', () 
     const result = await resolve_remote_dependency({ application_uid, version });
 
     expect(getTokenMock).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ ...mock_api_response, version });
+    expect(result).toEqual({
+      ...mock_api_response,
+      version,
+      requested_version: version,
+      platform: undefined,
+    });
     expect(axiosMock.get).toHaveBeenCalledWith(
       expect.stringContaining(
         `/resolve/${encodeURIComponent(application_uid)}/${encodeURIComponent(version)}`
@@ -93,5 +98,84 @@ describe('libs/zephyr-agent/src/zephyr-engine/resolve_remote_dependency.ts', () 
 
     await expect(promise).rejects.toThrow(ZephyrError);
     expect(axiosMock.get).toHaveBeenCalled();
+  });
+
+  it('should handle wildcard version "*" by requesting "latest"', async () => {
+    const resolvedVersion = '1.2.3';
+    getTokenMock.mockImplementation(() => Promise.resolve(mockToken));
+    axiosMock.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        value: {
+          ...mock_api_response,
+          version: resolvedVersion,
+        },
+      },
+    });
+
+    const result = await resolve_remote_dependency({
+      application_uid,
+      version: '*',
+      build_context: 'test-context',
+    });
+
+    expect(result).toEqual({
+      ...mock_api_response,
+      version: resolvedVersion,
+      requested_version: '*',
+      platform: undefined,
+    });
+
+    // Verify the API was called with "latest" instead of "*"
+    expect(axiosMock.get).toHaveBeenCalledWith(
+      expect.stringContaining('/resolve/test_app.test_project.test_organization/latest'),
+      expect.any(Object)
+    );
+  });
+
+  it('should include build_context in query params', async () => {
+    const build_context = 'eyJ0ZXN0IjoidmFsdWUifQ=='; // base64 encoded
+    getTokenMock.mockImplementation(() => Promise.resolve(mockToken));
+    axiosMock.get.mockResolvedValueOnce({
+      status: 200,
+      data: { value: mock_api_response },
+    });
+
+    const result = await resolve_remote_dependency({
+      application_uid,
+      version,
+      build_context,
+    });
+
+    expect(result).toEqual({
+      ...mock_api_response,
+      version,
+      requested_version: version,
+      platform: undefined,
+    });
+
+    const expectedUrl = expect.stringContaining('build_context=');
+    expect(axiosMock.get).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
+  });
+
+  it('should include platform in query params when provided', async () => {
+    const platform = 'ios';
+    getTokenMock.mockImplementation(() => Promise.resolve(mockToken));
+    axiosMock.get.mockResolvedValueOnce({
+      status: 200,
+      data: { value: mock_api_response },
+    });
+
+    await resolve_remote_dependency({
+      application_uid,
+      version,
+      platform,
+      build_context: 'test',
+    });
+
+    expect(axiosMock.get).toHaveBeenCalledWith(
+      expect.stringContaining('build_target=ios'),
+      expect.any(Object)
+    );
   });
 });


### PR DESCRIPTION
### What's added in this PR?

This PR aims to add resolution for zephyr:dependencies in `*` to resolve to latest.

It also aims to make it easier for users to realize what needs to be done in order to resolve if there is no environment on application.

### What are the steps to test this PR?

> _To help reviewer and tester to understand what's needed_

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [ ] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [ ] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
