### PR TITLE
feat: adapt bump patch script to also do minor and major bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.59",
   "license": "Apache-2.0",
   "scripts": {
-    "bump-patch": "node scripts/bump-patch-version.js",
+    "bump-patch": "node scripts/bump-version.js patch",
+    "bump-minor": "node scripts/bump-version.js minor",
+    "bump-major": "node scripts/bump-version.js major",
     "ze-version-patch": "pnpm --filter \"./libs/**\" patch-version",
     "ze-publish": "pnpm --filter \"./libs/**\" publish --provenance --access public --no-git-checks",
     "build": "nx run-many -t build --projects=\"libs/*\"",


### PR DESCRIPTION
### What's added in this PR?

This PR enhances the version bump script to support major, minor, and patch version bumps instead of only patch bumps.

**Changes made:**
- Renamed `scripts/bump-patch-version.js` to `scripts/bump-version.js` for better naming
- Modified the script to accept bump type as command line argument (major/minor/patch)
- Updated `incrementPatchVersion()` function to `incrementVersion()` with support for all bump types
- Added validation for valid bump types
- Updated commit messages and PR titles to include the specific bump type
- Added new package.json scripts: `bump-minor` and `bump-major`
- Updated existing `bump-patch` script to use new filename

The script maintains all existing functionality (clean working directory checks, branch creation, tagging, PR creation) while supporting the new version bump types.

#### Screenshots

> _Not applicable - this is a script enhancement_

### What's the issues or discussion related to this PR ?

This enhancement was requested to make the version bump script more flexible by supporting semantic versioning bump types (major, minor, patch) instead of being limited to patch-only bumps. This allows for proper semantic versioning workflow in the monorepo.

### What are the steps to test this PR?

1. Ensure you have a clean working directory
2. Test patch bump: `pnpm bump-patch`
3. Test minor bump: `pnpm bump-minor`
4. Test major bump: `pnpm bump-major`
5. Verify that:
   - Versions are incremented correctly in root package.json and all lib packages
   - Git tags are created properly
   - Commit messages include the bump type
   - PRs are created with correct titles (if on main/master branch)

### Documentation update for this PR (if applicable)?

The script's internal documentation has been updated to reflect the new usage patterns. No external documentation changes needed as this is an internal development tool.

### (Optional) What's left to be done for this PR?

Nothing - the implementation is complete.

### (Optional) What's the potential risk and how to mitigate it?

**Risk:** Accidentally running the wrong bump type (e.g., major instead of patch)
**Mitigation:** The script validates input and shows clear output of what version bump is being performed before executing.

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test