### PR TITLE
fix(zephyr-agent): make https-proxy-agent a direct dependency

### DIFF
--- a/libs/zephyr-agent/package.json
+++ b/libs/zephyr-agent/package.json
@@ -39,6 +39,7 @@
     "debug": "^4.3.4",
     "eventsource": "^4.0.0",
     "git-url-parse": "^15.0.0",
+    "https-proxy-agent": "^7.0.6",
     "is-ci": "catalog:plugin-shared",
     "jose": "^5.10.0",
     "node-persist": "^4.0.1",
@@ -58,9 +59,6 @@
     "@types/proper-lockfile": "^4.1.4",
     "@typescript-eslint/eslint-plugin": "catalog:eslint",
     "ts-jest": "catalog:typescript"
-  },
-  "peerDependencies": {
-    "https-proxy-agent": "^7.0.6"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🧠 Why

`https-proxy-agent` is a required runtime dependency — `zephyr-agent` imports it directly in `fetch-with-retries.ts`. Having it as a peer dependency forces consumers to install it separately, which is unnecessary friction and can lead to missing-dep errors.

## 📝 What changed

- Moved `https-proxy-agent` from `peerDependencies` to `dependencies` in `libs/zephyr-agent/package.json`
- Removed the now-empty `peerDependencies` field

## 🧪 How to test

- `pnpm nx test zephyr-agent` — all tests pass
- `pnpm nx build zephyr-agent` — builds clean
- Verify `https-proxy-agent` is listed under `dependencies` in `libs/zephyr-agent/package.json`