### PR TITLE
fix: add js var name normalization for remotes

### DIFF
--- a/libs/zephyr-edge-contract/src/index.ts
+++ b/libs/zephyr-edge-contract/src/index.ts
@@ -3,16 +3,17 @@
 // edge api
 export type {
   PublishRequest,
-  StageZeroPublishRequest,
   PublishTarget,
+  StageZeroPublishRequest,
 } from './lib/edge-api/publish-request';
 export type { ZeEnvs, ZeUploadBuildStats } from './lib/edge-api/ze-envs-request';
 
 export type { ZephyrPluginOptions } from './lib/plugin-options/zephyr-webpack-plugin-options';
+export * as ZeUtils from './lib/promise';
 export type { Snapshot, SnapshotAsset, SnapshotMetadata } from './lib/snapshot';
 export { createApplicationUid } from './lib/utils/create-application-uid';
 export { createSnapshotId, flatCreateSnapshotId } from './lib/utils/create-snapshot-id';
-export * as ZeUtils from './lib/promise';
+export { normalize_js_var_name as normalize_app_name } from './lib/utils/normalize-js-var-name';
 export { safe_json_parse } from './lib/utils/safe-json-parse';
 export type { ZeApplicationList } from './lib/ze-api/app-list';
 export type { ZeAppVersion, ZeAppVersionResponse } from './lib/ze-api/app-version';
@@ -31,23 +32,23 @@ export type {
 
 // api contract negotiation
 export {
-  ZEPHYR_API_ENDPOINT,
   ZE_API_ENDPOINT,
-  ZE_IS_PREVIEW,
-  ze_api_gateway,
   ZE_API_ENDPOINT_HOST,
+  ze_api_gateway,
+  ZE_IS_PREVIEW,
+  ZEPHYR_API_ENDPOINT,
 } from './lib/api-contract-negotiation/get-api-contract';
 
 // promise proto methods
 export {
+  deferred,
   forEachLimit,
-  PromiseTuple,
   isSuccessTuple,
   PromiseLazyLoad,
+  PromiseTuple,
   PromiseWithResolvers,
-  deferred,
 } from './lib/promise';
 
 // string proto methods
-export { type FindTemplates, formatString } from './lib/string/string';
+export { formatString, type FindTemplates } from './lib/string/string';
 export { stripAnsi } from './lib/string/strip-ansi';

--- a/libs/zephyr-edge-contract/src/lib/utils/normalize-js-var-name.ts
+++ b/libs/zephyr-edge-contract/src/lib/utils/normalize-js-var-name.ts
@@ -1,0 +1,7 @@
+// Normalize to allow only JavaScript var valid names
+export function normalize_js_var_name(name: string) {
+  // Replace invalid starting characters with '_'
+  const normalized = name.replace(/^[^a-zA-Z_$]/, '_');
+  // Replace invalid subsequent characters with '_'
+  return normalized.replace(/[^a-zA-Z0-9_$]/g, '_');
+}

--- a/libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts
@@ -1,5 +1,6 @@
 import type { ZephyrEngine } from 'zephyr-agent';
 import { ze_log, type ZeResolvedDependency } from 'zephyr-agent';
+import { normalize_app_name } from 'zephyr-edge-contract';
 import type { XPackConfiguration } from '../xpack.types';
 import { parseRemotesAsEntries } from './extract-federated-dependency-pairs';
 import { createMfRuntimeCode, xpack_delegate_module_template } from './index';
@@ -69,7 +70,7 @@ export function mutWebpackFederatedRemotesConfig<Compiler>(
       }
 
       resolved_dep.library_type = library_type;
-      resolved_dep.name = remote_name;
+      resolved_dep.name = normalize_app_name(remote_name);
       const runtimeCode = createMfRuntimeCode(
         zephyr_engine,
         resolved_dep,


### PR DESCRIPTION
### What's added in this PR?

Adding js var normalization for application name.
New version of Nx's module federation plugin now only has MF remotes aliases on the array of remotes.
We're now properly parsing it before passing them to delegate modules.
We need this to parse scope names for remote applications.

#### Screenshots

Nx's plugin reference [here](https://github.com/nrwl/nx/blob/e0d9709acded3d1e7961aa04f71cf2aec93f06d6/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts).

### What's the issues or discussion related to this PR ?

> _Provide some background information related to this PR, including issues or task. Prior to this PR what's the behavior that wasn't expected._

> _If there wasn't discussion related to this PR, you can include the reasoning behind this PR of why you did it._

### What are the steps to test this PR?

> _To help reviewer and tester to understand what's needed_

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
