### PR TITLE
fix(zephyr-agent): improve ci token auth errors

### DIFF
--- a/docs/ci-token-identity.md
+++ b/docs/ci-token-identity.md
@@ -35,3 +35,8 @@ to be linked in cloud-io as a `GitProviderIdentity`; email candidates are only a
 Cloud-io does not call GitLab for this flow; provider-specific validation stays in the plugin. The plugin calls
 ze-api-gateway's `ci-token-exchange` route, which proxies to cloud-io and does not use worker-auth. Cloud-io validates
 the CI token against its separate CI-token table and mints a short-lived Zephyr CI access token.
+
+When `ZE_CI_TOKEN` is present, token exchange failures are terminal. The plugin does not fall back to interactive browser
+login in CI. A rejected exchange usually means the workflow actor's Git provider identity is not linked to a Zephyr user.
+The error should tell the user to link that Git provider account in Zephyr Cloud and rerun the workflow, while also
+checking that the CI token secret belongs to the right Zephyr workspace.

--- a/libs/vite-plugin-zephyr/jest.config.ts
+++ b/libs/vite-plugin-zephyr/jest.config.ts
@@ -5,6 +5,9 @@ export default {
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
+  moduleNameMapper: {
+    '^zephyr-edge-contract$': '<rootDir>/../zephyr-edge-contract/src/index.ts',
+  },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/libs/vite-plugin-zephyr',
 };

--- a/libs/zephyr-agent/src/lib/errors/codes.ts
+++ b/libs/zephyr-agent/src/lib/errors/codes.ts
@@ -434,6 +434,28 @@ Please check your network connection and try again.
     kind: 'build',
   },
 
+  ERR_CI_TOKEN_AUTH: {
+    id: '037',
+    message: `
+ZE_CI_TOKEN could not be exchanged for a Zephyr access token.
+
+Zephyr detected this CI actor:
+- provider: {{ provider }}
+- username: {{ username }}
+- identity source: {{ source }}
+- issuer: {{ issuer }}
+
+Link this CI actor's Git provider account in Zephyr Cloud, then rerun the workflow. Zephyr uses linked Git provider identities to map provider-native CI actor data, such as GitHub actor IDs or GitLab user IDs/emails, to a Zephyr user.
+
+Also check:
+- ZE_CI_TOKEN is the repository or organization secret created for this Zephyr workspace.
+- The workflow checks out the Git repository with origin and commit history.
+
+{{ details }}
+`,
+    kind: 'build',
+  },
+
   ERR_RESOLVE_REMOTES: {
     id: '001',
     message: `

--- a/libs/zephyr-agent/src/lib/node-persist/token.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.test.ts
@@ -1,0 +1,73 @@
+import { getToken } from './token';
+import { inferCiTokenIdentity } from './ci-token-identity';
+import { makeRequest } from '../http/http-request';
+import { ZeErrors, ZephyrError } from '../errors';
+
+jest.mock('node-persist', () => ({
+  clear: jest.fn(),
+  getItem: jest.fn(),
+  removeItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+jest.mock('./storage', () => ({
+  storage: Promise.resolve(),
+}));
+
+jest.mock('./ci-token-identity', () => ({
+  inferCiTokenIdentity: jest.fn(),
+}));
+
+jest.mock('../http/http-request', () => ({
+  makeRequest: jest.fn(),
+}));
+
+const mockInferCiTokenIdentity = inferCiTokenIdentity as jest.MockedFunction<
+  typeof inferCiTokenIdentity
+>;
+const mockMakeRequest = makeRequest as jest.MockedFunction<typeof makeRequest>;
+
+describe('getToken', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env = { ...originalEnv, ZE_CI_TOKEN: 'ci-token' };
+    delete process.env['ZE_SECRET_TOKEN'];
+    delete process.env['ZE_SERVER_TOKEN'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('throws a CI-token-specific error when exchange is rejected', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue({
+      provider: 'github',
+      email: '12345+octocat@users.noreply.github.com',
+      emails: ['12345+octocat@users.noreply.github.com'],
+      issuer: 'https://github.com',
+      providerSubject: '12345',
+      username: 'octocat',
+      source: 'noreply',
+    });
+    mockMakeRequest.mockResolvedValue([
+      false,
+      new Error('GitHub identity is not linked to a Zephyr user'),
+    ]);
+
+    await expect(getToken()).rejects.toMatchObject({
+      code: ZephyrError.toZeCode(ZeErrors.ERR_CI_TOKEN_AUTH),
+      message: expect.stringContaining("Link this CI actor's Git provider account"),
+    });
+  });
+
+  it('throws a CI-token-specific error when no supported CI identity is detected', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(undefined);
+
+    await expect(getToken()).rejects.toMatchObject({
+      code: ZephyrError.toZeCode(ZeErrors.ERR_CI_TOKEN_AUTH),
+      message: expect.stringContaining('no supported CI identity was detected'),
+    });
+  });
+});

--- a/libs/zephyr-agent/src/lib/node-persist/token.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.ts
@@ -9,7 +9,8 @@ import { ZE_API_ENDPOINT, ze_api_gateway } from 'zephyr-edge-contract';
 import { getUserEmail } from './user-email';
 import { ze_log } from '../logging/debug';
 import { type ZeGitInfo } from '../build-context/ze-util-get-git-info';
-import { inferCiTokenIdentity } from './ci-token-identity';
+import { type CiTokenIdentity, inferCiTokenIdentity } from './ci-token-identity';
+import { ZeErrors, ZephyrError } from '../errors';
 
 export async function saveToken(token: string): Promise<void> {
   await storage;
@@ -28,12 +29,16 @@ export async function getToken(git_config?: ZeGitInfo): Promise<string | undefin
   if (ci_token) {
     const ciIdentity = await inferCiTokenIdentity();
     if (ciIdentity) {
-      ze_log.auth(`Using ${ciIdentity.provider} ${ciIdentity.source} identity for CI token attribution`);
+      ze_log.auth(
+        `Using ${ciIdentity.provider} ${ciIdentity.source} identity for CI token attribution`
+      );
       return await getTokenFromCiToken(ci_token, ciIdentity);
     }
 
-    ze_log.error(`${StorageKeys.ze_ci_token} was provided, but no supported CI identity was detected`);
-    return undefined;
+    throwCiTokenAuthError(
+      undefined,
+      `${StorageKeys.ze_ci_token} was provided, but no supported CI identity was detected.`
+    );
   }
 
   await storage;
@@ -95,15 +100,7 @@ async function getTokenFromServerToken(
 
 async function getTokenFromCiToken(
   ci_token: string,
-  identity: {
-    provider: string;
-    email?: string;
-    emails?: string[];
-    issuer?: string;
-    providerSubject?: string;
-    username?: string;
-    source?: string;
-  }
+  identity: CiTokenIdentity
 ): Promise<string | undefined> {
   const [ok, cause, data] = await makeRequest<{ access_token: string }>(
     {
@@ -122,14 +119,26 @@ async function getTokenFromCiToken(
   );
 
   if (!ok) {
-    if (cause instanceof Error) {
-      ze_log.error('Failed to get token from CI token:', cause.message);
-    } else {
-      ze_log.error('Failed to get token from CI token:', cause);
-    }
-    return undefined;
+    throwCiTokenAuthError(identity, cause);
   }
 
   await saveToken(data?.access_token ?? '');
   return data?.access_token;
+}
+
+function throwCiTokenAuthError(
+  identity: CiTokenIdentity | undefined,
+  cause: unknown
+): never {
+  const details = cause instanceof Error ? cause.message : String(cause);
+  ze_log.error('Failed to get token from CI token:', details);
+
+  throw new ZephyrError(ZeErrors.ERR_CI_TOKEN_AUTH, {
+    cause,
+    provider: identity?.provider ?? 'unknown',
+    username: identity?.username ?? 'unknown',
+    source: identity?.source ?? 'unknown',
+    issuer: identity?.issuer ?? 'unknown',
+    details,
+  });
 }


### PR DESCRIPTION
### What's added in this PR?

This improves `ZE_CI_TOKEN` authentication failures in `zephyr-agent`.

- Adds a CI-token-specific auth error for failed CI token exchanges.
- Stops CI token exchange failures from falling back to interactive browser login.
- Shows the inferred CI actor details so users can link the matching Git provider account in Zephyr Cloud.
- Adds regression coverage for rejected CI token exchange and unsupported CI identity detection.
- Stabilizes `vite-plugin-zephyr` Jest resolution by mapping `zephyr-edge-contract` to source during tests.

#### Screenshots

N/A

### What's the issues or discussion related to this PR ?

Some CI runs with `ZE_CI_TOKEN` failed because the workflow actor did not have a linked Git provider identity in Zephyr Cloud. The previous behavior fell through to the interactive login flow, printed an auth URL in CI, and eventually failed with a generic token error.

This PR makes that case explicit: when `ZE_CI_TOKEN` is present, exchange failures are terminal and explain the likely Git identity linking fix.

### What are the steps to test this PR?

- `pnpm nx test zephyr-agent --testFile=libs/zephyr-agent/src/lib/node-persist/token.test.ts --runInBand`
- `pnpm nx build zephyr-agent`
- `pnpm nx test zephyr-agent --runInBand`
- `pnpm nx lint zephyr-agent`
- `pnpm nx test vite-plugin-zephyr --runInBand`
- `docs-list`
- `committer "fix(zephyr-agent): improve ci token auth errors" ...` ran affected tests and lint before commit.
- `committer "test(vite-plugin-zephyr): map edge contract source in jest" ...` ran affected tests and lint before commit.

### Documentation update for this PR (if applicable)?

Updated `docs/ci-token-identity.md` with the terminal CI-token exchange failure behavior.

### (Optional) What's left to be done for this PR?

N/A

### (Optional) What's the potential risk and how to mitigate it?

Risk: existing CI jobs that relied on `ZE_CI_TOKEN` falling back to browser login will now fail earlier. That fallback was not useful in CI, and the new message gives the actionable fix.

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated documentation to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
