### PR TITLE
fix: add MF remote cache invalidation via buildHash and manifest freshness

### DIFF
--- a/.opencode/plans/1770755903294-jolly-panda.md
+++ b/.opencode/plans/1770755903294-jolly-panda.md
@@ -1,0 +1,108 @@
+# Plan: DTS `remoteTypeUrls` Support in Zephyr Bundler Plugin
+
+## Goal
+
+When Zephyr resolves remote URLs at build time and rewrites the Module Federation config, also inject `dts.consumeTypes.remoteTypeUrls` so the MF DTS plugin fetches types from the same resolved CDN location. This keeps type resolution in sync with remote entry resolution.
+
+## DTS Disabled Handling
+
+The implementation respects explicit opt-outs at every level:
+
+- `dts: false` -> skip entirely (user disabled DTS)
+- `dts.consumeTypes: false` -> skip (user disabled type consumption)
+- `dts.consumeTypes.remoteTypeUrls` already set -> skip (user provided their own)
+- Only inject for non-legacy MF plugins (legacy webpack `ModuleFederationPlugin` has no DTS support)
+
+## Files Already Modified (before plan mode)
+
+### 1. `libs/zephyr-xpack-internal/src/xpack.types.ts`
+
+- Added `RemoteTypeUrlEntry`, `DtsConfig` types
+- Added `dts?: boolean | DtsConfig` field to `XFederatedRemotesConfig`
+
+### 2. `libs/zephyr-xpack-internal/src/xpack-extract/mut-dts-remote-type-urls.ts` (new file)
+
+- `buildRemoteTypeUrls()` - derives `@mf-types.zip` / `@mf-types.d.ts` URLs from resolved remote entry URLs
+- `mutDtsRemoteTypeUrls()` - mutates MF config's `dts` in-place with proper disabled guards
+- `buildRemoteAliasMap()` - resolves remote aliases for the `alias` field in `RemoteTypeUrlEntry`
+
+## Changes Still Needed
+
+### Change 1: Export from barrel - `libs/zephyr-xpack-internal/src/xpack-extract/index.ts`
+
+Add export:
+
+```ts
+export { mutDtsRemoteTypeUrls } from './mut-dts-remote-type-urls';
+```
+
+### Change 2: Export from package - `libs/zephyr-xpack-internal/src/index.ts`
+
+Add `mutDtsRemoteTypeUrls` to the existing named export block from `'./xpack-extract'`.
+
+### Change 3: Wire into xpack path - `libs/zephyr-xpack-internal/src/xpack-extract/mut-webpack-federated-remotes-config.ts`
+
+This covers webpack, rspack, rsbuild (delegates to rspack), and modernjs (delegates to webpack/rspack).
+
+**What to do:**
+
+1. Import `mutDtsRemoteTypeUrls` from `./mut-dts-remote-type-urls`
+2. Before the `remoteEntries.forEach` loop (line 49), declare `const matchedResolvedDeps: ZeResolvedDependency[] = []`
+3. Inside the forEach, after `resolved_dep` is found and before URL mutation, push it: `matchedResolvedDeps.push(resolved_dep)`
+4. After the forEach loop ends (after line 134), add:
+
+```ts
+if (!isLegacyMFPlugin(plugin) && !isRepack && matchedResolvedDeps.length > 0) {
+  mutDtsRemoteTypeUrls(remotesConfig, matchedResolvedDeps);
+}
+```
+
+**Why gate on `!isLegacyMFPlugin(plugin) && !isRepack`:**
+
+- Legacy plugins don't support `dts` at all
+- Repack is React Native and doesn't use the DTS type system
+
+**Why collect deps and call once after the loop:**
+`mutDtsRemoteTypeUrls` sets `remoteTypeUrls` as a single object with ALL remotes. Calling per-remote would overwrite with partial data.
+
+**`name@` prefix on `remote_entry_url`:**
+By the time `mutDtsRemoteTypeUrls` reads `resolved_dep.remote_entry_url`, it will have the `name@` prefix (set at line 89). `buildRemoteTypeUrls` already handles this by checking `!rawUrl.startsWith('http')` and stripping the prefix.
+
+### Change 4: Wire into Vite path - `libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts`
+
+1. Import `mutDtsRemoteTypeUrls` from `zephyr-xpack-internal`
+2. In `configResolved`, after remote resolution succeeds (after line 126), add:
+
+```ts
+const resolvedDeps = zephyr_engine.federated_dependencies;
+if (resolvedDeps?.length && mfPlugin) {
+  mutDtsRemoteTypeUrls(mfPlugin._options as any, resolvedDeps);
+}
+```
+
+**Why `as any`:** `mfPlugin._options` is typed as `ModuleFederationOptions` (from `@module-federation/vite`) while the function expects `XFederatedRemotesConfig`. They are structurally compatible for `dts` and `remotes` fields but nominally different types.
+
+**Timing:** `federation(mfConfig)` is called earlier (line 67) but the MF DTS plugin reads `dts.consumeTypes.remoteTypeUrls` lazily during build, not at plugin creation. Mutating the shared config reference in `configResolved` takes effect in time.
+
+## Files NOT Modified
+
+| Package                  | Reason                                              |
+| ------------------------ | --------------------------------------------------- |
+| `zephyr-rsbuild-plugin`  | Delegates to rspack plugin -> xpack-internal        |
+| `zephyr-modernjs-plugin` | Delegates to webpack/rspack -> xpack-internal       |
+| `zephyr-rspack-plugin`   | Calls `mutWebpackFederatedRemotesConfig` (Change 3) |
+| `zephyr-webpack-plugin`  | Calls `mutWebpackFederatedRemotesConfig` (Change 3) |
+| `zephyr-repack-plugin`   | React Native, no DTS support                        |
+| `zephyr-metro-plugin`    | React Native, no DTS support                        |
+
+## Verification
+
+1. **Build check:** Run the project build to ensure no type errors
+2. **Unit tests for `mutDtsRemoteTypeUrls`:**
+   - `dts: false` -> no mutation
+   - `dts: undefined` -> injects `dts.consumeTypes.remoteTypeUrls`
+   - `dts: true` -> converts to object, injects
+   - `dts: { consumeTypes: false }` -> no mutation
+   - `dts: { consumeTypes: { remoteTypeUrls: userProvided } }` -> no overwrite
+3. **URL derivation test:** `https://cdn.zephyr.io/app/v1/remoteEntry.js` -> zip: `https://cdn.zephyr.io/app/v1/@mf-types.zip`, api: `https://cdn.zephyr.io/app/v1/@mf-types.d.ts`
+4. **`name@` prefix handling:** `app2@https://cdn.zephyr.io/app/v1/remoteEntry.js` correctly strips prefix before deriving type URLs


### PR DESCRIPTION
## Summary
- Add optional `buildHash` field to `ZephyrManifest` interface for cache-busting
- Compute `buildHash` (SHA-256 of sorted remote_entry_urls) during manifest creation
- Runtime plugin: always fetch fresh manifest with `cache: 'no-cache'` + timestamp query param for SSR compatibility
- Runtime plugin: append `?v=<buildHash>` to remote entry URLs so MF runtime treats each new build as a distinct remote
- Skip buildHash on session storage overrides (local dev)

## Related PRs (common branch `fix/mf-cache-invalidation-live-reload`)
- **zephyr-panel**: `bypassCache: true` on `chrome.tabs.reload()`
- **zephyr-mono**: Worker engine Cache-Control differentiation + ETag
- **zephyr-cloud-io**: WebSocket message enrichment with snapshot_id

## Problem
Module Federation's runtime caches loaded remotes by URL. When a new version is deployed, the remote entry URL doesn't change (same path, new content), so MF serves the cached old version. The runtime plugin's in-memory manifest cache (`window.__ZEPHYR_MANIFEST_CACHE__`) also prevents re-fetching updated manifests.

## Changes
| File | Change |
|------|--------|
| `libs/zephyr-edge-contract/src/lib/zephyr-manifest.ts` | Add `buildHash?: string` to `ZephyrManifest` |
| `libs/zephyr-agent/src/lib/transformers/ze-create-manifest.ts` | Compute buildHash from dependency URLs (skipped for standalone apps) |
| `libs/zephyr-xpack-internal/src/xpack-extract/runtime-plugin.ts` | `cache: 'no-cache'` + `?_t=` on manifest fetch, `?v=buildHash` on remote URLs, always re-resolve remotes |

## Backward Compatibility
- `buildHash` is optional — old manifests without it still work (no query param appended)
- `cache: 'no-cache'` still allows 304 responses — no performance regression
- Session storage overrides (local dev) are unaffected