### PR TITLE
Fix/release workflow trusted publishers

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -46,8 +46,17 @@ jobs:
 
       - name: Patch versions
         run: |
-          TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          pnpm ze-version-patch 0.0.0-canary-$TIMESTAMP
+          echo "Fetching current canary tag for zephyr-agent..."
+
+          # Get the version behind the canary tag (e.g., 0.0.0-canary.42)
+          CURRENT_CANARY=$(npm dist-tag ls zephyr-agent 2>/dev/null \
+            | awk '/canary:/{print $2}')
+
+          # Extract numeric suffix or default to 0
+          HIGHEST_CANARY=$(echo "$CURRENT_CANARY" | grep -oE '[0-9]+$' || echo 0)
+          NEXT_CANARY=$((HIGHEST_CANARY + 1))
+
+          pnpm ze-version-patch "0.0.0-canary.$NEXT_CANARY"
 
       - name: Publish package on NPM 📦
         run: pnpm ze-publish --tag=canary
@@ -94,10 +103,27 @@ jobs:
         run: |
           # Get current version from root package.json
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          NEXT_VERSION="${CURRENT_VERSION}-next-${TIMESTAMP}"
+
+          echo "Fetching current next tag for zephyr-agent…"
+
+          # Fetch current "next" dist-tag
+          CURRENT_NEXT=$(npm dist-tag ls zephyr-agent 2>/dev/null | awk '/next:/{print $2}')
+
+          # Build a regex for the current prefix: e.g., 1.2.3 → 1\.2\.3-next.NUMBER
+          PREFIX_REGEX="^${CURRENT_VERSION//./\\.}-next\.([0-9]+)$"
+
+          if [[ $CURRENT_NEXT =~ $PREFIX_REGEX ]]; then
+            # Increment from existing number
+            NEXT_NUMBER=$((BASH_REMATCH[1] + 1))
+          else
+            # Start fresh if prefix differs or format invalid
+            NEXT_NUMBER=1
+            echo "Different prefix or invalid format. Starting fresh with 1."
+          fi
+
+          NEXT_VERSION="${CURRENT_VERSION}-next.${NEXT_NUMBER}"
           echo "Setting version to: $NEXT_VERSION"
-          pnpm ze-version-patch $NEXT_VERSION
+          pnpm ze-version-patch "$NEXT_VERSION"
 
       - name: Publish package on NPM 📦
         run: pnpm ze-publish --tag=next
@@ -107,13 +133,9 @@ jobs:
       - name: Post Summary
         continue-on-error: true
         run: |
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          NEXT_VERSION="${CURRENT_VERSION}-next-${TIMESTAMP}"
           echo "## Pre-release version successfully published!" > $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Published with tag: \`next\`" >> $GITHUB_STEP_SUMMARY
-          echo "Version: \`$NEXT_VERSION\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Package | Version | npm Link |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|---------|----------|" >> $GITHUB_STEP_SUMMARY
@@ -130,9 +152,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Fetch the specific git tag that triggered this release
-          ref: ${{ github.event.release.tag_name }}
       - uses: ./.github/actions/setup
 
       - name: Verify git status


### PR DESCRIPTION
### What's added in this PR?

Migrated CI/CD publishing workflows from NPM short-lived tokens to NPM Trusted Publishers. Since Trusted Publishers don't support `npm dist-tag` promotion, replaced the promotion-based release workflow with direct build-and-publish workflows.

**Key changes:**
- **Pre-release workflow**: Now uses `{version}-next.{incremental}` format and publishes directly
- **Release workflow**: Builds fresh from git tag and publishes to `latest` (no promotion)

### What's the issues or discussion related to this PR?

The repo moved to NPM Trusted Publishers but the previous release workflow relied on `npm dist-tag` commands to promote packages from `next` to `latest`. This feature isn't supported by Trusted Publishers yet, causing release failures.

**Solution:** Instead of waiting for NPM support, implemented direct publishing workflows that are more robust and don't require dist-tag manipulation.

### What are the steps to test this PR?

1. **Canary**: Manual workflow dispatch → produces `0.0.0-canary.{number}`
2. **Pre-release**: Create GitHub pre-release → produces `{version}-next.{number}`
3. **Release**: Create GitHub release → publishes directly to `latest`

### Documentation update for this PR (if applicable)?

N/A - Internal CI/CD change, no user-facing behavior changes.
### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [ ] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [ ] I have/will run tests, or ask for help to add test
