### PR TITLE
feat: export ZeRspackPlugin and ZephyrRspackInternalPluginOptions from public entry

### DIFF
--- a/libs/zephyr-rspack-plugin/src/index.ts
+++ b/libs/zephyr-rspack-plugin/src/index.ts
@@ -1,5 +1,7 @@
 export { withZephyr } from './rspack-plugin/with-zephyr';
+export { ZeRspackPlugin } from './rspack-plugin/ze-rspack-plugin';
 export type { ZephyrRspackPluginOptions } from './types';
+export type { ZephyrRspackInternalPluginOptions } from './rspack-plugin/ze-rspack-plugin';
 export type { ZephyrBuildHooks, DeploymentInfo } from 'zephyr-agent';
 
 // hacks


### PR DESCRIPTION
### What's added in this PR?

Export `ZeRspackPlugin` and `ZephyrRspackInternalPluginOptions` from the
package's public entry point (`src/index.ts`). Purely additive — two new
exports, no behavior changes.

```ts
// before: only accessible via deep internal import
const { ZeRspackPlugin } = require(
  'zephyr-rspack-plugin/dist/rspack-plugin/ze-rspack-plugin'
)

// after: stable public API
import {
  ZeRspackPlugin,
  type ZephyrRspackInternalPluginOptions,
} from 'zephyr-rspack-plugin'
```

### What's the issues or discussion related to this PR?

We ship a `version.json` alongside every microfrontend as a runtime
observability artifact — it contains the commit SHA, branch, build
timestamp, pipeline ID, and app name. When something breaks in
production, any team can fetch `/<app>/version.json` and immediately
know what's deployed and trace it back to a CI run. That contract is
standardized across our platform.

We want to integrate Zephyr's build tracking into that same file —
specifically adding Zephyr's build ID so teams can correlate a deployed
artifact with its Zephyr build. To do that, we need to compose
`ZeRspackPlugin` directly so Zephyr's metadata lands inside our existing
schema rather than writing a parallel block that conflicts with it.

The deep internal import is the only way to do that composition today:

```ts
// fragile — breaks on any internal dist reorganization
const { ZeRspackPlugin } = require(
  'zephyr-rspack-plugin/dist/rspack-plugin/ze-rspack-plugin'
)
```

If there's a supported way to opt `withZephyr()` out of its built-in
version metadata behavior, we'd use that instead — but we couldn't find
one. Happy to discuss alternatives if the team has a preference.

### What are the steps to test this PR?

1. Build the package: `pnpm nx build zephyr-rspack-plugin`
2. Confirm `ZeRspackPlugin` and `ZephyrRspackInternalPluginOptions` are
   present in `dist/index.js` and `dist/index.d.ts`
3. In a consumer project, replace the deep import with:
   `import { ZeRspackPlugin } from 'zephyr-rspack-plugin'`
   and confirm it resolves and typechecks correctly.

### Documentation update for this PR (if applicable)?

No behavior change — no documentation update required. The new exports
are self-documenting via the existing `ZeRspackPlugin` source and types.

### (Optional) What's the potential risk and how to mitigate it?

Low risk — additive export only. Existing consumers are unaffected.
The class and its types already exist in the package; this only makes
them reachable from the public entry.

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable) — no new tests needed; existing build output verification covers this
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test