### PR TITLE
feat: add gitignore template to `create-zephyr-apps` 

### DIFF
--- a/libs/create-zephyr-apps/src/generate-pnpm-workspace.ts
+++ b/libs/create-zephyr-apps/src/generate-pnpm-workspace.ts
@@ -1,12 +1,13 @@
 import { findWorkspacePackagesNoCheck } from '@pnpm/workspace.find-packages';
-import * as fs from 'node:fs';
 import path from 'node:path';
 
-export async function generatePnpmWorkspaceConfig(rootPath: string): Promise<string | null> {
+export async function generatePnpmWorkspaceConfig(
+  rootPath: string
+): Promise<string | null> {
   try {
     // Use @pnpm/workspace.find-packages to detect packages
     const packages = await findWorkspacePackagesNoCheck(rootPath);
-    
+
     // If only one package found (likely the root), no workspace needed
     if (packages.length <= 1) {
       return null;
@@ -15,18 +16,18 @@ export async function generatePnpmWorkspaceConfig(rootPath: string): Promise<str
     // Group packages by their parent directory structure
     const workspacePaths = new Set<string>();
     const commonDirs = ['apps', 'packages', 'libs', 'examples', 'tools'];
-    
+
     for (const pkg of packages) {
       const relativePath = path.relative(rootPath, pkg.rootDir);
-      
+
       // Skip root package
       if (!relativePath || relativePath === '.') {
         continue;
       }
-      
+
       const pathParts = relativePath.split(path.sep);
       const topLevelDir = pathParts[0];
-      
+
       // Check if it's a common workspace directory pattern
       if (commonDirs.includes(topLevelDir)) {
         workspacePaths.add(`"${topLevelDir}/*"`);
@@ -40,7 +41,7 @@ export async function generatePnpmWorkspaceConfig(rootPath: string): Promise<str
     if (workspacePaths.size > 0) {
       const sortedPaths = Array.from(workspacePaths).sort();
       return `packages:
-${sortedPaths.map(p => `  - ${p}`).join('\n')}
+${sortedPaths.map((p) => `  - ${p}`).join('\n')}
   - "!**/dist/**"
   - "!**/build/**"
   - "!**/node_modules/**"
@@ -49,62 +50,7 @@ ${sortedPaths.map(p => `  - ${p}`).join('\n')}
 
     return null;
   } catch (error) {
-    // Fallback to manual detection if @pnpm modules fail
-    return generateFallbackWorkspaceConfig(rootPath);
+    // do nothing
+    return null;
   }
-}
-
-// Fallback function for when @pnpm modules are not available
-function generateFallbackWorkspaceConfig(rootPath: string): string | null {
-  const workspacePaths: string[] = [];
-  const commonDirs = ['apps', 'packages', 'libs', 'examples', 'tools'];
-
-  // Check for common workspace directory patterns
-  for (const dir of commonDirs) {
-    const dirPath = path.join(rootPath, dir);
-    if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
-      const subDirs = fs.readdirSync(dirPath);
-      const hasPackageJson = subDirs.some((subDir: string) => {
-        const subDirPath = path.join(dirPath, subDir);
-        return (
-          fs.statSync(subDirPath).isDirectory() &&
-          fs.existsSync(path.join(subDirPath, 'package.json'))
-        );
-      });
-
-      if (hasPackageJson) {
-        workspacePaths.push(`"${dir}/*"`);
-      }
-    }
-  }
-
-  // Check for package.json files in root-level directories
-  const rootItems = fs.readdirSync(rootPath);
-  const rootPackageDirs = rootItems.filter((item: string) => {
-    const itemPath = path.join(rootPath, item);
-    return (
-      fs.statSync(itemPath).isDirectory() &&
-      fs.existsSync(path.join(itemPath, 'package.json')) &&
-      !commonDirs.includes(item) &&
-      !item.startsWith('.') &&
-      item !== 'node_modules'
-    );
-  });
-
-  // Add individual directories that contain package.json
-  rootPackageDirs.forEach((dir: string) => {
-    workspacePaths.push(`"${dir}"`);
-  });
-
-  // Only create workspace config if we found multiple packages
-  if (workspacePaths.length > 1) {
-    return `packages:
-${workspacePaths.map((p) => `  - ${p}`).join('\n')}
-  - "!**/dist/**"
-  - "!**/build/**"
-  - "!**/node_modules/**"
-`;
-  }
-
-  return null;
 }

--- a/libs/create-zephyr-apps/src/generate-pnpm-workspace.ts
+++ b/libs/create-zephyr-apps/src/generate-pnpm-workspace.ts
@@ -1,0 +1,110 @@
+import { findWorkspacePackagesNoCheck } from '@pnpm/workspace.find-packages';
+import * as fs from 'node:fs';
+import path from 'node:path';
+
+export async function generatePnpmWorkspaceConfig(rootPath: string): Promise<string | null> {
+  try {
+    // Use @pnpm/workspace.find-packages to detect packages
+    const packages = await findWorkspacePackagesNoCheck(rootPath);
+    
+    // If only one package found (likely the root), no workspace needed
+    if (packages.length <= 1) {
+      return null;
+    }
+
+    // Group packages by their parent directory structure
+    const workspacePaths = new Set<string>();
+    const commonDirs = ['apps', 'packages', 'libs', 'examples', 'tools'];
+    
+    for (const pkg of packages) {
+      const relativePath = path.relative(rootPath, pkg.rootDir);
+      
+      // Skip root package
+      if (!relativePath || relativePath === '.') {
+        continue;
+      }
+      
+      const pathParts = relativePath.split(path.sep);
+      const topLevelDir = pathParts[0];
+      
+      // Check if it's a common workspace directory pattern
+      if (commonDirs.includes(topLevelDir)) {
+        workspacePaths.add(`"${topLevelDir}/*"`);
+      } else {
+        // Individual package directory
+        workspacePaths.add(`"${relativePath}"`);
+      }
+    }
+
+    // Only create workspace config if we found multiple packages
+    if (workspacePaths.size > 0) {
+      const sortedPaths = Array.from(workspacePaths).sort();
+      return `packages:
+${sortedPaths.map(p => `  - ${p}`).join('\n')}
+  - "!**/dist/**"
+  - "!**/build/**"
+  - "!**/node_modules/**"
+`;
+    }
+
+    return null;
+  } catch (error) {
+    // Fallback to manual detection if @pnpm modules fail
+    return generateFallbackWorkspaceConfig(rootPath);
+  }
+}
+
+// Fallback function for when @pnpm modules are not available
+function generateFallbackWorkspaceConfig(rootPath: string): string | null {
+  const workspacePaths: string[] = [];
+  const commonDirs = ['apps', 'packages', 'libs', 'examples', 'tools'];
+
+  // Check for common workspace directory patterns
+  for (const dir of commonDirs) {
+    const dirPath = path.join(rootPath, dir);
+    if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
+      const subDirs = fs.readdirSync(dirPath);
+      const hasPackageJson = subDirs.some((subDir: string) => {
+        const subDirPath = path.join(dirPath, subDir);
+        return (
+          fs.statSync(subDirPath).isDirectory() &&
+          fs.existsSync(path.join(subDirPath, 'package.json'))
+        );
+      });
+
+      if (hasPackageJson) {
+        workspacePaths.push(`"${dir}/*"`);
+      }
+    }
+  }
+
+  // Check for package.json files in root-level directories
+  const rootItems = fs.readdirSync(rootPath);
+  const rootPackageDirs = rootItems.filter((item: string) => {
+    const itemPath = path.join(rootPath, item);
+    return (
+      fs.statSync(itemPath).isDirectory() &&
+      fs.existsSync(path.join(itemPath, 'package.json')) &&
+      !commonDirs.includes(item) &&
+      !item.startsWith('.') &&
+      item !== 'node_modules'
+    );
+  });
+
+  // Add individual directories that contain package.json
+  rootPackageDirs.forEach((dir: string) => {
+    workspacePaths.push(`"${dir}"`);
+  });
+
+  // Only create workspace config if we found multiple packages
+  if (workspacePaths.length > 1) {
+    return `packages:
+${workspacePaths.map((p) => `  - ${p}`).join('\n')}
+  - "!**/dist/**"
+  - "!**/build/**"
+  - "!**/node_modules/**"
+`;
+  }
+
+  return null;
+}

--- a/libs/create-zephyr-apps/src/gitignore-template.ts
+++ b/libs/create-zephyr-apps/src/gitignore-template.ts
@@ -1,0 +1,108 @@
+
+export const DEFAULT_GITIGNORE = `# Dependencies
+node_modules/
+.pnpm-store/
+
+# Production builds
+dist/
+build/
+out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+jspm_packages/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env.test
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# Next.js build output
+.next
+
+# Nuxt.js build / generate output
+.nuxt
+dist
+
+# Gatsby files
+.cache/
+public
+
+# Storybook build outputs
+.out
+.storybook-out
+
+# Temporary folders
+tmp/
+temp/
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18413,7 +18413,7 @@ snapshots:
       webpack: 5.98.0(@swc/core@1.11.13(@swc/helpers@0.5.15))(esbuild@0.25.1)
     optionalDependencies:
       type-fest: 4.38.0
-      webpack-dev-server: 5.2.2(webpack@5.98.0(@swc/core@1.10.18(@swc/helpers@0.5.15))(esbuild@0.25.1))
+      webpack-dev-server: 5.2.2(webpack@5.98.0(@swc/core@1.11.13(@swc/helpers@0.5.15))(esbuild@0.25.1))
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.38.0)(webpack-dev-server@5.2.2(webpack@5.99.9(@swc/core@1.11.13(@swc/helpers@0.5.15))(esbuild@0.25.1)))(webpack@5.98.0(@swc/core@1.10.18(@swc/helpers@0.5.15))(esbuild@0.25.1))':
     dependencies:
@@ -19953,7 +19953,7 @@ snapshots:
       chokidar: 3.6.0
       http-proxy-middleware: 3.0.5
       p-retry: 6.2.1
-      webpack-dev-server: 5.2.2(webpack@5.98.0(@swc/core@1.10.18(@swc/helpers@0.5.15))(esbuild@0.25.1))
+      webpack-dev-server: 5.2.2(webpack@5.98.0(@swc/core@1.11.13(@swc/helpers@0.5.15))(esbuild@0.25.1))
       ws: 8.18.1
     transitivePeerDependencies:
       - bufferutil
@@ -30920,7 +30920,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.2.2(webpack@5.98.0(@swc/core@1.10.18(@swc/helpers@0.5.15))(esbuild@0.25.1)):
+  webpack-dev-server@5.2.2(webpack@5.98.0(@swc/core@1.11.13(@swc/helpers@0.5.15))(esbuild@0.25.1)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4


### PR DESCRIPTION
### What's added in this PR?

- Add gitignore template to `create-zephyr-apps` 
- generate pnpm workspace file for created folder 

#### Screenshots

N/A 

### What's the issues or discussion related to this PR ?

- Whenever we generate a template using `create-zephyr-apps` we never exclude the node_modules or have a `.gitignore` file in the created folder - if users don't manually add gitignore file to there they will end up having node_modules being uploaded

- `workspace` field in `package.json` is not supported in pnpm 

### What are the steps to test this PR?

run 

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [ ] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [ ] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
