### PR TITLE
feat(zephyr-metro-plugin): add built-in RNEF Zephyr plugin export

### DIFF
--- a/libs/zephyr-metro-plugin/package.json
+++ b/libs/zephyr-metro-plugin/package.json
@@ -22,8 +22,8 @@
     "url": "https://github.com/ZephyrCloudIO"
   },
   "peerDependencies": {
-    "@module-federation/metro": ">=0.0.0",
-    "@rnef/tools": ">=0.0.0",
+    "@module-federation/metro": "^0.21.6",
+    "@rnef/tools": "^0.7.28",
     "metro": ">=0.70.0",
     "react-native": ">=0.60.0"
   },

--- a/libs/zephyr-metro-plugin/package.json
+++ b/libs/zephyr-metro-plugin/package.json
@@ -22,6 +22,8 @@
     "url": "https://github.com/ZephyrCloudIO"
   },
   "peerDependencies": {
+    "@module-federation/metro": ">=0.0.0",
+    "@rnef/tools": ">=0.0.0",
     "metro": ">=0.70.0",
     "react-native": ">=0.60.0"
   },
@@ -35,6 +37,8 @@
     "directory": "libs/zephyr-metro-plugin"
   },
   "devDependencies": {
+    "@module-federation/metro": "^0.21.6",
+    "@rnef/tools": "^0.7.28",
     "@rspack/core": "catalog:rspack",
     "@types/find-package-json": "^1.2.6",
     "@types/jest": "catalog:typescript",

--- a/libs/zephyr-metro-plugin/package.json
+++ b/libs/zephyr-metro-plugin/package.json
@@ -27,6 +27,14 @@
     "metro": ">=0.70.0",
     "react-native": ">=0.60.0"
   },
+  "peerDependenciesMeta": {
+    "@module-federation/metro": {
+      "optional": true
+    },
+    "@rnef/tools": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "zephyr-agent": "workspace:*",
     "zephyr-edge-contract": "workspace:*"

--- a/libs/zephyr-metro-plugin/src/index.ts
+++ b/libs/zephyr-metro-plugin/src/index.ts
@@ -14,3 +14,10 @@ export {
   type MetroConfig,
   type MetroFederationConfig,
 } from './lib/zephyr-metro-command-wrapper';
+
+// RNEF plugin export for Module Federation host/remote bundling commands
+export {
+  zephyrMetroRNEFPlugin,
+  type ZephyrMetroRNEFPluginConfig,
+  type RNEFPluginApi,
+} from './lib/zephyr-metro-rnef-plugin';

--- a/libs/zephyr-metro-plugin/src/lib/__test__/index-exports.spec.ts
+++ b/libs/zephyr-metro-plugin/src/lib/__test__/index-exports.spec.ts
@@ -7,11 +7,20 @@ jest.mock('../zephyr-metro-command-wrapper', () => ({
   zephyrCommandWrapper: jest.fn(),
 }));
 
+jest.mock('../zephyr-metro-rnef-plugin', () => ({
+  zephyrMetroRNEFPlugin: jest.fn(),
+}));
+
 import * as zephyrMetroPlugin from '../../index';
 
 describe('package root exports', () => {
   it('exports zephyrCommandWrapper for CLI integrations', () => {
     expect(zephyrMetroPlugin).toHaveProperty('zephyrCommandWrapper');
     expect(typeof zephyrMetroPlugin.zephyrCommandWrapper).toBe('function');
+  });
+
+  it('exports zephyrMetroRNEFPlugin for RNEF integrations', () => {
+    expect(zephyrMetroPlugin).toHaveProperty('zephyrMetroRNEFPlugin');
+    expect(typeof zephyrMetroPlugin.zephyrMetroRNEFPlugin).toBe('function');
   });
 });

--- a/libs/zephyr-metro-plugin/src/lib/global.d.ts
+++ b/libs/zephyr-metro-plugin/src/lib/global.d.ts
@@ -1,6 +1,9 @@
 /** Global type declarations for Zephyr Metro Plugin. */
 
 declare global {
+  /** Module Federation manifest path populated by Metro bundling commands. */
+  var __METRO_FEDERATION_MANIFEST_PATH: string | undefined;
+
   /**
    * Module Federation global config set by Metro bundler. Used by zephyrCommandWrapper to
    * access the MF configuration.

--- a/libs/zephyr-metro-plugin/src/lib/zephyr-metro-rnef-plugin.ts
+++ b/libs/zephyr-metro-plugin/src/lib/zephyr-metro-rnef-plugin.ts
@@ -104,7 +104,7 @@ export const zephyrMetroRNEFPlugin =
         outro('Success.');
       },
       options: [
-        ...deps.commands['bundleFederatedHostOptions'],
+        ...(deps.commands['bundleFederatedHostOptions'] ?? []),
         {
           name: '--config-cmd [string]',
           description:
@@ -149,7 +149,7 @@ export const zephyrMetroRNEFPlugin =
         logger.info('Bundle artifacts uploaded to Zephyr.');
         outro('Success.');
       },
-      options: deps.commands['bundleFederatedRemoteOptions'],
+      options: deps.commands['bundleFederatedRemoteOptions'] ?? [],
     });
 
     return {

--- a/libs/zephyr-metro-plugin/src/lib/zephyr-metro-rnef-plugin.ts
+++ b/libs/zephyr-metro-plugin/src/lib/zephyr-metro-rnef-plugin.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'module';
+import { ZephyrError, ZeErrors } from 'zephyr-agent';
 import { zephyrCommandWrapper } from './zephyr-metro-command-wrapper';
 
 export interface ZephyrMetroRNEFPluginConfig {
@@ -38,20 +39,30 @@ export const zephyrMetroRNEFPlugin =
   (api: RNEFPluginApi) => {
     const loadRuntimeDeps = () => {
       const runtimeRequire = createRequire(__filename);
-      const { updateManifest } = runtimeRequire('@module-federation/metro') as {
-        updateManifest: (manifestPath: string, mfConfig: unknown) => void;
-      };
-      const { default: commands } = runtimeRequire(
-        '@module-federation/metro/commands'
-      ) as {
-        default: Record<string, any>;
-      };
-      const { color, logger, outro } = runtimeRequire('@rnef/tools') as {
-        color: { cyan: (value: string) => string };
-        logger: { info: (message: string) => void };
-        outro: (message: string) => void;
-      };
-      return { updateManifest, commands, color, logger, outro };
+      try {
+        const { updateManifest } = runtimeRequire('@module-federation/metro') as {
+          updateManifest: (manifestPath: string, mfConfig: unknown) => void;
+        };
+        const { default: commands } = runtimeRequire(
+          '@module-federation/metro/commands'
+        ) as {
+          default: Record<string, any>;
+        };
+        const { color, logger, outro } = runtimeRequire('@rnef/tools') as {
+          color: { cyan: (value: string) => string };
+          logger: { info: (message: string) => void };
+          outro: (message: string) => void;
+        };
+        return { updateManifest, commands, color, logger, outro };
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new ZephyrError(ZeErrors.ERR_UNKNOWN, {
+          message:
+            'zephyrMetroRNEFPlugin requires @module-federation/metro and @rnef/tools. ' +
+            'Install them in your app devDependencies to use this integration. ' +
+            `Original error: ${detail}`,
+        });
+      }
     };
 
     const deps = loadRuntimeDeps();

--- a/libs/zephyr-metro-plugin/src/lib/zephyr-metro-rnef-plugin.ts
+++ b/libs/zephyr-metro-plugin/src/lib/zephyr-metro-rnef-plugin.ts
@@ -1,0 +1,148 @@
+import { createRequire } from 'module';
+import { zephyrCommandWrapper } from './zephyr-metro-command-wrapper';
+
+export interface ZephyrMetroRNEFPluginConfig {
+  platforms?: Record<string, object>;
+}
+
+interface RNEFCommandArgv {
+  platform: string;
+  mode?: string;
+  maxWorkers?: number;
+  resetCache?: boolean;
+  config?: string;
+  [key: string]: unknown;
+}
+
+interface RNEFPluginCommandOption {
+  name: string;
+  description: string;
+}
+
+interface RNEFPluginCommand {
+  name: string;
+  description: string;
+  action: (args: RNEFCommandArgv) => Promise<void>;
+  options: RNEFPluginCommandOption[];
+}
+
+export interface RNEFPluginApi {
+  registerCommand: (command: RNEFPluginCommand) => void;
+  getProjectRoot: () => string;
+  getPlatforms: () => Record<string, object>;
+  getReactNativePath: () => string;
+}
+
+export const zephyrMetroRNEFPlugin =
+  (pluginConfig: ZephyrMetroRNEFPluginConfig = {}) =>
+  (api: RNEFPluginApi) => {
+    const loadRuntimeDeps = () => {
+      const runtimeRequire = createRequire(__filename);
+      const { updateManifest } = runtimeRequire('@module-federation/metro') as {
+        updateManifest: (manifestPath: string, mfConfig: unknown) => void;
+      };
+      const { default: commands } = runtimeRequire(
+        '@module-federation/metro/commands'
+      ) as {
+        default: Record<string, any>;
+      };
+      const { color, logger, outro } = runtimeRequire('@rnef/tools') as {
+        color: { cyan: (value: string) => string };
+        logger: { info: (message: string) => void };
+        outro: (message: string) => void;
+      };
+      return { updateManifest, commands, color, logger, outro };
+    };
+
+    const deps = loadRuntimeDeps();
+
+    api.registerCommand({
+      name: 'bundle-mf-host',
+      description: 'Bundles a Module Federation host with Zephyr Cloud',
+      action: async (args: RNEFCommandArgv) => {
+        const { updateManifest, commands, color, logger, outro } = deps;
+        const commandConfig = {
+          root: api.getProjectRoot(),
+          platforms: api.getPlatforms(),
+          reactNativePath: api.getReactNativePath(),
+          ...pluginConfig,
+        };
+
+        logger.info(
+          `Bundling Module Federation host for platform ${color.cyan(args.platform)} with Zephyr Cloud`
+        );
+
+        const bundleZephyrHostCommand = await zephyrCommandWrapper(
+          commands['bundleFederatedHost'],
+          commands['loadMetroConfig'],
+          () => {
+            const globalState = globalThis as any;
+            updateManifest(
+              globalState.__METRO_FEDERATION_MANIFEST_PATH,
+              globalState.__METRO_FEDERATION_CONFIG
+            );
+          }
+        );
+
+        await bundleZephyrHostCommand(
+          [{ mode: args.mode ?? 'production', ...args } as any],
+          commandConfig,
+          args as any
+        );
+        logger.info('Bundle artifacts uploaded to Zephyr.');
+        outro('Success.');
+      },
+      options: [
+        ...deps.commands['bundleFederatedHostOptions'],
+        {
+          name: '--config-cmd [string]',
+          description:
+            '[Internal] Pass-through for Xcode build script - matches the stock RNEF plugin.',
+        },
+      ],
+    });
+
+    api.registerCommand({
+      name: 'bundle-mf-remote',
+      description: 'Bundles a Module Federation remote with Zephyr Cloud',
+      action: async (args: RNEFCommandArgv) => {
+        const { updateManifest, commands, color, logger, outro } = deps;
+        const commandConfig = {
+          root: api.getProjectRoot(),
+          platforms: api.getPlatforms(),
+          reactNativePath: api.getReactNativePath(),
+          ...pluginConfig,
+        };
+
+        logger.info(
+          `Bundling Module Federation remote for platform ${color.cyan(args.platform)} with Zephyr Cloud`
+        );
+
+        const bundleZephyrRemoteCommand = await zephyrCommandWrapper(
+          commands['bundleFederatedRemote'],
+          commands['loadMetroConfig'],
+          () => {
+            const globalState = globalThis as any;
+            updateManifest(
+              globalState.__METRO_FEDERATION_MANIFEST_PATH,
+              globalState.__METRO_FEDERATION_CONFIG
+            );
+          }
+        );
+
+        await bundleZephyrRemoteCommand(
+          [{ mode: args.mode ?? 'production', ...args } as any],
+          commandConfig,
+          args as any
+        );
+        logger.info('Bundle artifacts uploaded to Zephyr.');
+        outro('Success.');
+      },
+      options: deps.commands['bundleFederatedRemoteOptions'],
+    });
+
+    return {
+      name: 'zephyr-metro-rnef-plugin',
+      description: 'RNEF plugin for Module Federation with Metro + Zephyr',
+    };
+  };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1884,6 +1884,12 @@ importers:
         specifier: workspace:*
         version: link:../zephyr-edge-contract
     devDependencies:
+      '@module-federation/metro':
+        specifier: ^0.21.6
+        version: 0.21.6(@babel/types@7.29.0)(metro-config@0.84.2)(metro-file-map@0.84.2)(metro-resolver@0.84.2)(metro-source-map@0.84.2)(metro@0.84.2)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      '@rnef/tools':
+        specifier: ^0.7.28
+        version: 0.7.28
       '@rspack/core':
         specifier: ^1.7.0
         version: 1.7.7(@swc/helpers@0.5.19)
@@ -3205,11 +3211,17 @@ packages:
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
 
+  '@clack/core@0.4.2':
+    resolution: {integrity: sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==}
+
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
   '@clack/core@1.1.0':
     resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
+
+  '@clack/prompts@0.10.1':
+    resolution: {integrity: sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==}
 
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
@@ -3611,6 +3623,19 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@expo/fingerprint@0.11.11':
+    resolution: {integrity: sha512-gNyn1KnAOpEa8gSNsYqXMTcq0fSwqU/vit6fP5863vLSKxHm/dNt/gm/uZJxrRZxKq71KUJWF6I7d3z8qIfq5g==}
+    hasBin: true
+
+  '@expo/metro-runtime@5.0.5':
+    resolution: {integrity: sha512-P8UFTi+YsmiD1BmdTdiIQITzDMcZgronsA3RTQ4QKJjHM3bas11oGzLQOnFaIZnlEV8Rrr3m1m+RHxvnpL+t/A==}
+    peerDependencies:
+      react-native: '*'
+
+  '@expo/spawn-async@1.7.2':
+    resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
+    engines: {node: '>=12'}
 
   '@hongzhiyuan/preact@10.24.0-00213bad':
     resolution: {integrity: sha512-bHWp4ZDK5ZimcY+bTWw3S3xGiB8eROpZj0RK3FClNIaTOajb0b11CsT3K+pdeakgPgq1jWN3T2e2rfrPm40JsQ==}
@@ -4502,6 +4527,18 @@ packages:
 
   '@module-federation/manifest@2.1.0':
     resolution: {integrity: sha512-icIUhMG4FwaFZyBmVjadkdqscNb98iXrITTVeMeAxJcrnZltSBBSEHepfpfeW+tHW+wMmr+lWFnAbSCepV73+A==}
+
+  '@module-federation/metro@0.21.6':
+    resolution: {integrity: sha512-iUYwidiJ1fMiBER9F9HcKFDNWP2pkfo6kSGTIx1CVhBZ8JcevmdAvgfnn35PloSKj/v9fdSY0raCEOrT9sj00g==}
+    peerDependencies:
+      '@babel/types': ^7.25.0
+      metro: ^0.82.1
+      metro-config: ^0.82.1
+      metro-file-map: ^0.82.1
+      metro-resolver: ^0.82.1
+      metro-source-map: ^0.82.1
+      react: '>=19.0.0'
+      react-native: '>=0.79.0'
 
   '@module-federation/node@2.7.25':
     resolution: {integrity: sha512-/u4f+GYRZfHpSvdt5n40lMCS9Cmve7N3JlDreaFXz8xrWDNOp2wvMgiVGpndo5J4iQdtLjpavWStahGQ05B2cQ==}
@@ -6103,6 +6140,9 @@ packages:
   '@resvg/resvg-wasm@2.4.0':
     resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
     engines: {node: '>= 10'}
+
+  '@rnef/tools@0.7.28':
+    resolution: {integrity: sha512-a4MumqUhmCRTdBZZHMHWR6dvy2JwNCHYYmBY2Jif9aj9F7pBrYfqMDCkwbVSZkYqu5vgBHAKzdRH8vCzKWLflw==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.6':
     resolution: {integrity: sha512-kvjTSWGcrv+BaR2vge57rsKiYdVR8V8CoS0vgKrc570qRBfty4bT+1X0z3j2TaVV+kAYzA0PjeB9+mdZyqUZlg==}
@@ -7727,6 +7767,9 @@ packages:
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
+  '@types/adm-zip@0.5.8':
+    resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -8641,6 +8684,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  appdirsjs@1.2.7:
+    resolution: {integrity: sha512-Quji6+8kLBC3NnBeo14nPDq0+2jUs5s3/xEye+udFHumHhRk4M7aAMXp/PBJqkKYGuuyR9M/6Dq7d2AViiGmhw==}
 
   append-transform@2.0.0:
     resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
@@ -11248,6 +11294,10 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  getenv@1.0.0:
+    resolution: {integrity: sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==}
+    engines: {node: '>=6'}
+
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
@@ -12121,6 +12171,10 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
@@ -13626,6 +13680,10 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nano-spawn@0.2.1:
+    resolution: {integrity: sha512-/pULofvsF8mOVcl/nUeVXL/GYOEvc7eJWSIxa+K4OYUolvXa5zwSgevsn4eoHs1xvh/BO3vx/PZiD9+Ow2ZVuw==}
+    engines: {node: '>=18.19'}
 
   nano-spawn@2.0.0:
     resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
@@ -19062,6 +19120,11 @@ snapshots:
     dependencies:
       fontkitten: 1.0.2
 
+  '@clack/core@0.4.2':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@clack/core@0.5.0':
     dependencies:
       picocolors: 1.1.1
@@ -19069,6 +19132,12 @@ snapshots:
 
   '@clack/core@1.1.0':
     dependencies:
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.10.1':
+    dependencies:
+      '@clack/core': 0.4.2
+      picocolors: 1.1.1
       sisteransi: 1.0.5
 
   '@clack/prompts@0.11.0':
@@ -19392,6 +19461,29 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@expo/fingerprint@0.11.11':
+    dependencies:
+      '@expo/spawn-async': 1.7.2
+      arg: 5.0.2
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@5.5.0)
+      find-up: 5.0.0
+      getenv: 1.0.0
+      minimatch: 3.1.5
+      p-limit: 3.1.0
+      resolve-from: 5.0.0
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/metro-runtime@5.0.5(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))':
+    dependencies:
+      react-native: 0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4)
+
+  '@expo/spawn-async@1.7.2':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@hongzhiyuan/preact@10.24.0-00213bad': {}
 
@@ -21118,6 +21210,20 @@ snapshots:
       - typescript
       - utf-8-validate
       - vue-tsc
+
+  '@module-federation/metro@0.21.6(@babel/types@7.29.0)(metro-config@0.84.2)(metro-file-map@0.84.2)(metro-resolver@0.84.2)(metro-source-map@0.84.2)(metro@0.84.2)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/types': 7.29.0
+      '@expo/metro-runtime': 5.0.5(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))
+      '@module-federation/runtime': 0.21.6
+      '@module-federation/sdk': 0.21.6
+      metro: 0.84.2
+      metro-config: 0.84.2
+      metro-file-map: 0.84.2
+      metro-resolver: 0.84.2
+      metro-source-map: 0.84.2
+      react: 19.2.4
+      react-native: 0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4)
 
   '@module-federation/node@2.7.25(@rspack/core@2.0.0-canary-20260116(@module-federation/runtime-tools@0.21.6)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.19))(esbuild@0.27.3))':
     dependencies:
@@ -23615,6 +23721,23 @@ snapshots:
 
   '@resvg/resvg-wasm@2.4.0': {}
 
+  '@rnef/tools@0.7.28':
+    dependencies:
+      '@clack/prompts': 0.10.1
+      '@expo/fingerprint': 0.11.11
+      '@types/adm-zip': 0.5.8
+      adm-zip: 0.5.16
+      appdirsjs: 1.2.7
+      fast-glob: 3.3.3
+      is-unicode-supported: 2.1.0
+      nano-spawn: 0.2.1
+      picocolors: 1.1.1
+      string-argv: 0.3.2
+      tar: 7.5.11
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@rolldown/binding-android-arm64@1.0.0-rc.6':
     optional: true
 
@@ -25590,6 +25713,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  '@types/adm-zip@0.5.8':
+    dependencies:
+      '@types/node': 22.19.13
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -26752,6 +26879,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  appdirsjs@1.2.7: {}
 
   append-transform@2.0.0:
     dependencies:
@@ -29916,6 +30045,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  getenv@1.0.0: {}
+
   giget@2.0.0:
     dependencies:
       citty: 0.1.6
@@ -30984,6 +31115,8 @@ snapshots:
       unc-path-regex: 0.1.2
 
   is-unicode-supported@0.1.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-url@1.2.4: {}
 
@@ -33754,6 +33887,8 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  nano-spawn@0.2.1: {}
 
   nano-spawn@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- add `zephyrMetroRNEFPlugin` to `zephyr-metro-plugin` so RNEF host/remote bundle commands can run Zephyr uploads without a separate package
- export the new API from the package root and cover it in index export tests
- wire runtime loading for `@module-federation/metro` + `@rnef/tools` inside the new plugin implementation and declare corresponding peer/dev dependency expectations

## Validation
- `pnpm --filter zephyr-metro-plugin build`
- nx test/lint hooks ran during commit and passed (warnings only)