### PR TITLE
fix(zephyr-agent): always emit zephyr manifest

### DIFF
--- a/libs/zephyr-agent/src/zephyr-engine/__test__/upload_assets.test.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/__test__/upload_assets.test.ts
@@ -1,0 +1,27 @@
+import { ZEPHYR_MANIFEST_FILENAME, type ZeBuildAssetsMap } from 'zephyr-edge-contract';
+import { ZephyrEngine } from '../index';
+
+describe('ZephyrEngine.upload_assets', () => {
+  it('adds an empty zephyr manifest asset when no federated dependencies were resolved', async () => {
+    const engine = Object.create(ZephyrEngine.prototype) as ZephyrEngine;
+    engine.federated_dependencies = null;
+
+    const assetsMap: ZeBuildAssetsMap = {};
+
+    await engine.upload_assets({
+      assetsMap,
+      buildStats: {} as never,
+    });
+
+    const manifestAsset = Object.values(assetsMap).find(
+      (asset) => asset.path === ZEPHYR_MANIFEST_FILENAME
+    );
+
+    expect(manifestAsset).toBeDefined();
+    expect(JSON.parse(manifestAsset?.buffer.toString('utf8') ?? '')).toMatchObject({
+      version: '1.0.0',
+      dependencies: {},
+      zeVars: {},
+    });
+  });
+});

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -506,14 +506,12 @@ https://docs.zephyr-cloud.io/features/remote-dependencies`,
     ze_log.upload('Initializing: upload assets');
     const { assetsMap, buildStats, mfConfig, snapshotType, entrypoint } = props;
 
-    if (zephyr_engine.federated_dependencies) {
-      const manifest = {
-        filepath: ZEPHYR_MANIFEST_FILENAME,
-        content: createManifestContent(zephyr_engine.federated_dependencies),
-      };
-      const manifestAsset = zeBuildAssets(manifest);
-      assetsMap[manifestAsset.hash] = manifestAsset;
-    }
+    const manifest = {
+      filepath: ZEPHYR_MANIFEST_FILENAME,
+      content: createManifestContent(zephyr_engine.federated_dependencies ?? []),
+    };
+    const manifestAsset = zeBuildAssets(manifest);
+    assetsMap[manifestAsset.hash] = manifestAsset;
 
     if (!zephyr_engine.application_uid || !zephyr_engine.build_id) {
       ze_log.upload('Failed to upload assets: missing application_uid or build_id');


### PR DESCRIPTION
### What's added in this PR?

This makes Zephyr uploads always include `zephyr-manifest.json`, even when a plugin has no resolved federated dependencies.

- Removes the `federated_dependencies` guard before manifest asset creation.
- Falls back to an empty dependencies list for manifest content.
- Adds regression coverage for the empty manifest path in `ZephyrEngine.upload_assets`.

#### Screenshots

Not applicable.

### What's the issues or discussion related to this PR ?

Some plugin builds can reach `upload_assets` without resolving remotes. In that case `federated_dependencies` stays `null`, and the shared upload path skipped `zephyr-manifest.json` entirely. Consumers expect the manifest file to exist, even when empty.

### What are the steps to test this PR?

```sh
pnpm nx test zephyr-agent
pnpm nx lint zephyr-agent
pnpm nx build zephyr-agent
committer "fix(zephyr-agent): always emit zephyr manifest" "libs/zephyr-agent/src/zephyr-engine/index.ts" "libs/zephyr-agent/src/zephyr-engine/__test__/upload_assets.test.ts"
```

`committer` also ran affected tests and lint before creating the commit.

### Documentation update for this PR (if applicable)?

Not applicable. This aligns existing upload behavior with the manifest file contract; no public API or setup option changed.

### (Optional) What's left to be done for this PR?

None.

### (Optional) What's the potential risk and how to mitigate it?

Low. Builds without remotes now upload a small JSON manifest with empty `dependencies` and `zeVars`. Existing builds with remotes keep the populated manifest path.

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
