### PR TITLE
fix: root and outDir definition

### DIFF
--- a/libs/zephyr-rspress-plugin/src/__test__/with-zephyr.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/__test__/with-zephyr.spec.ts
@@ -31,7 +31,7 @@ describe('withZephyr', () => {
       false
     );
 
-    expect(zephyrRspressSSGPlugin).toHaveBeenCalledWith({ outDir: 'dist' });
+    expect(zephyrRspressSSGPlugin).toHaveBeenCalledWith(config);
     expect(addPlugin).toHaveBeenCalledWith({ name: 'mock-ssg-plugin' });
     expect(result).toEqual(config);
   });

--- a/libs/zephyr-rspress-plugin/src/__test__/zephyrRspressSSGPlugin.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/__test__/zephyrRspressSSGPlugin.spec.ts
@@ -53,7 +53,7 @@ describe('zephyrRspressSSGPlugin', () => {
     expect(ZephyrEngine.defer_create).toHaveBeenCalled();
     expect(mockZephyrDefer).toHaveBeenCalledWith({
       builder: 'rspack',
-      context: path.resolve('custom-out'),
+      context: path.resolve(),
     });
   });
 
@@ -67,7 +67,7 @@ describe('zephyrRspressSSGPlugin', () => {
     expect(showFiles).toHaveBeenCalledWith(path.resolve('dist'), mockFiles);
     expect(setupZeDeploy).toHaveBeenCalledWith({
       deferEngine: mockEngine,
-      root: path.resolve('dist'),
+      outDir: path.resolve('dist'),
       files: mockFiles,
     });
   });

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/setupZeDeploy.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/setupZeDeploy.spec.ts
@@ -23,7 +23,7 @@ jest.mock('zephyr-agent', () => ({
   },
 }));
 
-// Get reference to ze_log.package mock
+// @ts-expect-error Get reference to ze_log.package mock
 const mockedZeLog = ze_log.package as jest.Mock;
 
 describe('setupZeDeploy', () => {
@@ -41,7 +41,7 @@ describe('setupZeDeploy', () => {
   it('should log and return early if no files are provided', async () => {
     await setupZeDeploy({
       deferEngine: Promise.resolve({ engine: 'mock' } as any),
-      root: '/root',
+      outDir: '/doc_build',
       files: [],
     });
 
@@ -54,17 +54,17 @@ describe('setupZeDeploy', () => {
   it('should build assets and stats and call xpack_zephyr_agent', async () => {
     await setupZeDeploy({
       deferEngine: Promise.resolve({ engine: 'mock' } as any),
-      root: '/root',
+      outDir: '/doc_build',
       files: ['index.html', 'main.js'],
     });
 
     await new Promise(process.nextTick); // Allow promises to resolve
 
-    expect(buildAssetMapFromFiles).toHaveBeenCalledWith('/root', [
+    expect(buildAssetMapFromFiles).toHaveBeenCalledWith('/doc_build', [
       'index.html',
       'main.js',
     ]);
-    expect(buildStats).toHaveBeenCalledWith('/root', ['index.html', 'main.js']);
+    expect(buildStats).toHaveBeenCalledWith('/doc_build', ['index.html', 'main.js']);
     expect(xpack_zephyr_agent).toHaveBeenCalledWith({
       stats: mockStats,
       stats_json: { some: 'json' },

--- a/libs/zephyr-rspress-plugin/src/internal/assets/setupZeDeploy.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/setupZeDeploy.ts
@@ -6,7 +6,7 @@ import { buildAssetMapFromFiles } from './buildAssets';
 
 export async function setupZeDeploy({
   deferEngine,
-  root,
+  outDir,
   files,
 }: ZephyrRspressPluginOptions): Promise<void> {
   if (!files.length) {
@@ -15,8 +15,8 @@ export async function setupZeDeploy({
   }
 
   const [assets, stats] = await Promise.all([
-    buildAssetMapFromFiles(root, files),
-    Promise.resolve(buildStats(root, files)),
+    buildAssetMapFromFiles(outDir, files),
+    Promise.resolve(buildStats(outDir, files)),
   ]);
 
   process.nextTick(xpack_zephyr_agent, {

--- a/libs/zephyr-rspress-plugin/src/types/index.ts
+++ b/libs/zephyr-rspress-plugin/src/types/index.ts
@@ -2,7 +2,7 @@ import type { ZephyrEngine } from 'zephyr-agent';
 
 export interface ZephyrRspressPluginOptions {
   deferEngine: Promise<ZephyrEngine>;
-  root: string;
+  outDir: string;
   files: string[];
 }
 

--- a/libs/zephyr-rspress-plugin/src/with-zephyr.ts
+++ b/libs/zephyr-rspress-plugin/src/with-zephyr.ts
@@ -9,7 +9,7 @@ export function withZephyr(): RspressPlugin {
       const { ssg = false } = config;
 
       if (ssg) {
-        addPlugin(zephyrRspressSSGPlugin({ outDir: config.outDir }));
+        addPlugin(zephyrRspressSSGPlugin(config));
       } else {
         config.builderPlugins = [...(config.builderPlugins ?? []), zephyrRsbuildPlugin()];
       }

--- a/libs/zephyr-rspress-plugin/src/zephyrRspressSSGPlugin.ts
+++ b/libs/zephyr-rspress-plugin/src/zephyrRspressSSGPlugin.ts
@@ -1,30 +1,31 @@
-import type { RspressPlugin } from '@rspress/shared';
-import path from 'node:path';
+import type { RspressPlugin, UserConfig } from '@rspress/shared';
+import { resolve } from 'node:path';
 import { ZephyrEngine, ZephyrError, logFn, ze_log } from 'zephyr-agent';
 import { setupZeDeploy } from './internal/assets/setupZeDeploy';
 import { showFiles } from './internal/files/showFiles';
 import { walkFiles } from './internal/files/walkFiles';
 
-export const zephyrRspressSSGPlugin = ({ outDir = 'doc_build' }): RspressPlugin => {
-  const root = path.resolve(outDir);
-
+export const zephyrRspressSSGPlugin = (config: UserConfig): RspressPlugin => {
   const { zephyr_engine_defer, zephyr_defer_create } = ZephyrEngine.defer_create();
+  const root = resolve(config.root ?? '');
+  const outDir = resolve(config.outDir ?? './doc_build');
+
   zephyr_defer_create({ builder: 'rspack', context: root });
 
   return {
     name: 'zephyr-rspress-plugin-ssg',
     async afterBuild() {
       try {
-        const files = await walkFiles(root);
+        const files = await walkFiles(outDir);
 
         if (files.length === 0) {
           ze_log.upload('No files found in output directory.');
           return;
         }
 
-        await showFiles(root, files);
+        await showFiles(outDir, files);
 
-        await setupZeDeploy({ deferEngine: zephyr_engine_defer, root, files });
+        await setupZeDeploy({ deferEngine: zephyr_engine_defer, outDir, files });
       } catch (error) {
         logFn('error', ZephyrError.format(error));
       }


### PR DESCRIPTION
### What's added in this PR?

The main goal for this fix is separate two similar path variables mixed in context, but causing some issues to build pipeline. root and outDir are not necessarily the same, except for some specific cases, used or previous testing.

#### Screenshots

**Before** - Previously with no doc_build folder before building:

![image](https://github.com/user-attachments/assets/1fa72f43-adf4-4cd1-971e-4b127b93b991)

**After** - Now with no doc_build folder before building:

![image](https://github.com/user-attachments/assets/916fd719-5d9a-41b7-a153-6ac89525b33f)

### What's the issues or discussion related to this PR ?

For the first build, the cycle was failing because some unknown path value, caused by the root variable used instead the output directory path.

### What are the steps to test this PR?

- go to repo root, run `pnpm install`
- go to the examples rspres-ssg folder and run `pnpm build` or `pnpm dev`

### Documentation update for this PR (if applicable)?

Output dir [https://rspress.rs/guide/start/getting-started](https://rspress.rs/guide/start/getting-started)

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test

Description edited by @fiorin 
