### PR TITLE
fix: dist folder creation timing issue on windows

### DIFF
--- a/libs/vite-plugin-zephyr/src/lib/internal/extract/load_static_entries.ts
+++ b/libs/vite-plugin-zephyr/src/lib/internal/extract/load_static_entries.ts
@@ -1,6 +1,6 @@
 import type { OutputAsset } from 'rollup';
 import { relative, resolve } from 'node:path';
-import { readdirSync, readFile, statSync } from 'node:fs';
+import { readdirSync, readFile, statSync, existsSync } from 'node:fs';
 import { normalizePath } from 'vite';
 import { promisify } from 'node:util';
 
@@ -16,6 +16,11 @@ export async function load_static_entries(
   const publicAssets: OutputAsset[] = [];
 
   const root_dist_dir = resolve(root, props.outDir);
+
+  // Check if the dist directory exists before trying to read it
+  if (!existsSync(root_dist_dir)) {
+    return publicAssets;
+  }
 
   const loadDir = async (destDir: string) => {
     for (const file of readdirSync(destDir)) {

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
@@ -76,6 +76,11 @@ function zephyrPlugin(): Plugin {
         return code;
       }
     },
+    writeBundle: async (options, bundle) => {
+      const vite_internal_options = await vite_internal_options_defer;
+      vite_internal_options.dir = options.dir;
+      vite_internal_options.assets = bundle;
+    },
     closeBundle: async () => {
       try {
         const [vite_internal_options, zephyr_engine] = await Promise.all([


### PR DESCRIPTION
### What's added in this PR?

ember-vite example on zephyr-examples is complaning about dist folder not being created at closeBundle hook time when building in Windows.
This adds the runtimeAssets to the bundle on writeBundle hook in cases where the folder is not there the closeBundle gets active.

cc: @ihor-zephyr 

#### Screenshots

> _If applicable, add some screenshots of the expected behavior._

### What's the issues or discussion related to this PR ?

> _Provide some background information related to this PR, including issues or task. Prior to this PR what's the behavior that wasn't expected._

> _If there wasn't discussion related to this PR, you can include the reasoning behind this PR of why you did it._

### What are the steps to test this PR?

> _To help reviewer and tester to understand what's needed_

### Documentation update for this PR (if applicable)?

> _Add documentation if how the application will behave differently than previous state. Copy paste your PR in [zephyr-documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) PR link here._

### (Optional) What's left to be done for this PR?

### (Optional) What's the potential risk and how to mitigate it?

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [ ] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [ ] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
