### PR TITLE
Fix zephyr-agent node-persist export paths

### DIFF
--- a/libs/zephyr-agent/package.json
+++ b/libs/zephyr-agent/package.json
@@ -20,9 +20,9 @@
       "types": "./dist/index.d.ts"
     },
     "./node-persist": {
-      "import": "./dist/node-persist/index.js",
-      "require": "./dist/node-persist/index.js",
-      "types": "./dist/node-persist/index.d.ts"
+      "import": "./dist/lib/node-persist/index.js",
+      "require": "./dist/lib/node-persist/index.js",
+      "types": "./dist/lib/node-persist/index.d.ts"
     }
   },
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Fixes the `zephyr-agent/node-persist` package export paths so they point to the files produced and published under `dist/lib/node-persist/`.

## Why

`zephyr-agent@1.1.2` currently maps the `./node-persist` subpath to `./dist/node-persist/index.js` and `./dist/node-persist/index.d.ts`. Those files are not present in the published package, while the matching runtime and declaration files are published at `dist/lib/node-persist/index.js` and `dist/lib/node-persist/index.d.ts`.

That makes `require("zephyr-agent/node-persist")` fail with `MODULE_NOT_FOUND` in a clean install.

## Validation

- `corepack prepare pnpm@10.0.0 --activate`
- `pnpm install --frozen-lockfile`
- `pnpm --filter zephyr-agent build`
- Verified the updated `import`, `require`, and `types` targets exist after build.
- `pnpm --filter zephyr-agent test` (26 suites passed, 210 tests passed; 1 suite / 5 tests skipped by the existing test config)
- `git diff --check`
