### PR TITLE
fix: remove throwing when facing remote resolution issues

### DIFF
--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -296,18 +296,17 @@ export class ZephyrEngine {
             ZephyrError.is(error) && error.template && 'version' in error.template
               ? (error.template.version as string)
               : dep.version;
-          return `  - Remote name: ${dep.name} Version: ${version} ${errorMessage}`;
+          return `  - ${dep.name}@${version} -> ${errorMessage}`;
         })
         .join('\n');
 
       logger({
-        level: 'error',
+        level: 'warn',
         action: 'build:error:dependency_resolution',
-        message: `
-          Failed to resolve ${resolution_errors.length} remote dependencies:\n
-          ${errorSummary}\n
-          More information on dependency resolution please check:\n
-          https://docs.zephyr-cloud.io/how-to/dependency-management\n`,
+        message: `Failed to resolve remote dependencies:
+${errorSummary}\n
+More information on remote dependency resolution please check:
+https://docs.zephyr-cloud.io/how-to/dependency-management`,
       });
     }
 

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -303,9 +303,6 @@ export class ZephyrEngine {
           message: `Failed to resolve ${resolution_errors.length} remote dependencies:\n${errorSummary}\n`,
         });
       }
-
-      // Throw the first error - it will be caught and formatted by the bundler plugin
-      throw resolution_errors[0].error;
     }
 
     this.federated_dependencies = resolution_results.filter(

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -282,27 +282,24 @@ export class ZephyrEngine {
 
     const resolution_results = await Promise.all(tasks);
 
-    // If there are resolution errors, throw with summary
+    // If there are resolution errors, log it with summary
     if (resolution_errors.length > 0) {
-      // Log a summary if multiple errors
-      if (resolution_errors.length > 1) {
-        const logger = await this.logger;
-        const errorSummary = resolution_errors
-          .map(({ dep, error }) => {
-            const version =
-              ZephyrError.is(error) && error.template && 'version' in error.template
-                ? (error.template.version as string)
-                : dep.version;
-            return `  - ${dep.name} @ ${version}`;
-          })
-          .join('\n');
+      const logger = await this.logger;
+      const errorSummary = resolution_errors
+        .map(({ dep, error }) => {
+          const version =
+            ZephyrError.is(error) && error.template && 'version' in error.template
+              ? (error.template.version as string)
+              : dep.version;
+          return `  - ${dep.name} @ ${version}`;
+        })
+        .join('\n');
 
-        logger({
-          level: 'error',
-          action: 'build:error:dependency_resolution',
-          message: `Failed to resolve ${resolution_errors.length} remote dependencies:\n${errorSummary}\n`,
-        });
-      }
+      logger({
+        level: 'error',
+        action: 'build:error:dependency_resolution',
+        message: `Failed to resolve ${resolution_errors.length} remote dependencies:\n${errorSummary}\n`,
+      });
     }
 
     this.federated_dependencies = resolution_results.filter(

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -191,7 +191,9 @@ export class ZephyrEngine {
         level: 'info',
         action: 'build:info:user',
         ignore: true,
-        message: `Hi ${cyanBright(username)}!\n${white(application_uid)}${yellow(`#${buildId}`)}\n`,
+        message: `Hi ${cyanBright(username)}!\n${white(application_uid)}${yellow(
+          `#${buildId}`
+        )}\n`,
       });
     });
 
@@ -287,18 +289,25 @@ export class ZephyrEngine {
       const logger = await this.logger;
       const errorSummary = resolution_errors
         .map(({ dep, error }) => {
+          const errorMessage = ZephyrError.is(error)
+            ? `Error code: ${error.code}`
+            : `Unknown error`;
           const version =
             ZephyrError.is(error) && error.template && 'version' in error.template
               ? (error.template.version as string)
               : dep.version;
-          return `  - ${dep.name} @ ${version}`;
+          return `  - Remote name: ${dep.name} Version: ${version} ${errorMessage}`;
         })
         .join('\n');
 
       logger({
         level: 'error',
         action: 'build:error:dependency_resolution',
-        message: `Failed to resolve ${resolution_errors.length} remote dependencies:\n${errorSummary}\n`,
+        message: `
+          Failed to resolve ${resolution_errors.length} remote dependencies:\n
+          ${errorSummary}\n
+          More information on dependency resolution please check:\n
+          https://docs.zephyr-cloud.io/how-to/dependency-management\n`,
       });
     }
 
@@ -379,15 +388,21 @@ export class ZephyrEngine {
           action: 'build:info:user',
           ignore: true,
           message: if_target_is_react_native
-            ? `Resolved zephyr dependencies: ${dependencies.map((dep) => dep.name).join(', ')} for platform: ${zephyr_engine.env.target}`
-            : `Resolved zephyr dependencies: ${dependencies.map((dep) => dep.name).join(', ')}`,
+            ? `Resolved zephyr dependencies: ${dependencies
+                .map((dep) => dep.name)
+                .join(', ')} for platform: ${zephyr_engine.env.target}`
+            : `Resolved zephyr dependencies: ${dependencies
+                .map((dep) => dep.name)
+                .join(', ')}`,
         });
       }
 
       logger({
         level: 'trace',
         action: 'deploy:url',
-        message: `Deployed to ${cyanBright('Zephyr')}'s edge in ${yellow(`${Date.now() - zeStart}`)}ms.\n\n${cyanBright(versionUrl)}`,
+        message: `Deployed to ${cyanBright('Zephyr')}'s edge in ${yellow(
+          `${Date.now() - zeStart}`
+        )}ms.\n\n${cyanBright(versionUrl)}`,
       });
     }
 


### PR DESCRIPTION
### What's added in this PR?

When facing remote resolution issues, we shouldn't stop Zephyr deployment.

#### Screenshots

![image](https://github.com/user-attachments/assets/371c6bbd-d366-49b5-bf48-1e197e4ad30d)

### What's the issues or discussion related to this PR ?

We shouldn't block users from building without resolving their remotes.
If they either want to host their own remotes or they want to serve locally without zephyr, they can.
This also enables us to deploy circular dependant projects without changing their dependencies.

### What are the steps to test this PR?

`turbo-rspack-mf` from `zephyr-examples` should be deployed.

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [X] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [X] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
