### PR TITLE
fix(zephyr-native-cache): make podspec robust for RN helper scope and canary versions

### DIFF
--- a/libs/zephyr-native-cache/zephyr-native-cache.podspec
+++ b/libs/zephyr-native-cache/zephyr-native-cache.podspec
@@ -1,6 +1,28 @@
 require "json"
 
+begin
+  react_native_pods = Pod::Executable.execute_command(
+    "node",
+    [
+      "-p",
+      'require.resolve("react-native/scripts/react_native_pods.rb", {paths: [process.argv[1]]})',
+      __dir__,
+    ],
+  ).strip
+  require react_native_pods
+rescue StandardError
+  # Keep podspec evaluation working even when React Native helpers are unavailable.
+end
+
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+min_ios_version = if respond_to?(:min_ios_version_supported, true)
+  min_ios_version_supported
+else
+  "13.4"
+end
+install_modules_dependencies_fn = if respond_to?(:install_modules_dependencies, true)
+  method(:install_modules_dependencies)
+end
 
 Pod::Spec.new do |s|
   s.name         = "zephyr-native-cache"
@@ -9,9 +31,13 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/ZephyrCloudIO/zephyr-packages"
   s.license      = package["license"]
   s.authors      = "Zephyr Cloud Contributors"
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => min_ios_version }
   s.source       = { :git => "https://github.com/ZephyrCloudIO/zephyr-packages.git", :tag => s.version }
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
 
-  install_modules_dependencies(s)
+  if install_modules_dependencies_fn
+    install_modules_dependencies_fn.call(s)
+  else
+    s.dependency "React-Core"
+  end
 end

--- a/libs/zephyr-native-cache/zephyr-native-cache.podspec
+++ b/libs/zephyr-native-cache/zephyr-native-cache.podspec
@@ -15,6 +15,7 @@ rescue StandardError
 end
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+podspec_version = package["version"].split("-").first
 min_ios_version = if respond_to?(:min_ios_version_supported, true)
   min_ios_version_supported
 else
@@ -26,7 +27,7 @@ end
 
 Pod::Spec.new do |s|
   s.name         = "zephyr-native-cache"
-  s.version      = package["version"]
+  s.version      = podspec_version
   s.summary      = package["description"]
   s.homepage     = "https://github.com/ZephyrCloudIO/zephyr-packages"
   s.license      = package["license"]


### PR DESCRIPTION
## Summary
- load `react_native_pods.rb` from the podspec via Node resolution so `min_ios_version_supported` and `install_modules_dependencies` are available during CocoaPods evaluation
- add safe fallbacks when React Native helper methods are unavailable (`ios` floor version + `React-Core` dependency), preventing podspec evaluation failures in stricter tooling contexts
- normalize podspec version for npm pre-release builds by mapping `package[\"version\"]` to a CocoaPods-compatible release string (`split(\"-\").first`)
- keep existing pod dependency wiring unchanged when helper methods are present, so normal React Native installs continue to use the full dependency set

## Why
- `pnpm exec rnef build:ios --configuration Release --destination simulator` in `zephyr-native-cache-test/apps/host` failed during pod install with:
  - `CocoaPods could not find compatible versions for pod \"zephyr-native-cache\"`
- there were two contributing issues:
  1. podspec helper methods were not always available in all CocoaPods evaluation contexts
  2. canary prerelease versions (e.g. `0.0.0-canary.57`) needed podspec version normalization for reliable CocoaPods resolution

## Validation
- `bundle exec pod ipc spec /Users/ryok90/zephyr/zephyr-packages/libs/zephyr-native-cache/zephyr-native-cache.podspec`
  - confirms podspec parses and resolves platform/dependencies successfully
- `pnpm exec rnef build:ios --configuration Release --destination simulator` in `zephyr-native-cache-test/apps/host`
  - succeeds with canary `0.0.0-canary.57`
- commit hooks also ran `nx` affected checks on this package and passed