### PR TITLE
feat: add logging for remote resolution and missing 'zephyr:dependencies' key

### DIFF
--- a/libs/zephyr-agent/src/lib/build-context/ze-util-read-package-json.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-read-package-json.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { safe_json_parse } from 'zephyr-edge-contract';
 import { ZeErrors, ZephyrError } from '../errors';
 import { ze_log } from '../logging';
+import { logFn } from '../logging/ze-log-event';
 import { find_nearest_package_json } from './find-nearest-package-json';
 import type { ZePackageJson } from './ze-package-json.type';
 import { parseZeDependencies } from './ze-util-parse-ze-dependencies';
@@ -92,6 +93,13 @@ export async function getPackageJson(
     const zephyr_dependencies = parsed_package_json['zephyr:dependencies'];
     if (zephyr_dependencies) {
       parsed_package_json.zephyrDependencies = parseZeDependencies(zephyr_dependencies);
+    } else {
+      logFn(
+        'warn',
+        'No zephyr:dependencies found in package.json, to give you more control over your dependencies, please add a "zephyr:dependencies" field in your package.json'
+      );
+      logFn('warn', 'For more information, please refer to the documentation:');
+      logFn('warn', 'https://docs.zephyr-cloud.io/how-to/dependency-management');
     }
 
     ze_log.package('Successfully parsed package.json', {

--- a/libs/zephyr-agent/src/lib/build-context/ze-util-read-package-json.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-read-package-json.ts
@@ -95,11 +95,10 @@ export async function getPackageJson(
       parsed_package_json.zephyrDependencies = parseZeDependencies(zephyr_dependencies);
     } else {
       logFn(
-        'warn',
-        'No zephyr:dependencies found in package.json, to give you more control over your dependencies, please add a "zephyr:dependencies" field in your package.json'
+        'info',
+        'No zephyr:dependencies found in package.json, to give you more control over your dependencies, check out our documentation:'
       );
-      logFn('warn', 'For more information, please refer to the documentation:');
-      logFn('warn', 'https://docs.zephyr-cloud.io/how-to/dependency-management');
+      logFn('info', 'https://docs.zephyr-cloud.io/how-to/dependency-management');
     }
 
     ze_log.package('Successfully parsed package.json', {

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -23,7 +23,7 @@ import { getBuildId } from '../lib/edge-requests/get-build-id';
 import { ZephyrError } from '../lib/errors';
 import { ze_log } from '../lib/logging';
 import { cyanBright, white, yellow } from '../lib/logging/picocolor';
-import { type ZeLogger, logger } from '../lib/logging/ze-log-event';
+import { type ZeLogger, logFn, logger } from '../lib/logging/ze-log-event';
 import { setAppDeployResult } from '../lib/node-persist/app-deploy-result-cache';
 import type { ZeApplicationConfig } from '../lib/node-persist/upload-provider-options';
 import { createSnapshot } from '../lib/transformers/ze-build-snapshot';
@@ -313,6 +313,15 @@ https://docs.zephyr-cloud.io/how-to/dependency-management`,
     this.federated_dependencies = resolution_results.filter(
       is_zephyr_resolved_dependency
     );
+
+    // Log resolved remotes for build visibility
+    if (this.federated_dependencies.length > 0) {
+      const remotesList = this.federated_dependencies
+        .map((dep) => `  ${dep.name} → ${dep.remote_entry_url}`)
+        .join('\n');
+      logFn('info', `Resolved remotes:\n${remotesList}`);
+    }
+
     return this.federated_dependencies;
   }
 


### PR DESCRIPTION
### What's added in this PR?

Some feedback I got from a customer was they never knew what they were resolving to. So i added logging to display the remote name and the url it resolved to at build time.

Additionally we want folks to be using the zephyr:dependencies key moving forward so added a warning if that key was missing from a project about falling back to default behavior. 

#### Resolved remote mapping output
<img width="1842" height="120" alt="image" src="https://github.com/user-attachments/assets/7ab9df59-217b-4c7c-96ab-d686ec78ded4" />

#### Missing `zephyr:dependencies` key in package json warning
<img width="1900" height="110" alt="image" src="https://github.com/user-attachments/assets/289e8dce-6c59-4073-8563-5d16894bf745" />



### What are the steps to test this PR?

Build an application with the `zephyr:dependencies` key and without the key to see the output change

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
