### PR TITLE
fix(zephyr-agent): include ZE_ENV in build stats

### DIFF
--- a/libs/zephyr-agent/src/lib/transformers/__test__/ze-build-dash-data.spec.ts
+++ b/libs/zephyr-agent/src/lib/transformers/__test__/ze-build-dash-data.spec.ts
@@ -1,0 +1,54 @@
+import { zeBuildDashData } from '../ze-build-dash-data';
+import type { ZephyrEngine } from '../../../zephyr-engine';
+
+describe('zeBuildDashData', () => {
+  it('includes the selected Zephyr environment in build stats', async () => {
+    const engine = {
+      snapshotId: Promise.resolve('snapshot-id'),
+      build_id: Promise.resolve('build-id'),
+      application_uid: 'app.repo.org',
+      env: {
+        isCI: false,
+        target: 'web',
+        env: 'staging',
+      },
+      gitProperties: {
+        git: {
+          name: 'User',
+          email: 'user@example.com',
+          branch: 'main',
+          commit: 'abc123',
+        },
+      },
+      applicationProperties: {
+        org: 'org',
+        project: 'repo',
+        name: 'app',
+        version: '1.0.0',
+      },
+      application_configuration: Promise.resolve({
+        EDGE_URL: 'https://edge.example.com',
+        username: 'user',
+        DELIMITER: '-',
+      }),
+      npmProperties: {
+        dependencies: {},
+        devDependencies: {},
+        optionalDependencies: {},
+        peerDependencies: {},
+      },
+      federated_dependencies: null,
+      zephyr_dependencies: {},
+      ze_env_vars: null,
+      ze_env_vars_hash: null,
+    } as unknown as ZephyrEngine;
+
+    const stats = await zeBuildDashData(engine);
+
+    expect(stats.environment).toBe('staging');
+    expect(stats.context).toMatchObject({
+      env: 'staging',
+      target: 'web',
+    });
+  });
+});

--- a/libs/zephyr-agent/src/lib/transformers/ze-build-dash-data.ts
+++ b/libs/zephyr-agent/src/lib/transformers/ze-build-dash-data.ts
@@ -34,14 +34,19 @@ export async function zeBuildDashData(
   return {
     id: application_uid,
     name,
-    environment: '',
+    environment: zephyr_engine.env.env ?? '',
     edge: { url: edge_url, delimiter },
     app: Object.assign({}, app, {
       buildId,
     }),
     version: snapshotId,
     git,
-    context: { isCI, username },
+    context: {
+      isCI,
+      username,
+      env: zephyr_engine.env.env,
+      target: zephyr_engine.env.target,
+    },
     dependencies: to_raw(zephyr_engine.npmProperties.dependencies),
     devDependencies: to_raw(zephyr_engine.npmProperties.devDependencies),
     optionalDependencies: to_raw(zephyr_engine.npmProperties.optionalDependencies),


### PR DESCRIPTION
### What's added in this PR?

This fixes Zephyr build stats so the selected `ZE_ENV` is included in the payload uploaded to `/build-stats`.

- Populates legacy `environment` from `zephyr_engine.env.env`.
- Adds `context.env` and `context.target` to build stats.
- Adds regression coverage for the build stats transformer.

#### Screenshots

Not applicable.

### What's the issues or discussion related to this PR ?

Astro builds were receiving `ZE_ENV` in process env, but the stats payload still sent `environment: ''`. With `DEBUG=zephyr*`, the build logs showed `Using environment: <value>` after build stats upload, while the upload payload did not include the selected environment.

### What are the steps to test this PR?

```sh
pnpm nx test zephyr-agent --runInBand
pnpm nx test zephyr-astro-integration --runInBand
pnpm nx run zephyr-agent:build --skip-nx-cache
DEBUG='zephyr*' ZE_ENV='payload-check' ZE_PUBLIC_CODEX_CHECK='payload-works' pnpm build
```

The Astro example DEBUG run shows `/build-stats` now includes:

```ts
environment: 'payload-check'
context: { env: 'payload-check', target: 'web' }
```

### Documentation update for this PR (if applicable)?

Not applicable. This fixes internal build stats payload propagation for an existing env selector.

### (Optional) What's left to be done for this PR?

None.

### (Optional) What's the potential risk and how to mitigate it?

Low. The change only fills previously-empty build stats fields from existing engine state and keeps the empty-string fallback when no environment is selected.

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
