### PR TITLE
feat(agent): gzip wasm uploads over 25MB and persist encoding metadata

### DIFF
--- a/libs/zephyr-agent/README.md
+++ b/libs/zephyr-agent/README.md
@@ -21,7 +21,7 @@ The Zephyr Agent is the core engine that powers all Zephyr bundler plugins. It p
 - **Authentication**: Manages secure communication with Zephyr Cloud services
 - **Build Context**: Provides build-time context and metadata for plugins
 - **Edge Communication**: Handles communication with Zephyr's edge network
-- **Large WASM Optimization**: Gzips `.wasm` assets larger than 25MB before upload
+- **Large Asset Optimization**: Gzips assets larger than 25MB before upload
 
 ## Architecture
 

--- a/libs/zephyr-agent/README.md
+++ b/libs/zephyr-agent/README.md
@@ -21,6 +21,7 @@ The Zephyr Agent is the core engine that powers all Zephyr bundler plugins. It p
 - **Authentication**: Manages secure communication with Zephyr Cloud services
 - **Build Context**: Provides build-time context and metadata for plugins
 - **Edge Communication**: Handles communication with Zephyr's edge network
+- **Large WASM Optimization**: Gzips `.wasm` assets larger than 25MB before upload
 
 ## Architecture
 
@@ -43,6 +44,7 @@ The agent is structured into several key modules:
 - Implements deployment strategies for different CDN providers
 - Supports Cloudflare, Fastly, and Netlify deployment targets
 - Handles asset uploads and build stats publication
+- Preserves asset `contentEncoding` metadata in snapshots for correct edge serving
 
 ### Edge Actions (`lib/edge-actions/`)
 

--- a/libs/zephyr-agent/src/lib/transformers/__test__/ze-build-snapshot.spec.ts
+++ b/libs/zephyr-agent/src/lib/transformers/__test__/ze-build-snapshot.spec.ts
@@ -1,0 +1,59 @@
+import type { ZephyrEngine } from '../../../zephyr-engine';
+import { zeBuildAssets } from '../ze-build-assets';
+import { createSnapshot } from '../ze-build-snapshot';
+
+function createMockZephyrEngine(): ZephyrEngine {
+  return {
+    build_id: Promise.resolve('1'),
+    env: {
+      isCI: false,
+      target: 'web',
+      env: 'development',
+      ssr: false,
+    },
+    buildProperties: { output: './dist' },
+    gitProperties: {
+      app: { org: 'acme', project: 'dashboard' },
+      git: {
+        branch: 'main',
+        commit: 'abc123',
+      },
+    },
+    applicationProperties: {
+      org: 'acme',
+      project: 'dashboard',
+      name: 'host',
+      version: '1.0.0',
+    },
+    application_configuration: Promise.resolve({
+      username: 'user',
+      email: 'user@example.com',
+      EDGE_URL: 'https://edge.example.com',
+    }),
+  } as unknown as ZephyrEngine;
+}
+
+describe('createSnapshot', () => {
+  it('keeps contentEncoding metadata in snapshot assets', async () => {
+    const zephyrEngine = createMockZephyrEngine();
+    const encodedAsset = zeBuildAssets({
+      filepath: 'assets/server.wasm',
+      content: Buffer.from('A'.repeat(120_000)),
+      contentEncoding: 'gzip',
+    });
+
+    const snapshot = await createSnapshot(zephyrEngine, {
+      mfConfig: undefined,
+      assets: {
+        [encodedAsset.hash]: encodedAsset,
+      },
+      snapshotType: 'csr',
+    });
+
+    expect(snapshot.assets['assets/server.wasm']).toMatchObject({
+      path: 'assets/server.wasm',
+      hash: encodedAsset.hash,
+      contentEncoding: 'gzip',
+    });
+  });
+});

--- a/libs/zephyr-agent/src/lib/transformers/__test__/ze-compress-assets.spec.ts
+++ b/libs/zephyr-agent/src/lib/transformers/__test__/ze-compress-assets.spec.ts
@@ -1,6 +1,7 @@
+import { randomFillSync } from 'node:crypto';
 import type { ZeBuildAssetsMap } from 'zephyr-edge-contract';
 import { zeBuildAssets } from '../ze-build-assets';
-import { compressWasmAssets } from '../ze-compress-assets';
+import { compressLargeAssets } from '../ze-compress-assets';
 
 function toMap(...assets: ReturnType<typeof zeBuildAssets>[]): ZeBuildAssetsMap {
   return assets.reduce((memo, asset) => {
@@ -9,56 +10,58 @@ function toMap(...assets: ReturnType<typeof zeBuildAssets>[]): ZeBuildAssetsMap 
   }, {} as ZeBuildAssetsMap);
 }
 
-describe('compressWasmAssets', () => {
-  it('compresses large wasm assets (>25MB) and marks gzip encoding', () => {
-    const wasmAsset = zeBuildAssets({
-      filepath: 'server.wasm',
+describe('compressLargeAssets', () => {
+  it('compresses large assets (>25MB) and marks gzip encoding', () => {
+    const largeJsAsset = zeBuildAssets({
+      filepath: 'large.js',
       content: Buffer.alloc(26 * 1024 * 1024, 'A'),
     });
 
-    const result = compressWasmAssets(toMap(wasmAsset));
+    const result = compressLargeAssets(toMap(largeJsAsset));
     const compressedAsset = Object.values(result)[0];
 
-    expect(compressedAsset.path).toBe('server.wasm');
+    expect(compressedAsset.path).toBe('large.js');
     expect(compressedAsset.contentEncoding).toBe('gzip');
-    expect(compressedAsset.size).toBeLessThan(wasmAsset.size);
-    expect(compressedAsset.hash).not.toBe(wasmAsset.hash);
+    expect(compressedAsset.size).toBeLessThan(largeJsAsset.size);
+    expect(compressedAsset.hash).not.toBe(largeJsAsset.hash);
   });
 
-  it('keeps non-wasm assets unchanged', () => {
+  it('keeps small assets unchanged', () => {
     const jsAsset = zeBuildAssets({
       filepath: 'main.js',
       content: 'console.log("hello");',
     });
 
-    const result = compressWasmAssets(toMap(jsAsset));
+    const result = compressLargeAssets(toMap(jsAsset));
     const output = result[jsAsset.hash];
 
     expect(output).toBe(jsAsset);
     expect(output.contentEncoding).toBeUndefined();
   });
 
-  it('keeps small wasm assets unchanged', () => {
-    const tinyWasmAsset = zeBuildAssets({
-      filepath: 'tiny.wasm',
-      content: Buffer.from([0x00, 0x61]),
+  it('keeps large incompressible assets unchanged', () => {
+    const incompressible = Buffer.alloc(26 * 1024 * 1024);
+    randomFillSync(incompressible);
+    const largeAsset = zeBuildAssets({
+      filepath: 'large.bin',
+      content: incompressible,
     });
 
-    const result = compressWasmAssets(toMap(tinyWasmAsset));
-    const output = result[tinyWasmAsset.hash];
+    const result = compressLargeAssets(toMap(largeAsset));
+    const output = result[largeAsset.hash];
 
-    expect(output).toBe(tinyWasmAsset);
+    expect(output).toBe(largeAsset);
     expect(output.contentEncoding).toBeUndefined();
   });
 
   it('does not recompress already encoded assets', () => {
     const encodedAsset = zeBuildAssets({
-      filepath: 'server.wasm',
+      filepath: 'large.js',
       content: Buffer.from('A'.repeat(150_000)),
       contentEncoding: 'gzip',
     });
 
-    const result = compressWasmAssets(toMap(encodedAsset));
+    const result = compressLargeAssets(toMap(encodedAsset));
     const output = result[encodedAsset.hash];
 
     expect(output).toBe(encodedAsset);

--- a/libs/zephyr-agent/src/lib/transformers/__test__/ze-compress-assets.spec.ts
+++ b/libs/zephyr-agent/src/lib/transformers/__test__/ze-compress-assets.spec.ts
@@ -1,0 +1,67 @@
+import type { ZeBuildAssetsMap } from 'zephyr-edge-contract';
+import { zeBuildAssets } from '../ze-build-assets';
+import { compressWasmAssets } from '../ze-compress-assets';
+
+function toMap(...assets: ReturnType<typeof zeBuildAssets>[]): ZeBuildAssetsMap {
+  return assets.reduce((memo, asset) => {
+    memo[asset.hash] = asset;
+    return memo;
+  }, {} as ZeBuildAssetsMap);
+}
+
+describe('compressWasmAssets', () => {
+  it('compresses large wasm assets (>25MB) and marks gzip encoding', () => {
+    const wasmAsset = zeBuildAssets({
+      filepath: 'server.wasm',
+      content: Buffer.alloc(26 * 1024 * 1024, 'A'),
+    });
+
+    const result = compressWasmAssets(toMap(wasmAsset));
+    const compressedAsset = Object.values(result)[0];
+
+    expect(compressedAsset.path).toBe('server.wasm');
+    expect(compressedAsset.contentEncoding).toBe('gzip');
+    expect(compressedAsset.size).toBeLessThan(wasmAsset.size);
+    expect(compressedAsset.hash).not.toBe(wasmAsset.hash);
+  });
+
+  it('keeps non-wasm assets unchanged', () => {
+    const jsAsset = zeBuildAssets({
+      filepath: 'main.js',
+      content: 'console.log("hello");',
+    });
+
+    const result = compressWasmAssets(toMap(jsAsset));
+    const output = result[jsAsset.hash];
+
+    expect(output).toBe(jsAsset);
+    expect(output.contentEncoding).toBeUndefined();
+  });
+
+  it('keeps small wasm assets unchanged', () => {
+    const tinyWasmAsset = zeBuildAssets({
+      filepath: 'tiny.wasm',
+      content: Buffer.from([0x00, 0x61]),
+    });
+
+    const result = compressWasmAssets(toMap(tinyWasmAsset));
+    const output = result[tinyWasmAsset.hash];
+
+    expect(output).toBe(tinyWasmAsset);
+    expect(output.contentEncoding).toBeUndefined();
+  });
+
+  it('does not recompress already encoded assets', () => {
+    const encodedAsset = zeBuildAssets({
+      filepath: 'server.wasm',
+      content: Buffer.from('A'.repeat(150_000)),
+      contentEncoding: 'gzip',
+    });
+
+    const result = compressWasmAssets(toMap(encodedAsset));
+    const output = result[encodedAsset.hash];
+
+    expect(output).toBe(encodedAsset);
+    expect(output.contentEncoding).toBe('gzip');
+  });
+});

--- a/libs/zephyr-agent/src/lib/transformers/ze-build-assets.ts
+++ b/libs/zephyr-agent/src/lib/transformers/ze-build-assets.ts
@@ -5,9 +5,11 @@ import { extname } from 'node:path';
 export function zeBuildAssets({
   filepath,
   content,
+  contentEncoding,
 }: {
   filepath: string;
   content: string | Buffer;
+  contentEncoding?: 'gzip' | 'br';
 }): ZeBuildAsset {
   const buffer = typeof content === 'string' ? Buffer.from(content, 'utf8') : content;
 
@@ -22,5 +24,6 @@ export function zeBuildAssets({
     hash,
     size: buffer.length,
     buffer: buffer,
+    ...(contentEncoding ? { contentEncoding } : {}),
   };
 }

--- a/libs/zephyr-agent/src/lib/transformers/ze-build-snapshot.ts
+++ b/libs/zephyr-agent/src/lib/transformers/ze-build-snapshot.ts
@@ -79,9 +79,15 @@ export async function createSnapshot(
     assets: Object.keys(basedAssets).reduce(
       (memo, hash: string) => {
         const asset = basedAssets[hash];
-        const { path, extname, size } = asset;
+        const { path, extname, size, contentEncoding } = asset;
         const normalizedPath = normalizePathSeparators(path);
-        memo[normalizedPath] = { path: normalizedPath, extname, hash: asset.hash, size };
+        memo[normalizedPath] = {
+          path: normalizedPath,
+          extname,
+          hash: asset.hash,
+          size,
+          ...(contentEncoding ? { contentEncoding } : {}),
+        };
         return memo;
       },
       {} as Record<string, SnapshotAsset>

--- a/libs/zephyr-agent/src/lib/transformers/ze-compress-assets.ts
+++ b/libs/zephyr-agent/src/lib/transformers/ze-compress-assets.ts
@@ -4,27 +4,23 @@ import { zeBuildAssets } from './ze-build-assets';
 
 const MAX_UPLOAD_PAYLOAD_BYTES = 25 * 1024 * 1024;
 
-function shouldCompressAsset(
-  extname: string,
-  size: number,
-  contentEncoding?: string
-): boolean {
+function shouldCompressAsset(size: number, contentEncoding?: string): boolean {
   if (contentEncoding) {
     return false;
   }
 
-  return extname.toLowerCase() === '.wasm' && size > MAX_UPLOAD_PAYLOAD_BYTES;
+  return size > MAX_UPLOAD_PAYLOAD_BYTES;
 }
 
 /**
- * Compresses WASM assets before upload and marks them with content encoding metadata.
+ * Compresses large assets before upload and marks them with content encoding metadata.
  *
  * This keeps transport payloads significantly smaller while preserving the original asset
  * path and extension for runtime lookup.
  */
-export function compressWasmAssets(assetsMap: ZeBuildAssetsMap): ZeBuildAssetsMap {
+export function compressLargeAssets(assetsMap: ZeBuildAssetsMap): ZeBuildAssetsMap {
   return Object.values(assetsMap).reduce((memo, asset) => {
-    if (!shouldCompressAsset(asset.extname, asset.size, asset.contentEncoding)) {
+    if (!shouldCompressAsset(asset.size, asset.contentEncoding)) {
       memo[asset.hash] = asset;
       return memo;
     }

--- a/libs/zephyr-agent/src/lib/transformers/ze-compress-assets.ts
+++ b/libs/zephyr-agent/src/lib/transformers/ze-compress-assets.ts
@@ -1,0 +1,51 @@
+import { gzipSync } from 'node:zlib';
+import type { ZeBuildAssetsMap } from 'zephyr-edge-contract';
+import { zeBuildAssets } from './ze-build-assets';
+
+const MAX_UPLOAD_PAYLOAD_BYTES = 25 * 1024 * 1024;
+
+function shouldCompressAsset(
+  extname: string,
+  size: number,
+  contentEncoding?: string
+): boolean {
+  if (contentEncoding) {
+    return false;
+  }
+
+  return extname.toLowerCase() === '.wasm' && size > MAX_UPLOAD_PAYLOAD_BYTES;
+}
+
+/**
+ * Compresses WASM assets before upload and marks them with content encoding metadata.
+ *
+ * This keeps transport payloads significantly smaller while preserving the original asset
+ * path and extension for runtime lookup.
+ */
+export function compressWasmAssets(assetsMap: ZeBuildAssetsMap): ZeBuildAssetsMap {
+  return Object.values(assetsMap).reduce((memo, asset) => {
+    if (!shouldCompressAsset(asset.extname, asset.size, asset.contentEncoding)) {
+      memo[asset.hash] = asset;
+      return memo;
+    }
+
+    const buffer =
+      typeof asset.buffer === 'string' ? Buffer.from(asset.buffer) : asset.buffer;
+    const compressed = gzipSync(buffer, { level: 9 });
+
+    // Keep original binary if compression is not beneficial.
+    if (compressed.length >= buffer.length) {
+      memo[asset.hash] = asset;
+      return memo;
+    }
+
+    const compressedAsset = zeBuildAssets({
+      filepath: asset.path,
+      content: compressed,
+      contentEncoding: 'gzip',
+    });
+    memo[compressedAsset.hash] = compressedAsset;
+
+    return memo;
+  }, {} as ZeBuildAssetsMap);
+}

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -30,7 +30,7 @@ import { type ZeLogger, logFn, logger } from '../lib/logging/ze-log-event';
 import { setAppDeployResult } from '../lib/node-persist/app-deploy-result-cache';
 import type { ZeApplicationConfig } from '../lib/node-persist/upload-provider-options';
 import { zeBuildAssets } from '../lib/transformers/ze-build-assets';
-import { compressWasmAssets } from '../lib/transformers/ze-compress-assets';
+import { compressLargeAssets } from '../lib/transformers/ze-compress-assets';
 import { createSnapshot } from '../lib/transformers/ze-build-snapshot';
 import {
   convertResolvedDependencies,
@@ -494,7 +494,7 @@ https://docs.zephyr-cloud.io/features/remote-dependencies`,
       assetsMap[manifestAsset.hash] = manifestAsset;
     }
 
-    const optimizedAssetsMap = compressWasmAssets(assetsMap);
+    const optimizedAssetsMap = compressLargeAssets(assetsMap);
 
     if (!zephyr_engine.application_uid || !zephyr_engine.build_id) {
       ze_log.upload('Failed to upload assets: missing application_uid or build_id');

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -30,6 +30,7 @@ import { type ZeLogger, logFn, logger } from '../lib/logging/ze-log-event';
 import { setAppDeployResult } from '../lib/node-persist/app-deploy-result-cache';
 import type { ZeApplicationConfig } from '../lib/node-persist/upload-provider-options';
 import { zeBuildAssets } from '../lib/transformers/ze-build-assets';
+import { compressWasmAssets } from '../lib/transformers/ze-compress-assets';
 import { createSnapshot } from '../lib/transformers/ze-build-snapshot';
 import {
   convertResolvedDependencies,
@@ -481,7 +482,8 @@ https://docs.zephyr-cloud.io/features/remote-dependencies`,
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const zephyr_engine = this;
     ze_log.upload('Initializing: upload assets');
-    const { assetsMap, buildStats, mfConfig, snapshotType, entrypoint } = props;
+    const { buildStats, mfConfig, snapshotType, entrypoint } = props;
+    const assetsMap: ZeBuildAssetsMap = { ...props.assetsMap };
 
     if (zephyr_engine.federated_dependencies) {
       const manifest = {
@@ -492,6 +494,8 @@ https://docs.zephyr-cloud.io/features/remote-dependencies`,
       assetsMap[manifestAsset.hash] = manifestAsset;
     }
 
+    const optimizedAssetsMap = compressWasmAssets(assetsMap);
+
     if (!zephyr_engine.application_uid || !zephyr_engine.build_id) {
       ze_log.upload('Failed to upload assets: missing application_uid or build_id');
       return;
@@ -501,13 +505,13 @@ https://docs.zephyr-cloud.io/features/remote-dependencies`,
     const hash_set = zephyr_engine.resolved_hash_list;
 
     const missingAssets = get_missing_assets({
-      assetsMap,
+      assetsMap: optimizedAssetsMap,
       hash_set: hash_set ?? { hash_set: new Set() },
     });
 
     // upload data
     const snapshot = await createSnapshot(zephyr_engine, {
-      assets: assetsMap,
+      assets: optimizedAssetsMap,
       mfConfig,
       snapshotType,
       entrypoint,
@@ -528,7 +532,7 @@ https://docs.zephyr-cloud.io/features/remote-dependencies`,
         };
       },
       assets: {
-        assetsMap,
+        assetsMap: optimizedAssetsMap,
         missingAssets,
       },
     };

--- a/libs/zephyr-edge-contract/src/lib/snapshot.ts
+++ b/libs/zephyr-edge-contract/src/lib/snapshot.ts
@@ -62,6 +62,7 @@ export interface SnapshotAsset {
   extname: string;
   hash: string;
   size: number;
+  contentEncoding?: 'gzip' | 'br';
 }
 
 export interface SnapshotMetadata {

--- a/libs/zephyr-edge-contract/src/lib/zephyr-edge-contract.ts
+++ b/libs/zephyr-edge-contract/src/lib/zephyr-edge-contract.ts
@@ -72,6 +72,7 @@ export interface UploadableAsset {
   hash: string;
   size: number;
   buffer: Buffer | string;
+  contentEncoding?: 'gzip' | 'br';
 }
 
 export interface ZeUploadAssetsOptions {
@@ -87,6 +88,7 @@ export interface ZeBuildAsset {
   hash: string;
   size: number; // Size in bytes
   buffer: Buffer | string;
+  contentEncoding?: 'gzip' | 'br';
 }
 
 export interface ZeBuildAssetsMap {


### PR DESCRIPTION
## Summary
- gzip .wasm assets larger than 25MB before upload in zephyr-agent
- propagate contentEncoding through build assets and snapshot contracts
- preserve encoding metadata in snapshot creation and upload payloads
- add transformer and snapshot tests plus README note

## Verification
- pnpm nx test zephyr-agent --runInBand
- pnpm nx test zephyr-edge-contract --runInBand
- manual local e2e against worker: uploaded compressed wasm + snapshot and verified response headers/body via curl (Content-Encoding: gzip, Content-Type: application/wasm)
