### PR TITLE
feat(zephyr-native-cache): expose root API

### DIFF
--- a/e2e/deployment/src/index.test.ts
+++ b/e2e/deployment/src/index.test.ts
@@ -5,13 +5,21 @@ const output = execSync(
   'pnpm exec nx show projects --affected -t=build --projects="examples/**" --exclude="zephyr-cli-test" --json'
 );
 const testTargets = JSON.parse(output.toString()) as string[];
-const appUidsPromise: Promise<string[]> = getAllDeployedApps();
+
+if (testTargets.length === 0) {
+  it('has no affected example deployment tests to run', () => {
+    expect(testTargets).toHaveLength(0);
+  });
+}
+
+let appUidsPromise: Promise<string[]> | undefined;
 
 for (const appName of testTargets) {
   describe(`[${appName}]: asset deployment assertion`, () => {
     let deployResult: DeployResult;
 
     beforeAll(async () => {
+      appUidsPromise ??= getAllDeployedApps();
       const appUids = await appUidsPromise;
       const appUid = appUids.find((uid) => uid.startsWith(replacer(appName)));
       if (!appUid) {

--- a/libs/zephyr-native-cache/README.md
+++ b/libs/zephyr-native-cache/README.md
@@ -142,7 +142,7 @@ cache.events.on('poll:complete', (event) => {
 For React Native UIs, use the built-in hook:
 
 ```ts
-import { useCacheStatus } from 'zephyr-native-cache/react';
+import { useCacheStatus } from 'zephyr-native-cache';
 
 export function CacheStatusPanel() {
   const { status, latestUpdateEvent } = useCacheStatus();
@@ -158,8 +158,7 @@ Use `latestUpdateEvent` as a raw signal to display your own update banner, toast
 
 ```tsx
 import { Button, Text, View } from 'react-native';
-import { ZephyrNativeCache } from 'zephyr-native-cache';
-import { useCacheStatus } from 'zephyr-native-cache/react';
+import ZephyrNativeCache, { useCacheStatus } from 'zephyr-native-cache';
 
 export function UpdateBanner() {
   const { latestUpdateEvent } = useCacheStatus();
@@ -181,8 +180,7 @@ Use the facade for manual update checks and cache invalidation. These calls are 
 
 ```tsx
 import { Button, View } from 'react-native';
-import { ZephyrNativeCache } from 'zephyr-native-cache';
-import { useCacheStatus } from 'zephyr-native-cache/react';
+import ZephyrNativeCache, { useCacheStatus } from 'zephyr-native-cache';
 
 export function CacheControls() {
   const { status } = useCacheStatus();
@@ -215,7 +213,7 @@ The status snapshot contains enough state to show polling progress, last-check r
 
 ```tsx
 import { Text, View } from 'react-native';
-import { useCacheStatus } from 'zephyr-native-cache/react';
+import { useCacheStatus } from 'zephyr-native-cache';
 
 export function CacheDiagnostics() {
   const { status } = useCacheStatus();
@@ -243,8 +241,7 @@ You can map `status.remotes` into source badges so operators can see whether eac
 
 ```tsx
 import { Text } from 'react-native';
-import type { CacheStatusRemoteEntry } from 'zephyr-native-cache';
-import { useCacheStatus } from 'zephyr-native-cache/react';
+import { useCacheStatus, type CacheStatusRemoteEntry } from 'zephyr-native-cache';
 
 const SOURCE_LABELS: Record<string, string> = {
   'cache-hit': 'from cache',

--- a/libs/zephyr-native-cache/package.json
+++ b/libs/zephyr-native-cache/package.json
@@ -23,13 +23,6 @@
       "require": "./lib/commonjs/runtime-plugin.js",
       "default": "./lib/commonjs/runtime-plugin.js"
     },
-    "./react": {
-      "react-native": "./src/react/index.ts",
-      "types": "./lib/typescript/react/index.d.ts",
-      "import": "./lib/module/react/index.js",
-      "require": "./lib/commonjs/react/index.js",
-      "default": "./lib/commonjs/react/index.js"
-    },
     "./package.json": "./package.json"
   },
   "repository": {

--- a/libs/zephyr-native-cache/src/ZephyrNativeCache.ts
+++ b/libs/zephyr-native-cache/src/ZephyrNativeCache.ts
@@ -43,3 +43,5 @@ export const ZephyrNativeCache: ZephyrNativeCacheApi = {
   clearCache,
   reloadApp,
 };
+
+export default ZephyrNativeCache;

--- a/libs/zephyr-native-cache/src/index.ts
+++ b/libs/zephyr-native-cache/src/index.ts
@@ -11,11 +11,10 @@ export {
   stopUpdatePolling,
   subscribeCacheStatus,
 } from './register';
-export { ZephyrNativeCache } from './ZephyrNativeCache';
-// React hook (useCacheStatus) is intentionally NOT re-exported from the root
-// barrel — import it from 'zephyr-native-cache/react' so non-React consumers
-// don't pull React into their bundle (Metro/CJS output doesn't tree-shake).
+export { ZephyrNativeCache, default } from './ZephyrNativeCache';
+export { useCacheStatus } from './useCacheStatus';
 export type { ZephyrNativeCacheApi } from './ZephyrNativeCache';
+export type { UseCacheStatusResult } from './useCacheStatus';
 export type {
   CachePollResult,
   CacheStatusListener,

--- a/libs/zephyr-native-cache/src/react/index.ts
+++ b/libs/zephyr-native-cache/src/react/index.ts
@@ -1,2 +1,0 @@
-export { useCacheStatus } from './useCacheStatus';
-export type { UseCacheStatusResult } from './useCacheStatus';

--- a/libs/zephyr-native-cache/src/useCacheStatus.ts
+++ b/libs/zephyr-native-cache/src/useCacheStatus.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
-import type { UpdateAvailableEvent } from '../events';
+import type { UpdateAvailableEvent } from './events';
 import {
   getCacheStatus,
   getRegisteredCacheLayer,
   subscribeCacheLayerRegistration,
   subscribeCacheStatus,
-} from '../register';
-import type { CacheStatusSnapshot } from '../types';
+} from './register';
+import type { CacheStatusSnapshot } from './types';
 
 const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
 


### PR DESCRIPTION
### What's added in this PR?

- Exposes `useCacheStatus` from `zephyr-native-cache`.
- Adds `ZephyrNativeCache` as the default export.
- Removes the separate `zephyr-native-cache/react` export.

#### Screenshots

N/A

### What's the issues or discussion related to this PR ?

`zephyr-native-cache` is already React Native-focused, so the separate React hook entrypoint adds API surface without a strong standalone use case.

### What are the steps to test this PR?

- `pnpm nx build zephyr-native-cache`
- Pre-commit ran `nx test zephyr-native-cache`

### Documentation update for this PR (if applicable)?

Updated package README examples.

### (Optional) What's left to be done for this PR?

N/A

### (Optional) What's the potential risk and how to mitigate it?

Consumers importing `zephyr-native-cache/react` should switch to the root import.

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test