### PR TITLE
chore: bump minor version to 0.1.0

### DIFF
--- a/libs/create-zephyr-apps/package.json
+++ b/libs/create-zephyr-apps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-zephyr-apps",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "A CLI tool to create web applications using Zephyr.",
   "keywords": [
     "zephyr",

--- a/libs/parcel-reporter-zephyr/package.json
+++ b/libs/parcel-reporter-zephyr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-reporter-zephyr",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Parcel reporter for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/rollup-plugin-zephyr/package.json
+++ b/libs/rollup-plugin-zephyr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-zephyr",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Rollup plugin for Zephyr",
   "keywords": [
     "rollup",

--- a/libs/vite-plugin-zephyr/package.json
+++ b/libs/vite-plugin-zephyr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-zephyr",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Vite plugin for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/with-zephyr/package.json
+++ b/libs/with-zephyr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-zephyr",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "A codemod to automatically add withZephyr plugin to bundler configurations",
   "main": "dist/index.js",
   "repository": {

--- a/libs/zephyr-agent/package.json
+++ b/libs/zephyr-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-agent",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Zephyr plugin agent",
   "repository": {
     "type": "git",

--- a/libs/zephyr-edge-contract/package.json
+++ b/libs/zephyr-edge-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-edge-contract",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Edge contract for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/zephyr-modernjs-plugin/package.json
+++ b/libs/zephyr-modernjs-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-modernjs-plugin",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Modernjs plugin for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/zephyr-repack-plugin/package.json
+++ b/libs/zephyr-repack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-repack-plugin",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Repack plugin for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/zephyr-rolldown-plugin/package.json
+++ b/libs/zephyr-rolldown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-rolldown-plugin",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Rolldown plugin for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/zephyr-rsbuild-plugin/package.json
+++ b/libs/zephyr-rsbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-rsbuild-plugin",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Rsbuild plugin for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/zephyr-rspack-plugin/package.json
+++ b/libs/zephyr-rspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-rspack-plugin",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Repack plugin for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/zephyr-rspress-plugin/package.json
+++ b/libs/zephyr-rspress-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-rspress-plugin",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Rspress plugin for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/zephyr-webpack-plugin/package.json
+++ b/libs/zephyr-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-webpack-plugin",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Webpack plugin for Zephyr",
   "repository": {
     "type": "git",

--- a/libs/zephyr-xpack-internal/package.json
+++ b/libs/zephyr-xpack-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-xpack-internal",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "description": "Xpack internals for Zephyr",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-packages",
-  "version": "0.0.59",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "scripts": {
     "bump-patch": "node scripts/bump-version.js patch",


### PR DESCRIPTION
## Summary
• Bump minor version from 0.0.59 to 0.1.0
• Update root package.json and all lib package.json files
• Add version tag v0.1.0

## Test plan
- [ ] Verify all package.json files have correct version
- [ ] Verify git tag is created
- [ ] Verify no breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)