### PR TITLE
feat: add DNS plugin version warnings + auto TXT updates on release

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -188,6 +188,12 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
+      - name: Update plugin version DNS TXT
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: node scripts/update-plugin-version-dns.js
+
       - name: Post Summary
         continue-on-error: true
         run: |

--- a/README.md
+++ b/README.md
@@ -85,15 +85,4 @@ pnpm install
   - gh CLI installed and authenticated (for automatic PR creation)
   - Git configured with push access to origin
 
-### Release Automation
-
-- `.github/workflows/publish_packages.yml` updates Cloudflare TXT
-  `_ze_version.zephyr-cloud.io` on `release.released` after publishing `latest`.
-- Workflow secrets required:
-  - `CLOUDFLARE_API_TOKEN` (DNS edit permission for zone)
-  - `CLOUDFLARE_ZONE_ID` (zone containing `zephyr-cloud.io`)
-- Script: `scripts/update-plugin-version-dns.js`
-  - Updates `latest=<release version>` (infers from GitHub tag/ref, strips leading `v`)
-  - Preserves existing `schema` and `msg`, and removes legacy `min` / `urgent` keys
-
 Note: Please ensure you have run `pnpm install` before executing any of these commands.

--- a/README.md
+++ b/README.md
@@ -85,4 +85,15 @@ pnpm install
   - gh CLI installed and authenticated (for automatic PR creation)
   - Git configured with push access to origin
 
+### Release Automation
+
+- `.github/workflows/publish_packages.yml` updates Cloudflare TXT
+  `_ze_version.zephyr-cloud.io` on `release.released` after publishing `latest`.
+- Workflow secrets required:
+  - `CLOUDFLARE_API_TOKEN` (DNS edit permission for zone)
+  - `CLOUDFLARE_ZONE_ID` (zone containing `zephyr-cloud.io`)
+- Script: `scripts/update-plugin-version-dns.js`
+  - Updates `latest=<release version>` (infers from GitHub tag/ref, strips leading `v`)
+  - Preserves existing `schema` and `msg`, and removes legacy `min` / `urgent` keys
+
 Note: Please ensure you have run `pnpm install` before executing any of these commands.

--- a/docs/plugin-version-dns.md
+++ b/docs/plugin-version-dns.md
@@ -1,0 +1,64 @@
+---
+title: Plugin Version DNS
+summary: DNS-based plugin version warning + release-time TXT automation.
+read_when:
+  - Changing plugin update warning behavior
+  - Updating release publish automation
+---
+
+# Plugin Version DNS
+
+## Purpose
+
+Use DNS TXT as a lightweight version beacon for Zephyr plugins.
+
+- Record: `_ze_version.zephyr-cloud.io`
+- Current fields: `schema`, `latest`, `msg`
+- Example:
+  - `schema=1; latest=1.7.3; msg=Upgrade recommended`
+
+## Runtime Behavior (Plugin Side)
+
+Implemented in `zephyr-agent`:
+
+- Resolve TXT from `_ze_version.zephyr-cloud.io`
+- Parse `latest` and `msg`
+- Compare current plugin version vs `latest`
+- If behind, log warning only (non-blocking)
+- If DNS fails, ignore (best effort)
+
+Code:
+
+- `libs/zephyr-agent/src/lib/version-check/plugin-version-check.ts`
+- Hooked from `libs/zephyr-agent/src/zephyr-engine/index.ts`
+
+## Release Automation (CI Side)
+
+On GitHub `release.released`, after publishing `latest`, CI updates TXT automatically.
+
+Workflow:
+
+- `.github/workflows/publish_packages.yml`
+
+Script:
+
+- `scripts/update-plugin-version-dns.js`
+
+Script behavior:
+
+- Infers version from GitHub tag/ref (`v1.7.3` -> `1.7.3`)
+- Updates TXT record `_ze_version.zephyr-cloud.io`
+- Keeps `schema` and `msg`
+- Rewrites `latest`
+- Removes legacy keys: `min`, `urgent`
+
+Required GitHub secrets:
+
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ZONE_ID`
+
+## Operational Notes
+
+- TTL currently `300` seconds
+- Recommended default: keep `300` for normal release flow
+- Use lower TTL only for urgent rollout messaging

--- a/libs/zephyr-agent/src/lib/version-check/plugin-version-check.spec.ts
+++ b/libs/zephyr-agent/src/lib/version-check/plugin-version-check.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  checkPluginVersionWarning,
+  compareSemver,
+  parseTxtFields,
+  parseTxtRecord,
+} from './plugin-version-check';
+
+describe('plugin-version-check', () => {
+  it('parses TXT key-value content', () => {
+    const result = parseTxtFields('schema=1; latest=1.7.3; msg=Upgrade recommended');
+    expect(result.get('schema')).toBe('1');
+    expect(result.get('latest')).toBe('1.7.3');
+    expect(result.get('msg')).toBe('Upgrade recommended');
+  });
+
+  it('parses TXT records split across chunks', () => {
+    const result = parseTxtRecord([['schema=1; ', 'latest=1.7.3; msg=Upgrade now']]);
+    expect(result.get('latest')).toBe('1.7.3');
+    expect(result.get('msg')).toBe('Upgrade now');
+  });
+
+  it('compares semver strings', () => {
+    expect(compareSemver('1.2.3', '1.2.3')).toBe(0);
+    expect(compareSemver('1.2.3', '1.2.4')).toBe(-1);
+    expect(compareSemver('1.3.0', '1.2.4')).toBe(1);
+    expect(compareSemver('v1.2.3', '1.2.4')).toBe(-1);
+    expect(compareSemver('invalid', '1.2.4')).toBeNull();
+  });
+
+  it('logs warning when current version is behind latest', async () => {
+    const logger = jest.fn();
+    const resolveTxt = jest
+      .fn<() => Promise<string[][]>>()
+      .mockResolvedValue([['schema=1; latest=1.7.3; msg=Upgrade recommended']]);
+
+    await checkPluginVersionWarning({
+      resolveTxt,
+      logger,
+      currentVersion: '1.6.2',
+    });
+
+    expect(logger).toHaveBeenCalledTimes(1);
+    expect(logger).toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('Update available: 1.6.2 -> 1.7.3'),
+      'build:warn:plugin_version'
+    );
+  });
+
+  it('does not log warning when current version is up to date', async () => {
+    const logger = jest.fn();
+    const resolveTxt = jest
+      .fn<() => Promise<string[][]>>()
+      .mockResolvedValue([['schema=1; latest=1.7.3; msg=Upgrade recommended']]);
+
+    await checkPluginVersionWarning({
+      resolveTxt,
+      logger,
+      currentVersion: '1.7.3',
+    });
+
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('never throws when DNS resolution fails', async () => {
+    const logger = jest.fn();
+    const resolveTxt = jest
+      .fn<() => Promise<string[][]>>()
+      .mockRejectedValue(new Error('dns'));
+
+    await expect(
+      checkPluginVersionWarning({
+        resolveTxt,
+        logger,
+        currentVersion: '1.0.0',
+      })
+    ).resolves.toBeUndefined();
+    expect(logger).not.toHaveBeenCalled();
+  });
+});

--- a/libs/zephyr-agent/src/lib/version-check/plugin-version-check.ts
+++ b/libs/zephyr-agent/src/lib/version-check/plugin-version-check.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from 'node:fs';
+import dns from 'node:dns/promises';
+import { join } from 'node:path';
+import { logFn } from '../logging/ze-log-event';
+
+const DEFAULT_VERSION_RECORD = '_ze_version.zephyr-cloud.io';
+
+let cachedVersion: string | null = null;
+
+export function parseTxtFields(content: string): Map<string, string> {
+  const fields = new Map<string, string>();
+
+  for (const part of content.split(';')) {
+    const segment = part.trim();
+    if (!segment) continue;
+
+    const separatorIndex = segment.indexOf('=');
+    if (separatorIndex === -1) continue;
+
+    const key = segment.slice(0, separatorIndex).trim();
+    const value = segment.slice(separatorIndex + 1).trim();
+    if (!key || !value) continue;
+
+    fields.set(key, value);
+  }
+
+  return fields;
+}
+
+export function parseTxtRecord(records: string[][]): Map<string, string> {
+  for (const chunks of records) {
+    const fields = parseTxtFields(chunks.join(''));
+    if (fields.has('latest')) {
+      return fields;
+    }
+  }
+
+  return new Map<string, string>();
+}
+
+export function compareSemver(
+  currentVersion: string,
+  latestVersion: string
+): number | null {
+  const normalize = (value: string): [number, number, number] | null => {
+    const clean = value.trim().replace(/^v/i, '').split('-', 1)[0];
+    const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(clean);
+    if (!match) return null;
+
+    return [
+      Number.parseInt(match[1], 10),
+      Number.parseInt(match[2], 10),
+      Number.parseInt(match[3], 10),
+    ];
+  };
+
+  const current = normalize(currentVersion);
+  const latest = normalize(latestVersion);
+  if (!current || !latest) {
+    return null;
+  }
+
+  for (let index = 0; index < 3; index += 1) {
+    if (current[index] < latest[index]) return -1;
+    if (current[index] > latest[index]) return 1;
+  }
+  return 0;
+}
+
+function getCurrentPluginVersion(): string | null {
+  if (cachedVersion) {
+    return cachedVersion;
+  }
+
+  try {
+    const packageJsonPath = join(__dirname, '../../../package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+      version?: string;
+    };
+    cachedVersion = packageJson.version ?? null;
+    return cachedVersion;
+  } catch {
+    return null;
+  }
+}
+
+export async function checkPluginVersionWarning(deps?: {
+  resolveTxt?: (hostname: string) => Promise<string[][]>;
+  logger?: typeof logFn;
+  currentVersion?: string | null;
+}): Promise<void> {
+  const resolveTxt = deps?.resolveTxt ?? dns.resolveTxt;
+  const logger = deps?.logger ?? logFn;
+  const host = DEFAULT_VERSION_RECORD;
+
+  try {
+    const txtRecords = await resolveTxt(host);
+    const fields = parseTxtRecord(txtRecords);
+    const latest = fields.get('latest');
+
+    if (!latest) {
+      return;
+    }
+
+    const current = deps?.currentVersion ?? getCurrentPluginVersion();
+    if (!current) {
+      return;
+    }
+
+    const comparison = compareSemver(current, latest);
+    if (comparison === null || comparison >= 0) {
+      return;
+    }
+
+    const msg =
+      fields.get('msg') ?? 'Please upgrade to the latest Zephyr plugin version.';
+    logger(
+      'warn',
+      `[Zephyr] Update available: ${current} -> ${latest}. ${msg}`,
+      'build:warn:plugin_version'
+    );
+  } catch {
+    // Version checks are best-effort and must never affect plugin behavior.
+  }
+}

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -30,6 +30,7 @@ import { type ZeLogger, logFn, logger } from '../lib/logging/ze-log-event';
 import { setAppDeployResult } from '../lib/node-persist/app-deploy-result-cache';
 import type { ZeApplicationConfig } from '../lib/node-persist/upload-provider-options';
 import { zeBuildAssets } from '../lib/transformers/ze-build-assets';
+import { checkPluginVersionWarning } from '../lib/version-check/plugin-version-check';
 import { createSnapshot } from '../lib/transformers/ze-build-snapshot';
 import {
   convertResolvedDependencies,
@@ -214,6 +215,8 @@ export class ZephyrEngine {
         ze_log.init('Loaded: application configuration', { username, email, EDGE_URL });
       })
       .catch((err) => ze_log.init(`Failed to get application configuration: ${err}`));
+
+    void checkPluginVersionWarning();
 
     await ze.start_new_build();
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@swc/helpers": "catalog:swc",
     "@types/node": "catalog:typescript",
     "@typescript-eslint/eslint-plugin": "^8.48.1",
+    "cloudflare": "^5.2.0",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.7",
     "eslint": "^9.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.48.1
         version: 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.23.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.23.0(jiti@2.6.1))(typescript@5.9.3)
+      cloudflare:
+        specifier: ^5.2.0
+        version: 5.2.0(encoding@0.1.13)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1652,7 +1655,7 @@ importers:
         version: 1.13.5(debug@4.4.3)
       axios-retry:
         specifier: ^4.5.0
-        version: 4.5.0(axios@1.13.5(debug@4.4.3))
+        version: 4.5.0(axios@1.13.5)
       debug:
         specifier: ^4.3.4
         version: 4.4.3(supports-color@5.5.0)
@@ -8424,6 +8427,9 @@ packages:
 
   cloudflare@3.5.0:
     resolution: {integrity: sha512-sIRZ4K2WQf8tZ74gZGan3u6+50VY1cB6uNc9XIGGLQa7Ti/nrvvadirm8EPVFlQMG11PUXPsX1Buheh4MPLiew==}
+
+  cloudflare@5.2.0:
+    resolution: {integrity: sha512-dVzqDpPFYR9ApEC9e+JJshFJZXcw4HzM8W+3DHzO5oy9+8rLC53G7x6fEf9A7/gSuSCxuvndzui5qJKftfIM9A==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -15201,6 +15207,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tcp-port-used@1.0.2:
     resolution: {integrity: sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==}
@@ -24655,7 +24662,7 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios-retry@4.5.0(axios@1.13.5(debug@4.4.3)):
+  axios-retry@4.5.0(axios@1.13.5):
     dependencies:
       axios: 1.13.5(debug@4.4.3)
       is-retry-allowed: 2.2.0
@@ -25380,6 +25387,18 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       qs: 6.14.1
       web-streams-polyfill: 3.3.3
+    transitivePeerDependencies:
+      - encoding
+
+  cloudflare@5.2.0(encoding@0.1.13):
+    dependencies:
+      '@types/node': 22.13.13
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -35791,7 +35810,7 @@ snapshots:
     dependencies:
       '@toon-format/toon': 0.8.0
       axios: 1.13.5(debug@4.4.3)
-      axios-retry: 4.5.0(axios@1.13.5(debug@4.4.3))
+      axios-retry: 4.5.0(axios@1.13.5)
       cloudflare: 3.5.0(encoding@0.1.13)
       debug: 4.4.3(supports-color@5.5.0)
       eventsource: 4.0.0

--- a/scripts/update-plugin-version-dns.js
+++ b/scripts/update-plugin-version-dns.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+const { Cloudflare } = require('cloudflare');
+const { readFileSync } = require('node:fs');
+
+const DEFAULT_RECORD_NAME = '_ze_version.zephyr-cloud.io';
+const DEFAULT_TTL = 300;
+const DEFAULT_SCHEMA = '1';
+const DEFAULT_MSG = 'Upgrade recommended';
+
+function getRequiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function normalizeVersion(version) {
+  return version.startsWith('v') ? version.slice(1) : version;
+}
+
+function inferPluginVersion() {
+  const refName = process.env.GITHUB_REF_NAME;
+  if (refName) {
+    return normalizeVersion(refName);
+  }
+
+  const ref = process.env.GITHUB_REF;
+  if (ref && ref.startsWith('refs/tags/')) {
+    return normalizeVersion(ref.slice('refs/tags/'.length));
+  }
+
+  try {
+    const rootPackageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
+    if (rootPackageJson.version) {
+      return normalizeVersion(String(rootPackageJson.version));
+    }
+  } catch {
+    // Continue to hard failure below.
+  }
+
+  throw new Error('Could not infer plugin version from GitHub ref or package.json');
+}
+
+function parseTxtContent(content) {
+  const fields = new Map();
+  for (const part of String(content || '').split(';')) {
+    const segment = part.trim();
+    if (!segment) continue;
+
+    const separatorIndex = segment.indexOf('=');
+    if (separatorIndex === -1) continue;
+
+    const key = segment.slice(0, separatorIndex).trim();
+    let value = segment.slice(separatorIndex + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (key) {
+      fields.set(key, value);
+    }
+  }
+
+  return fields;
+}
+
+function buildTxtContent(fields) {
+  const orderedKeys = ['schema', 'latest', 'msg'];
+  const output = [];
+  const seen = new Set();
+
+  for (const key of orderedKeys) {
+    if (!fields.has(key)) continue;
+    output.push(`${key}=${fields.get(key)}`);
+    seen.add(key);
+  }
+
+  for (const [key, value] of fields.entries()) {
+    if (seen.has(key)) continue;
+    output.push(`${key}=${value}`);
+  }
+
+  return output.join('; ');
+}
+
+async function main() {
+  const apiToken = getRequiredEnv('CLOUDFLARE_API_TOKEN');
+  const zoneId = getRequiredEnv('CLOUDFLARE_ZONE_ID');
+  const pluginVersion = inferPluginVersion();
+  const recordName = DEFAULT_RECORD_NAME;
+  const ttl = DEFAULT_TTL;
+
+  const client = new Cloudflare({ apiToken });
+
+  let existingRecord = null;
+  // SDK list is paginated and async iterable.
+  for await (const record of client.dns.records.list({
+    zone_id: zoneId,
+    type: 'TXT',
+    name: { exact: recordName },
+  })) {
+    if (record.type === 'TXT' && record.name.toLowerCase() === recordName.toLowerCase()) {
+      existingRecord = record;
+      break;
+    }
+  }
+
+  const fields = existingRecord
+    ? parseTxtContent(existingRecord.content)
+    : new Map([
+        ['schema', DEFAULT_SCHEMA],
+        ['msg', DEFAULT_MSG],
+      ]);
+
+  if (!fields.has('schema')) {
+    fields.set('schema', DEFAULT_SCHEMA);
+  }
+  if (!fields.has('msg')) {
+    fields.set('msg', DEFAULT_MSG);
+  }
+
+  // Explicitly remove deprecated keys from the DNS value.
+  fields.delete('min');
+  fields.delete('urgent');
+  fields.set('latest', pluginVersion);
+
+  const content = buildTxtContent(fields);
+  const basePayload = {
+    type: 'TXT',
+    name: recordName,
+    content,
+    ttl,
+  };
+
+  if (existingRecord) {
+    await client.dns.records.edit(existingRecord.id, {
+      zone_id: zoneId,
+      ...basePayload,
+    });
+    console.log(`Updated TXT record ${recordName} -> ${content}`);
+    return;
+  }
+
+  await client.dns.records.create({
+    zone_id: zoneId,
+    ...basePayload,
+  });
+  console.log(`Created TXT record ${recordName} -> ${content}`);
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## What this adds
- Adds a DNS version check in `zephyr-agent` using TXT record `_ze_version.zephyr-cloud.io`.
- Shows a warning if local plugin version is older than `latest` in DNS.
- Warning is non-blocking: plugin keeps working normally.
- Adds CI step on release publish to update the TXT record automatically.
- TXT format now keeps only: `schema`, `latest`, `msg` (drops `min` and `urgent`).
- Moves release/version-check docs from `README.md` into `docs/plugin-version-dns.md`.

## Why
- Users get a simple upgrade warning when they are behind.
- We stop doing manual DNS updates on every latest release.
- README stays focused; operational details live in docs.

## Release behavior
- `publish_packages.yml` runs `scripts/update-plugin-version-dns.js` after `latest` publish.
- Script infers version from GitHub tag/ref, then updates `_ze_version.zephyr-cloud.io`.

## Setup needed
- GitHub secrets:
  - `CLOUDFLARE_API_TOKEN`
  - `CLOUDFLARE_ZONE_ID`

## Validation
- `nx test zephyr-agent` includes new `plugin-version-check.spec.ts` tests.
- `nx build zephyr-agent` passes.
- Live DNS check verified against `_ze_version.zephyr-cloud.io`.
