### PR TITLE
chore: bump form-data to >=4.0.4 to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
       "@rspack/dev-server>http-proxy-middleware": ">=3.0.5",
       "prismjs@<1.30.0": ">=1.30.0",
       "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5",
-      "pbkdf2": ">=3.1.3"
+      "pbkdf2": ">=3.1.3",
+      "form-data": ">=4.0.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,7 @@ overrides:
   prismjs@<1.30.0: '>=1.30.0'
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   pbkdf2: '>=3.1.3'
+  form-data: '>=4.0.4'
 
 importers:
 
@@ -8574,8 +8575,8 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -21348,7 +21349,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 24.0.11
-      form-data: 4.0.2
+      form-data: 4.0.4
 
   '@types/node-forge@1.3.11':
     dependencies:
@@ -22373,7 +22374,7 @@ snapshots:
   axios@1.10.0:
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.0)
-      form-data: 4.0.2
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -22381,7 +22382,7 @@ snapshots:
   axios@1.9.0(debug@4.4.0):
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.0)
-      form-data: 4.0.2
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -24739,11 +24740,12 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
-  form-data@4.0.2:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -26550,7 +26552,7 @@ snapshots:
       decimal.js: 10.5.0
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.2
+      form-data: 4.0.4
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1


### PR DESCRIPTION
## Summary
- Added form-data override to existing pnpm overrides to force version to >=4.0.4 to address security vulnerability in previous version

## Test plan
- [x] Updated package.json with pnpm override
- [x] Verified dependencies are updated correctly
- [x] Tests and linting pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)