### PR TITLE
fix(rspress): rewrite federated SSG asset paths

### DIFF
--- a/libs/zephyr-rspress-plugin/src/__test__/with-zephyr.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/__test__/with-zephyr.spec.ts
@@ -9,6 +9,16 @@ jest.mock('../zephyrRspressSSGPlugin', () => ({
 }));
 
 const rsbuildPluginMock = jest.fn(() => ({ name: 'mock-rsbuild-plugin' }));
+const moduleFederationPublicPathPlugin = {
+  name: 'mock-mf-public-path-plugin',
+};
+const moduleFederationPublicPathPluginMock = jest.fn(
+  () => moduleFederationPublicPathPlugin
+);
+
+jest.mock('../internal/assets/moduleFederationPublicPathPlugin', () => ({
+  moduleFederationPublicPathPlugin: () => moduleFederationPublicPathPluginMock(),
+}));
 
 jest.mock(
   'zephyr-rsbuild-plugin',
@@ -40,7 +50,37 @@ describe('withZephyr', () => {
 
     expect(rspressPluginMock).toHaveBeenCalledWith(config);
     expect(addPlugin).toHaveBeenCalledWith({ name: 'mock-ssg-plugin' });
+    expect(result?.builderConfig?.plugins).toContain(moduleFederationPublicPathPlugin);
     expect(result).toEqual(config);
+  });
+
+  it('should preserve existing SSG builder config while adding portable MF assets', async () => {
+    const addPlugin = jest.fn();
+    const plugin = withZephyr();
+    const existingPlugin = { name: 'existing-plugin' };
+    const config = {
+      ssg: true,
+      builderConfig: {
+        plugins: [existingPlugin],
+        output: {
+          assetPrefix: 'http://localhost:4178/',
+          distPath: { root: 'dist' },
+        },
+      },
+    };
+
+    const result = await plugin.config?.(
+      config as any,
+      { addPlugin, removePlugin: jest.fn() },
+      false
+    );
+
+    expect(result?.builderConfig?.plugins).toEqual([
+      existingPlugin,
+      moduleFederationPublicPathPlugin,
+    ]);
+    expect(result?.builderConfig?.output).toEqual(config.builderConfig.output);
+    expect(addPlugin).toHaveBeenCalledWith({ name: 'mock-ssg-plugin' });
   });
 
   it('should add the zephyrRsbuildPlugin when ssg is false', async () => {
@@ -214,6 +254,7 @@ describe('withZephyr', () => {
 
       expect(rspressPluginMock).toHaveBeenCalledWith(config);
       expect(addPlugin).toHaveBeenCalledWith({ name: 'mock-ssg-plugin' });
+      expect(result?.builderConfig?.plugins).toContain(moduleFederationPublicPathPlugin);
       expect(result).toEqual(config);
     });
 

--- a/libs/zephyr-rspress-plugin/src/__test__/zephyrRspressSSGPlugin.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/__test__/zephyrRspressSSGPlugin.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { ZephyrEngine, logFn } from 'zephyr-agent';
+import { rewriteRspressModuleFederationAssets } from '../internal/assets/rewriteRspressModuleFederationAssets';
 import { setupZeDeploy } from '../internal/assets/setupZeDeploy';
 import { showFiles } from '../internal/files/showFiles';
 import { walkFiles } from '../internal/files/walkFiles';
@@ -32,6 +33,10 @@ jest.mock('../internal/assets/setupZeDeploy', () => ({
   setupZeDeploy: jest.fn(),
 }));
 
+jest.mock('../internal/assets/rewriteRspressModuleFederationAssets', () => ({
+  rewriteRspressModuleFederationAssets: jest.fn(),
+}));
+
 describe('zephyrRspressSSGPlugin', () => {
   const mockZephyrDefer = jest.fn();
   const mockEngine = Promise.resolve({ engine: 'mock' });
@@ -62,6 +67,10 @@ describe('zephyrRspressSSGPlugin', () => {
     const plugin = zephyrRspressSSGPlugin({ outDir: 'dist' });
     await plugin.afterBuild?.();
 
+    expect(rewriteRspressModuleFederationAssets).toHaveBeenCalledWith(
+      path.resolve('dist'),
+      mockFiles
+    );
     expect(showFiles).toHaveBeenCalledWith(path.resolve('dist'), mockFiles);
     expect(setupZeDeploy).toHaveBeenCalledWith({
       deferEngine: mockEngine,

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/moduleFederationPublicPathPlugin.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/moduleFederationPublicPathPlugin.spec.ts
@@ -1,0 +1,144 @@
+import {
+  moduleFederationPublicPathPlugin,
+  setModuleFederationGetPublicPath,
+  setPortableModuleFederationPublicPath,
+  ZEPHYR_RSPRESS_MODULE_FEDERATION_GET_PUBLIC_PATH,
+} from '../assets/moduleFederationPublicPathPlugin';
+
+describe('moduleFederationPublicPathPlugin', () => {
+  it('sets getPublicPath on rspack module federation plugins with exposes', () => {
+    const moduleFederationPlugin = {
+      name: 'RspackModuleFederationPlugin',
+      _options: {
+        exposes: {
+          './docs': './docs/index.mdx',
+        },
+      },
+    };
+
+    setModuleFederationGetPublicPath([moduleFederationPlugin]);
+
+    expect(moduleFederationPlugin._options.getPublicPath).toBe(
+      ZEPHYR_RSPRESS_MODULE_FEDERATION_GET_PUBLIC_PATH
+    );
+  });
+
+  it('preserves an explicit getPublicPath', () => {
+    const moduleFederationPlugin = {
+      name: 'RspackModuleFederationPlugin',
+      _options: {
+        exposes: {
+          './docs': './docs/index.mdx',
+        },
+        getPublicPath: 'return "https://example.com/"',
+      },
+    };
+
+    setModuleFederationGetPublicPath([moduleFederationPlugin]);
+
+    expect(moduleFederationPlugin._options.getPublicPath).toBe(
+      'return "https://example.com/"'
+    );
+  });
+
+  it('skips consumers and non-module-federation plugins', () => {
+    const consumerPlugin = {
+      name: 'RspackModuleFederationPlugin',
+      _options: {},
+    };
+    const otherPlugin = {
+      name: 'OtherPlugin',
+      _options: {
+        exposes: {
+          './docs': './docs/index.mdx',
+        },
+      },
+    };
+
+    setModuleFederationGetPublicPath([consumerPlugin, otherPlugin]);
+
+    expect(consumerPlugin._options.getPublicPath).toBeUndefined();
+    expect(otherPlugin._options.getPublicPath).toBeUndefined();
+  });
+
+  it('normalizes absolute compiler publicPath for remote browser builds', () => {
+    const moduleFederationPlugin = {
+      name: 'RspackModuleFederationPlugin',
+      _options: {
+        exposes: {
+          './docs': './docs/index.mdx',
+        },
+      },
+    };
+    const config = {
+      output: {
+        publicPath: 'http://localhost:4178/',
+      },
+      plugins: [moduleFederationPlugin],
+    };
+
+    setPortableModuleFederationPublicPath(config);
+
+    expect(config.output.publicPath).toBe('/');
+    expect(moduleFederationPlugin._options.getPublicPath).toBe(
+      ZEPHYR_RSPRESS_MODULE_FEDERATION_GET_PUBLIC_PATH
+    );
+  });
+
+  it('preserves relative compiler publicPath values', () => {
+    const moduleFederationPlugin = {
+      name: 'RspackModuleFederationPlugin',
+      _options: {
+        exposes: {
+          './docs': './docs/index.mdx',
+        },
+      },
+    };
+    const config = {
+      output: {
+        publicPath: '/docs/',
+      },
+      plugins: [moduleFederationPlugin],
+    };
+
+    setPortableModuleFederationPublicPath(config);
+
+    expect(config.output.publicPath).toBe('/docs/');
+  });
+
+  it('runs after module federation materializes rspack plugins', () => {
+    const moduleFederationPlugin = {
+      name: 'RspackModuleFederationPlugin',
+      _options: {
+        exposes: {
+          './docs': './docs/index.mdx',
+        },
+      },
+    };
+    const onBeforeCreateCompiler = jest.fn();
+    const plugin = moduleFederationPublicPathPlugin();
+
+    plugin.setup({ onBeforeCreateCompiler });
+
+    expect(onBeforeCreateCompiler).toHaveBeenCalledWith({
+      order: 'post',
+      handler: expect.any(Function),
+    });
+
+    const [{ handler }] = onBeforeCreateCompiler.mock.calls[0];
+    handler({
+      bundlerConfigs: [
+        {
+          output: {
+            publicPath: 'http://localhost:4178/',
+          },
+          plugins: [moduleFederationPlugin],
+        },
+      ],
+    });
+
+    expect(moduleFederationPlugin._options.getPublicPath).toBe(
+      ZEPHYR_RSPRESS_MODULE_FEDERATION_GET_PUBLIC_PATH
+    );
+  });
+});

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -224,6 +224,11 @@ describe('rewriteRspressModuleFederationAssets', () => {
         metaData: {
           publicPath: 'http://localhost:4178/',
           ssrPublicPath: 'http://localhost:4178/server/',
+          ssrRemoteEntry: {
+            name: 'ssrRemote.js',
+            path: '',
+            type: 'module',
+          },
         },
       })
     );
@@ -254,6 +259,15 @@ describe('rewriteRspressModuleFederationAssets', () => {
     await expect(
       readFile(path.join(outDir, 'server/nested/chunk.js'), 'utf8')
     ).resolves.toBe('export default (()=>{__webpack_require__.p="/"})();');
+
+    const browserManifest = JSON.parse(
+      await readFile(path.join(outDir, 'mf-manifest.json'), 'utf8')
+    );
+    expect(browserManifest.metaData.ssrRemoteEntry).toMatchObject({
+      name: 'ssrRemote.js',
+      path: 'server/nested/',
+      type: 'module',
+    });
   });
 
   it('preserves custom SSR output paths from the emitted manifest', async () => {

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -119,7 +119,7 @@ describe('rewriteRspressModuleFederationAssets', () => {
       ssrRemoteEntry: {
         name: 'remoteEntry.js',
         path: 'mf-ssg/',
-        type: 'commonjs-module',
+        type: 'module',
       },
     });
     expect(browserManifest.metaData.ssrPublicPath).toBeUndefined();
@@ -132,7 +132,7 @@ describe('rewriteRspressModuleFederationAssets', () => {
       remoteEntry: {
         name: 'remoteEntry.js',
         path: '',
-        type: 'commonjs-module',
+        type: 'module',
       },
     });
     expect(ssgManifest.metaData.ssrPublicPath).toBeUndefined();
@@ -299,7 +299,7 @@ describe('rewriteRspressModuleFederationAssets', () => {
       ssrRemoteEntry: {
         name: 'remoteEntry.js',
         path: 'server/',
-        type: 'commonjs-module',
+        type: 'module',
       },
     });
 
@@ -311,7 +311,7 @@ describe('rewriteRspressModuleFederationAssets', () => {
       remoteEntry: {
         name: 'remoteEntry.js',
         path: '',
-        type: 'commonjs-module',
+        type: 'module',
       },
     });
   });

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { rewriteRspressModuleFederationAssets } from '../assets/rewriteRspressModuleFederationAssets';
+
+describe('rewriteRspressModuleFederationAssets', () => {
+  let outDir: string;
+
+  beforeEach(async () => {
+    outDir = await mkdtemp(path.join(tmpdir(), 'zephyr-rspress-mf-'));
+  });
+
+  afterEach(async () => {
+    await rm(outDir, { recursive: true, force: true });
+  });
+
+  it('does nothing when the build is not a module federation remote', async () => {
+    const htmlPath = path.join(outDir, 'index.html');
+    const html = '<link rel="stylesheet" href="https://cdn.example.com/static/app.css">';
+    await writeFile(htmlPath, html);
+
+    await rewriteRspressModuleFederationAssets(outDir, ['index.html']);
+
+    await expect(readFile(htmlPath, 'utf8')).resolves.toBe(html);
+  });
+
+  it('rewrites rspress module federation output for Zephyr immutable URLs', async () => {
+    await mkdir(path.join(outDir, 'zh'), { recursive: true });
+    await mkdir(path.join(outDir, 'mf-ssg'), { recursive: true });
+
+    await writeFile(
+      path.join(outDir, 'index.html'),
+      [
+        '<link rel="stylesheet" href="http://localhost:4178/static/css/styles.css">',
+        '<script src="http://localhost:4178/static/js/index.js"></script>',
+      ].join('')
+    );
+    await mkdir(path.join(outDir, 'static/js'), { recursive: true });
+    await writeFile(
+      path.join(outDir, 'remoteEntry.js'),
+      '(()=>{__webpack_require__.p="http://localhost:4178/"})();'
+    );
+    await writeFile(
+      path.join(outDir, 'static/js/index.js'),
+      '(()=>{__webpack_require__.p="http://localhost:4178/"})();'
+    );
+    await writeFile(
+      path.join(outDir, 'zh/vite.html'),
+      '<script src="http://localhost:4178/static/js/zh.js"></script>'
+    );
+    await writeFile(
+      path.join(outDir, 'mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'http://localhost:4178/',
+          ssrPublicPath: 'http://localhost:4178/mf-ssg/',
+          remoteEntry: {
+            name: 'remoteEntry.js',
+            path: '',
+            type: 'module',
+          },
+          ssrRemoteEntry: {
+            name: 'remoteEntry.js',
+            path: '',
+            type: 'module',
+          },
+        },
+      })
+    );
+    await writeFile(
+      path.join(outDir, 'mf-ssg/mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'http://localhost:4178/mf-ssg/',
+          remoteEntry: {
+            name: 'remoteEntry.js',
+            path: '',
+            type: 'module',
+          },
+        },
+      })
+    );
+
+    await rewriteRspressModuleFederationAssets(outDir, [
+      'index.html',
+      'zh/vite.html',
+      'remoteEntry.js',
+      'static/js/index.js',
+      'mf-manifest.json',
+      'mf-ssg/mf-manifest.json',
+    ]);
+
+    await expect(readFile(path.join(outDir, 'index.html'), 'utf8')).resolves.toBe(
+      [
+        '<link rel="stylesheet" href="/static/css/styles.css">',
+        '<script src="/static/js/index.js"></script>',
+      ].join('')
+    );
+    await expect(readFile(path.join(outDir, 'zh/vite.html'), 'utf8')).resolves.toBe(
+      '<script src="/static/js/zh.js"></script>'
+    );
+    await expect(
+      readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')
+    ).resolves.toContain('document.currentScript');
+    await expect(
+      readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')
+    ).resolves.not.toContain('localhost:4178');
+    await expect(readFile(path.join(outDir, 'static/js/index.js'), 'utf8')).resolves.toBe(
+      '(()=>{__webpack_require__.p="/"})();'
+    );
+
+    const browserManifest = JSON.parse(
+      await readFile(path.join(outDir, 'mf-manifest.json'), 'utf8')
+    );
+    expect(browserManifest.metaData).toMatchObject({
+      publicPath: 'auto',
+      ssrRemoteEntry: {
+        name: 'remoteEntry.js',
+        path: 'mf-ssg/',
+        type: 'commonjs-module',
+      },
+    });
+    expect(browserManifest.metaData.ssrPublicPath).toBeUndefined();
+
+    const ssgManifest = JSON.parse(
+      await readFile(path.join(outDir, 'mf-ssg/mf-manifest.json'), 'utf8')
+    );
+    expect(ssgManifest.metaData).toMatchObject({
+      publicPath: 'auto',
+      remoteEntry: {
+        name: 'remoteEntry.js',
+        path: '',
+        type: 'commonjs-module',
+      },
+    });
+    expect(ssgManifest.metaData.ssrPublicPath).toBeUndefined();
+  });
+});

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -170,6 +170,92 @@ describe('rewriteRspressModuleFederationAssets', () => {
     ).resolves.not.toContain('document.currentScript');
   });
 
+  it('uses manifest path and name to find custom browser remote entries', async () => {
+    await mkdir(path.join(outDir, 'assets/mf'), { recursive: true });
+    await writeFile(
+      path.join(outDir, 'assets/mf/customRemote.js'),
+      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();'
+    );
+    await writeFile(
+      path.join(outDir, 'assets/mf/chunk.js'),
+      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();'
+    );
+    await writeFile(
+      path.join(outDir, 'mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'http://localhost:4178/',
+          remoteEntry: {
+            name: 'customRemote.js',
+            path: 'assets/mf/',
+            type: 'global',
+          },
+        },
+      })
+    );
+
+    await rewriteRspressModuleFederationAssets(outDir, [
+      'assets/mf/customRemote.js',
+      'assets/mf/chunk.js',
+      'mf-manifest.json',
+    ]);
+
+    await expect(
+      readFile(path.join(outDir, 'assets/mf/customRemote.js'), 'utf8')
+    ).resolves.toContain('document.currentScript');
+    await expect(readFile(path.join(outDir, 'assets/mf/chunk.js'), 'utf8')).resolves.toBe(
+      '(()=>{__webpack_require__.p="/"})();'
+    );
+  });
+
+  it('uses the SSG manifest path and name to find SSR remote entries', async () => {
+    await mkdir(path.join(outDir, 'server/nested'), { recursive: true });
+    await writeFile(
+      path.join(outDir, 'server/nested/ssrRemote.js'),
+      'export default (()=>{__webpack_require__.p = "http://localhost:4178/server/"})();'
+    );
+    await writeFile(
+      path.join(outDir, 'server/nested/chunk.js'),
+      'export default (()=>{__webpack_require__.p = "http://localhost:4178/server/"})();'
+    );
+    await writeFile(
+      path.join(outDir, 'mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'http://localhost:4178/',
+          ssrPublicPath: 'http://localhost:4178/server/',
+        },
+      })
+    );
+    await writeFile(
+      path.join(outDir, 'server/mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'http://localhost:4178/server/',
+          remoteEntry: {
+            name: 'ssrRemote.js',
+            path: 'nested/',
+            type: 'module',
+          },
+        },
+      })
+    );
+
+    await rewriteRspressModuleFederationAssets(outDir, [
+      'server/nested/ssrRemote.js',
+      'server/nested/chunk.js',
+      'mf-manifest.json',
+      'server/mf-manifest.json',
+    ]);
+
+    await expect(
+      readFile(path.join(outDir, 'server/nested/ssrRemote.js'), 'utf8')
+    ).resolves.toContain('import.meta.url');
+    await expect(
+      readFile(path.join(outDir, 'server/nested/chunk.js'), 'utf8')
+    ).resolves.toBe('export default (()=>{__webpack_require__.p="/"})();');
+  });
+
   it('preserves custom SSR output paths from the emitted manifest', async () => {
     await mkdir(path.join(outDir, 'server'), { recursive: true });
     await writeFile(

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -38,11 +38,11 @@ describe('rewriteRspressModuleFederationAssets', () => {
     await mkdir(path.join(outDir, 'static/js'), { recursive: true });
     await writeFile(
       path.join(outDir, 'remoteEntry.js'),
-      '(()=>{__webpack_require__.p="http://localhost:4178/"})();'
+      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();'
     );
     await writeFile(
       path.join(outDir, 'static/js/index.js'),
-      '(()=>{__webpack_require__.p="http://localhost:4178/"})();'
+      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();'
     );
     await writeFile(
       path.join(outDir, 'zh/vite.html'),
@@ -134,5 +134,65 @@ describe('rewriteRspressModuleFederationAssets', () => {
       },
     });
     expect(ssgManifest.metaData.ssrPublicPath).toBeUndefined();
+  });
+
+  it('preserves custom SSR output paths from the emitted manifest', async () => {
+    await mkdir(path.join(outDir, 'server'), { recursive: true });
+    await writeFile(
+      path.join(outDir, 'mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'http://localhost:4178/',
+          ssrPublicPath: 'http://localhost:4178/server/',
+          ssrRemoteEntry: {
+            name: 'remoteEntry.js',
+            path: '',
+            type: 'module',
+          },
+        },
+      })
+    );
+    await writeFile(
+      path.join(outDir, 'server/mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'http://localhost:4178/server/',
+          remoteEntry: {
+            name: 'remoteEntry.js',
+            path: '',
+            type: 'module',
+          },
+        },
+      })
+    );
+
+    await rewriteRspressModuleFederationAssets(outDir, [
+      'mf-manifest.json',
+      'server/mf-manifest.json',
+    ]);
+
+    const browserManifest = JSON.parse(
+      await readFile(path.join(outDir, 'mf-manifest.json'), 'utf8')
+    );
+    expect(browserManifest.metaData).toMatchObject({
+      publicPath: 'auto',
+      ssrRemoteEntry: {
+        name: 'remoteEntry.js',
+        path: 'server/',
+        type: 'commonjs-module',
+      },
+    });
+
+    const ssgManifest = JSON.parse(
+      await readFile(path.join(outDir, 'server/mf-manifest.json'), 'utf8')
+    );
+    expect(ssgManifest.metaData).toMatchObject({
+      publicPath: 'auto',
+      remoteEntry: {
+        name: 'remoteEntry.js',
+        path: '',
+        type: 'commonjs-module',
+      },
+    });
   });
 });

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -33,6 +33,7 @@ describe('rewriteRspressModuleFederationAssets', () => {
       [
         '<link rel="stylesheet" href="http://localhost:4178/static/css/styles.css">',
         '<script src="http://localhost:4178/static/js/index.js"></script>',
+        '<pre>http://localhost:4178/static/js/example.js</pre>',
       ].join('')
     );
     await mkdir(path.join(outDir, 'static/js'), { recursive: true });
@@ -57,7 +58,7 @@ describe('rewriteRspressModuleFederationAssets', () => {
           remoteEntry: {
             name: 'remoteEntry.js',
             path: '',
-            type: 'module',
+            type: 'global',
           },
           ssrRemoteEntry: {
             name: 'remoteEntry.js',
@@ -94,6 +95,7 @@ describe('rewriteRspressModuleFederationAssets', () => {
       [
         '<link rel="stylesheet" href="/static/css/styles.css">',
         '<script src="/static/js/index.js"></script>',
+        '<pre>http://localhost:4178/static/js/example.js</pre>',
       ].join('')
     );
     await expect(readFile(path.join(outDir, 'zh/vite.html'), 'utf8')).resolves.toBe(
@@ -134,6 +136,38 @@ describe('rewriteRspressModuleFederationAssets', () => {
       },
     });
     expect(ssgManifest.metaData.ssrPublicPath).toBeUndefined();
+  });
+
+  it('uses import.meta.url for module remote entry public path rewrites', async () => {
+    await writeFile(
+      path.join(outDir, 'remoteEntry.js'),
+      'export default (()=>{__webpack_require__.p = "http://localhost:4178/"})();'
+    );
+    await writeFile(
+      path.join(outDir, 'mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'http://localhost:4178/',
+          remoteEntry: {
+            name: 'remoteEntry.js',
+            path: '',
+            type: 'module',
+          },
+        },
+      })
+    );
+
+    await rewriteRspressModuleFederationAssets(outDir, [
+      'remoteEntry.js',
+      'mf-manifest.json',
+    ]);
+
+    await expect(
+      readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')
+    ).resolves.toContain('import.meta.url');
+    await expect(
+      readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')
+    ).resolves.not.toContain('document.currentScript');
   });
 
   it('preserves custom SSR output paths from the emitted manifest', async () => {

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -183,6 +183,7 @@ describe('rewriteRspressModuleFederationAssets', () => {
       [
         '<link href="http://localhost:4178/static/css/styles.css" rel="stylesheet">',
         '<script defer src="http://localhost:4178/static/js/index.js"></script>',
+        '<script defer src="https://cdn.vendor.com/static/widget.js"></script>',
         '<a href="http://localhost:4178/static/reference">Reference</a>',
       ].join('')
     );
@@ -198,12 +199,15 @@ describe('rewriteRspressModuleFederationAssets', () => {
     await rewriteRspressModuleFederationAssets(outDir, [
       'index.html',
       'mf-manifest.json',
+      'static/css/styles.css',
+      'static/js/index.js',
     ]);
 
     await expect(readFile(path.join(outDir, 'index.html'), 'utf8')).resolves.toBe(
       [
         '<link href="/static/css/styles.css" rel="stylesheet">',
         '<script defer src="/static/js/index.js"></script>',
+        '<script defer src="https://cdn.vendor.com/static/widget.js"></script>',
         '<a href="http://localhost:4178/static/reference">Reference</a>',
       ].join('')
     );

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -37,14 +37,11 @@ describe('rewriteRspressModuleFederationAssets', () => {
       ].join('')
     );
     await mkdir(path.join(outDir, 'static/js'), { recursive: true });
-    await writeFile(
-      path.join(outDir, 'remoteEntry.js'),
-      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();'
-    );
-    await writeFile(
-      path.join(outDir, 'static/js/index.js'),
-      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();'
-    );
+    const remoteEntrySource =
+      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();';
+    const chunkSource = '(()=>{__webpack_require__.p = "http://localhost:4178/"})();';
+    await writeFile(path.join(outDir, 'remoteEntry.js'), remoteEntrySource);
+    await writeFile(path.join(outDir, 'static/js/index.js'), chunkSource);
     await writeFile(
       path.join(outDir, 'zh/vite.html'),
       '<script src="http://localhost:4178/static/js/zh.js"></script>'
@@ -101,14 +98,11 @@ describe('rewriteRspressModuleFederationAssets', () => {
     await expect(readFile(path.join(outDir, 'zh/vite.html'), 'utf8')).resolves.toBe(
       '<script src="/static/js/zh.js"></script>'
     );
-    await expect(
-      readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')
-    ).resolves.toContain('document.currentScript');
-    await expect(
-      readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')
-    ).resolves.not.toContain('localhost:4178');
+    await expect(readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')).resolves.toBe(
+      remoteEntrySource
+    );
     await expect(readFile(path.join(outDir, 'static/js/index.js'), 'utf8')).resolves.toBe(
-      '(()=>{__webpack_require__.p="/"})();'
+      chunkSource
     );
 
     const browserManifest = JSON.parse(
@@ -138,86 +132,8 @@ describe('rewriteRspressModuleFederationAssets', () => {
     expect(ssgManifest.metaData.ssrPublicPath).toBeUndefined();
   });
 
-  it('uses import.meta.url for module remote entry public path rewrites', async () => {
-    await writeFile(
-      path.join(outDir, 'remoteEntry.js'),
-      'export default (()=>{__webpack_require__.p = "http://localhost:4178/"})();'
-    );
-    await writeFile(
-      path.join(outDir, 'mf-manifest.json'),
-      JSON.stringify({
-        metaData: {
-          publicPath: 'http://localhost:4178/',
-          remoteEntry: {
-            name: 'remoteEntry.js',
-            path: '',
-            type: 'module',
-          },
-        },
-      })
-    );
-
-    await rewriteRspressModuleFederationAssets(outDir, [
-      'remoteEntry.js',
-      'mf-manifest.json',
-    ]);
-
-    await expect(
-      readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')
-    ).resolves.toContain('import.meta.url');
-    await expect(
-      readFile(path.join(outDir, 'remoteEntry.js'), 'utf8')
-    ).resolves.not.toContain('document.currentScript');
-  });
-
-  it('uses manifest path and name to find custom browser remote entries', async () => {
-    await mkdir(path.join(outDir, 'assets/mf'), { recursive: true });
-    await writeFile(
-      path.join(outDir, 'assets/mf/customRemote.js'),
-      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();'
-    );
-    await writeFile(
-      path.join(outDir, 'assets/mf/chunk.js'),
-      '(()=>{__webpack_require__.p = "http://localhost:4178/"})();'
-    );
-    await writeFile(
-      path.join(outDir, 'mf-manifest.json'),
-      JSON.stringify({
-        metaData: {
-          publicPath: 'http://localhost:4178/',
-          remoteEntry: {
-            name: 'customRemote.js',
-            path: 'assets/mf/',
-            type: 'global',
-          },
-        },
-      })
-    );
-
-    await rewriteRspressModuleFederationAssets(outDir, [
-      'assets/mf/customRemote.js',
-      'assets/mf/chunk.js',
-      'mf-manifest.json',
-    ]);
-
-    await expect(
-      readFile(path.join(outDir, 'assets/mf/customRemote.js'), 'utf8')
-    ).resolves.toContain('document.currentScript');
-    await expect(readFile(path.join(outDir, 'assets/mf/chunk.js'), 'utf8')).resolves.toBe(
-      '(()=>{__webpack_require__.p="/"})();'
-    );
-  });
-
   it('uses the SSG manifest path and name to find SSR remote entries', async () => {
     await mkdir(path.join(outDir, 'server/nested'), { recursive: true });
-    await writeFile(
-      path.join(outDir, 'server/nested/ssrRemote.js'),
-      'export default (()=>{__webpack_require__.p = "http://localhost:4178/server/"})();'
-    );
-    await writeFile(
-      path.join(outDir, 'server/nested/chunk.js'),
-      'export default (()=>{__webpack_require__.p = "http://localhost:4178/server/"})();'
-    );
     await writeFile(
       path.join(outDir, 'mf-manifest.json'),
       JSON.stringify({
@@ -247,18 +163,9 @@ describe('rewriteRspressModuleFederationAssets', () => {
     );
 
     await rewriteRspressModuleFederationAssets(outDir, [
-      'server/nested/ssrRemote.js',
-      'server/nested/chunk.js',
       'mf-manifest.json',
       'server/mf-manifest.json',
     ]);
-
-    await expect(
-      readFile(path.join(outDir, 'server/nested/ssrRemote.js'), 'utf8')
-    ).resolves.toContain('import.meta.url');
-    await expect(
-      readFile(path.join(outDir, 'server/nested/chunk.js'), 'utf8')
-    ).resolves.toBe('export default (()=>{__webpack_require__.p="/"})();');
 
     const browserManifest = JSON.parse(
       await readFile(path.join(outDir, 'mf-manifest.json'), 'utf8')
@@ -268,6 +175,38 @@ describe('rewriteRspressModuleFederationAssets', () => {
       path: 'server/nested/',
       type: 'module',
     });
+  });
+
+  it('rewrites absolute Rspress HTML asset URLs when manifest uses getPublicPath', async () => {
+    await writeFile(
+      path.join(outDir, 'index.html'),
+      [
+        '<link href="http://localhost:4178/static/css/styles.css" rel="stylesheet">',
+        '<script defer src="http://localhost:4178/static/js/index.js"></script>',
+        '<a href="http://localhost:4178/static/reference">Reference</a>',
+      ].join('')
+    );
+    await writeFile(
+      path.join(outDir, 'mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          getPublicPath: 'return "http://localhost:4178/"',
+        },
+      })
+    );
+
+    await rewriteRspressModuleFederationAssets(outDir, [
+      'index.html',
+      'mf-manifest.json',
+    ]);
+
+    await expect(readFile(path.join(outDir, 'index.html'), 'utf8')).resolves.toBe(
+      [
+        '<link href="/static/css/styles.css" rel="stylesheet">',
+        '<script defer src="/static/js/index.js"></script>',
+        '<a href="http://localhost:4178/static/reference">Reference</a>',
+      ].join('')
+    );
   });
 
   it('preserves custom SSR output paths from the emitted manifest', async () => {

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/rewriteRspressModuleFederationAssets.spec.ts
@@ -315,4 +315,49 @@ describe('rewriteRspressModuleFederationAssets', () => {
       },
     });
   });
+
+  it('prefers discovered SSG manifest directories over URL public path prefixes', async () => {
+    await mkdir(path.join(outDir, 'mf-ssg'), { recursive: true });
+    await writeFile(
+      path.join(outDir, 'mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'https://cdn.example.com/docs/',
+          ssrPublicPath: 'https://cdn.example.com/docs/mf-ssg/',
+          ssrRemoteEntry: {
+            name: 'remoteEntry.js',
+            path: '',
+            type: 'module',
+          },
+        },
+      })
+    );
+    await writeFile(
+      path.join(outDir, 'mf-ssg/mf-manifest.json'),
+      JSON.stringify({
+        metaData: {
+          publicPath: 'https://cdn.example.com/docs/mf-ssg/',
+          remoteEntry: {
+            name: 'remoteEntry.js',
+            path: '',
+            type: 'module',
+          },
+        },
+      })
+    );
+
+    await rewriteRspressModuleFederationAssets(outDir, [
+      'mf-manifest.json',
+      'mf-ssg/mf-manifest.json',
+    ]);
+
+    const browserManifest = JSON.parse(
+      await readFile(path.join(outDir, 'mf-manifest.json'), 'utf8')
+    );
+    expect(browserManifest.metaData.ssrRemoteEntry).toMatchObject({
+      name: 'remoteEntry.js',
+      path: 'mf-ssg/',
+      type: 'module',
+    });
+  });
 });

--- a/libs/zephyr-rspress-plugin/src/internal/assets/moduleFederationPublicPathPlugin.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/moduleFederationPublicPathPlugin.ts
@@ -1,0 +1,146 @@
+type RsbuildOnBeforeCreateCompilerArgs = {
+  bundlerConfigs?: RspackConfig[];
+};
+
+type RspackConfig = {
+  name?: string;
+  output?: {
+    publicPath?: unknown;
+  };
+  plugins?: unknown[];
+};
+
+type RsbuildPluginApi = {
+  onBeforeCreateCompiler: (options: {
+    order: 'post';
+    handler: (args: RsbuildOnBeforeCreateCompilerArgs) => void;
+  }) => void;
+};
+
+type RsbuildPlugin = {
+  name: string;
+  setup: (api: RsbuildPluginApi) => void;
+};
+
+type ModuleFederationOptions = {
+  exposes?: unknown;
+  getPublicPath?: string;
+};
+
+type RspackModuleFederationPlugin = {
+  name?: string;
+  _options?: ModuleFederationOptions;
+};
+
+const RSPACK_MODULE_FEDERATION_PLUGIN_NAME = 'RspackModuleFederationPlugin';
+
+export const ZEPHYR_RSPRESS_MODULE_FEDERATION_GET_PUBLIC_PATH = [
+  'var scriptUrl;',
+  'if (typeof document !== "undefined") {',
+  '  var currentScript = document.currentScript;',
+  '  if (currentScript && currentScript.tagName === "SCRIPT") {',
+  '    scriptUrl = currentScript.src;',
+  '  }',
+  '  if (!scriptUrl) {',
+  '    var scripts = document.getElementsByTagName("script");',
+  '    if (scripts.length) {',
+  '      scriptUrl = scripts[scripts.length - 1].src;',
+  '    }',
+  '  }',
+  '}',
+  'if (!scriptUrl && typeof location !== "undefined") {',
+  '  scriptUrl = location.href;',
+  '}',
+  'if (!scriptUrl) {',
+  '  return "/";',
+  '}',
+  'return scriptUrl',
+  '  .replace(/#.*$/, "")',
+  '  .replace(/\\?.*$/, "")',
+  '  .replace(/\\/[^\\/]*$/, "/");',
+].join('\n');
+
+export function moduleFederationPublicPathPlugin(): RsbuildPlugin {
+  return {
+    name: 'zephyr-rspress-module-federation-public-path',
+    setup(api) {
+      api.onBeforeCreateCompiler({
+        order: 'post',
+        handler({ bundlerConfigs }) {
+          for (const config of bundlerConfigs ?? []) {
+            setPortableModuleFederationPublicPath(config);
+          }
+        },
+      });
+    },
+  };
+}
+
+export function setPortableModuleFederationPublicPath(config: RspackConfig): void {
+  const hasRemote = setModuleFederationGetPublicPath(config.plugins);
+
+  if (hasRemote && isHttpPublicPath(config.output?.publicPath)) {
+    config.output = {
+      ...config.output,
+      publicPath: '/',
+    };
+  }
+}
+
+export function setModuleFederationGetPublicPath(plugins: unknown[] = []): boolean {
+  let hasRemote = false;
+
+  for (const plugin of plugins) {
+    const options = getModuleFederationOptions(plugin);
+
+    if (!options || !hasExposes(options.exposes)) {
+      continue;
+    }
+
+    hasRemote = true;
+
+    if (!options.getPublicPath) {
+      options.getPublicPath = ZEPHYR_RSPRESS_MODULE_FEDERATION_GET_PUBLIC_PATH;
+    }
+  }
+
+  return hasRemote;
+}
+
+function getModuleFederationOptions(plugin: unknown): ModuleFederationOptions | null {
+  if (!isRecord(plugin)) {
+    return null;
+  }
+
+  const candidate = plugin as RspackModuleFederationPlugin;
+
+  if (candidate.name !== RSPACK_MODULE_FEDERATION_PLUGIN_NAME) {
+    return null;
+  }
+
+  return isRecord(candidate._options) ? candidate._options : null;
+}
+
+function hasExposes(exposes: unknown): boolean {
+  if (!exposes) {
+    return false;
+  }
+
+  if (Array.isArray(exposes)) {
+    return exposes.length > 0;
+  }
+
+  if (isRecord(exposes)) {
+    return Object.keys(exposes).length > 0;
+  }
+
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isHttpPublicPath(value: unknown): value is string {
+  return typeof value === 'string' && /^https?:\/\//.test(value);
+}

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -1,0 +1,212 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { ZeErrors, ZephyrError } from 'zephyr-agent';
+
+type ManifestEntry = {
+  name?: string;
+  path?: string;
+  type?: string;
+};
+
+type ModuleFederationManifest = {
+  metaData?: {
+    publicPath?: string;
+    ssrPublicPath?: string;
+    remoteEntry?: ManifestEntry;
+    ssrRemoteEntry?: ManifestEntry;
+  };
+};
+
+const BROWSER_MANIFEST = 'mf-manifest.json';
+const SSG_MANIFEST = 'mf-ssg/mf-manifest.json';
+const AUTO_PUBLIC_PATH_RUNTIME =
+  '__webpack_require__.p=(()=>{var e;if(typeof document!="undefined"){var t=document.currentScript;if(t&&t.tagName==="SCRIPT")e=t.src;if(!e){var r=document.getElementsByTagName("script");if(r.length)e=r[r.length-1].src}}if(!e&&typeof location!="undefined")e=location.href;if(!e)return "/";return e.replace(/#.*$/,"").replace(/\\?.*$/,"").replace(/\\/[^\\/]*$/,"/")})()';
+
+export async function rewriteRspressModuleFederationAssets(
+  outDir: string,
+  files: string[]
+): Promise<void> {
+  const normalizedFiles = new Set(files.map(toPortablePath));
+
+  if (!normalizedFiles.has(BROWSER_MANIFEST)) {
+    return;
+  }
+
+  const publicPaths = await collectManifestPublicPaths(outDir, normalizedFiles);
+  await rewriteHtmlAssetPrefixes(outDir, files, publicPaths);
+  await rewriteJsPublicPaths(outDir, files, publicPaths);
+  await rewriteManifest(outDir, BROWSER_MANIFEST, normalizeBrowserManifest);
+
+  if (normalizedFiles.has(SSG_MANIFEST)) {
+    await rewriteManifest(outDir, SSG_MANIFEST, normalizeSsgManifest);
+  }
+}
+
+async function collectManifestPublicPaths(
+  outDir: string,
+  files: Set<string>
+): Promise<string[]> {
+  const publicPaths = new Set<string>();
+
+  for (const file of [BROWSER_MANIFEST, SSG_MANIFEST]) {
+    if (!files.has(file)) {
+      continue;
+    }
+
+    const manifest = await readManifest(outDir, file);
+
+    for (const value of [
+      manifest.metaData?.publicPath,
+      manifest.metaData?.ssrPublicPath,
+    ]) {
+      const prefix = normalizeHttpPrefix(value);
+
+      if (prefix) {
+        publicPaths.add(prefix);
+      }
+    }
+  }
+
+  return [...publicPaths].sort((a, b) => b.length - a.length);
+}
+
+async function rewriteHtmlAssetPrefixes(
+  outDir: string,
+  files: string[],
+  publicPaths: string[]
+): Promise<void> {
+  if (publicPaths.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    files
+      .filter((file) => toPortablePath(file).endsWith('.html'))
+      .map(async (file) => {
+        const filePath = resolveOutputPath(outDir, file);
+        let source = await readFile(filePath, 'utf8');
+        const original = source;
+
+        for (const publicPath of publicPaths) {
+          source = source.split(publicPath).join('/');
+        }
+
+        if (source !== original) {
+          await writeFile(filePath, source);
+        }
+      })
+  );
+}
+
+async function rewriteJsPublicPaths(
+  outDir: string,
+  files: string[],
+  publicPaths: string[]
+): Promise<void> {
+  if (publicPaths.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    files
+      .filter((file) => toPortablePath(file).endsWith('.js'))
+      .map(async (file) => {
+        const normalizedFile = toPortablePath(file);
+        const filePath = resolveOutputPath(outDir, file);
+        let source = await readFile(filePath, 'utf8');
+        const original = source;
+        const replacement =
+          normalizedFile === 'remoteEntry.js'
+            ? AUTO_PUBLIC_PATH_RUNTIME
+            : '__webpack_require__.p="/"';
+
+        for (const publicPath of publicPaths) {
+          source = source
+            .split(`__webpack_require__.p=${JSON.stringify(publicPath)}`)
+            .join(replacement);
+        }
+
+        if (source !== original) {
+          await writeFile(filePath, source);
+        }
+      })
+  );
+}
+
+async function rewriteManifest(
+  outDir: string,
+  file: string,
+  normalize: (manifest: ModuleFederationManifest) => void
+): Promise<void> {
+  const manifest = await readManifest(outDir, file);
+  normalize(manifest);
+  await writeFile(
+    resolveOutputPath(outDir, file),
+    `${JSON.stringify(manifest, null, 2)}\n`
+  );
+}
+
+async function readManifest(
+  outDir: string,
+  file: string
+): Promise<ModuleFederationManifest> {
+  return JSON.parse(await readFile(resolveOutputPath(outDir, file), 'utf8'));
+}
+
+function normalizeBrowserManifest(manifest: ModuleFederationManifest): void {
+  if (!manifest.metaData) {
+    return;
+  }
+
+  manifest.metaData.publicPath = 'auto';
+  delete manifest.metaData.ssrPublicPath;
+
+  if (manifest.metaData.ssrRemoteEntry) {
+    manifest.metaData.ssrRemoteEntry = {
+      ...manifest.metaData.ssrRemoteEntry,
+      path: 'mf-ssg/',
+      type: 'commonjs-module',
+    };
+  }
+}
+
+function normalizeSsgManifest(manifest: ModuleFederationManifest): void {
+  if (!manifest.metaData) {
+    return;
+  }
+
+  manifest.metaData.publicPath = 'auto';
+  delete manifest.metaData.ssrPublicPath;
+
+  if (manifest.metaData.remoteEntry) {
+    manifest.metaData.remoteEntry = {
+      ...manifest.metaData.remoteEntry,
+      type: 'commonjs-module',
+    };
+  }
+}
+
+function normalizeHttpPrefix(value: string | undefined): string | null {
+  if (!value || !/^https?:\/\//.test(value)) {
+    return null;
+  }
+
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function resolveOutputPath(outDir: string, file: string): string {
+  const root = path.resolve(outDir);
+  const resolved = path.resolve(root, file);
+
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    throw new ZephyrError(ZeErrors.ERR_UNKNOWN, {
+      message: `Invalid output file path: ${file}`,
+    });
+  }
+
+  return resolved;
+}
+
+function toPortablePath(file: string): string {
+  return file.split(path.sep).join('/');
+}

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -85,6 +85,8 @@ async function rewriteHtmlAssetPrefixes(
   files: string[],
   publicPaths: string[]
 ): Promise<void> {
+  const emittedFiles = new Set(files.map(toPortablePath));
+
   await Promise.all(
     files
       .filter((file) => toPortablePath(file).endsWith('.html'))
@@ -96,7 +98,7 @@ async function rewriteHtmlAssetPrefixes(
         for (const publicPath of publicPaths) {
           source = rewriteHtmlAssetPrefix(source, publicPath);
         }
-        source = rewriteAbsoluteRspressAssetUrls(source);
+        source = rewriteAbsoluteRspressAssetUrls(source, emittedFiles);
 
         if (source !== original) {
           await writeFile(filePath, source);
@@ -181,8 +183,18 @@ function rewriteHtmlAssetPrefix(source: string, publicPath: string): string {
   return source.replace(createHtmlAssetUrl(publicPath), '$1/');
 }
 
-function rewriteAbsoluteRspressAssetUrls(source: string): string {
-  return source.replace(createAbsoluteRspressAssetUrl(), '$1/');
+function rewriteAbsoluteRspressAssetUrls(
+  source: string,
+  emittedFiles: Set<string>
+): string {
+  return source.replace(
+    createAbsoluteRspressAssetUrl(),
+    (match: string, prefix: string, assetPath: string) => {
+      const emittedFile = toPortablePath(assetPath).replace(/[?#].*$/, '');
+
+      return emittedFiles.has(emittedFile) ? `${prefix}/${assetPath}` : match;
+    }
+  );
 }
 
 function createHtmlAssetUrl(publicPath: string): RegExp {
@@ -190,7 +202,7 @@ function createHtmlAssetUrl(publicPath: string): RegExp {
 }
 
 function createAbsoluteRspressAssetUrl(): RegExp {
-  return /(<(?:link|script)\b[^>]*\b(?:href|src)\s*=\s*["'])https?:\/\/[^"']+\/(?=static\/)/g;
+  return /(<(?:link|script)\b[^>]*\b(?:href|src)\s*=\s*["'])https?:\/\/[^"']+\/(static\/[^"']+)/g;
 }
 
 function findSsgManifestFile(

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -195,7 +195,6 @@ function normalizeBrowserManifest(
     manifest.metaData.ssrRemoteEntry = {
       ...manifest.metaData.ssrRemoteEntry,
       path: ssrRemoteEntryPath,
-      type: 'commonjs-module',
     };
   }
 
@@ -209,13 +208,6 @@ function normalizeSsgManifest(manifest: ModuleFederationManifest): void {
 
   manifest.metaData.publicPath = 'auto';
   delete manifest.metaData.ssrPublicPath;
-
-  if (manifest.metaData.remoteEntry) {
-    manifest.metaData.remoteEntry = {
-      ...manifest.metaData.remoteEntry,
-      type: 'commonjs-module',
-    };
-  }
 }
 
 function normalizeHttpPrefix(value: string | undefined): string | null {

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -18,6 +18,7 @@ type ModuleFederationManifest = {
 };
 
 const BROWSER_MANIFEST = 'mf-manifest.json';
+const CHUNK_PUBLIC_PATH_RUNTIME = '__webpack_require__.p="/"';
 const GLOBAL_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME =
   '__webpack_require__.p=(()=>{var e;if(typeof document!="undefined"){var t=document.currentScript;if(t&&t.tagName==="SCRIPT")e=t.src;if(!e){var r=document.getElementsByTagName("script");if(r.length)e=r[r.length-1].src}}if(!e&&typeof location!="undefined")e=location.href;if(!e)return "/";return e.replace(/#.*$/,"").replace(/\\?.*$/,"").replace(/\\/[^\\/]*$/,"/")})()';
 const MODULE_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME =
@@ -35,6 +36,7 @@ export async function rewriteRspressModuleFederationAssets(
 
   const browserManifest = await readManifest(outDir, BROWSER_MANIFEST);
   const ssgManifest = findSsgManifestFile(browserManifest, normalizedFiles);
+  const ssgManifestData = ssgManifest ? await readManifest(outDir, ssgManifest) : null;
   const publicPaths = await collectManifestPublicPaths(
     outDir,
     normalizedFiles,
@@ -45,7 +47,7 @@ export async function rewriteRspressModuleFederationAssets(
     outDir,
     files,
     publicPaths,
-    getRemoteEntryPublicPathRuntime(browserManifest)
+    getRemoteEntryPublicPathRuntimes(browserManifest, ssgManifest, ssgManifestData)
   );
   await writeManifest(
     outDir,
@@ -121,7 +123,7 @@ async function rewriteJsPublicPaths(
   outDir: string,
   files: string[],
   publicPaths: string[],
-  remoteEntryPublicPathRuntime: string
+  remoteEntryPublicPathRuntimes: Map<string, string>
 ): Promise<void> {
   if (publicPaths.length === 0) {
     return;
@@ -136,9 +138,7 @@ async function rewriteJsPublicPaths(
         let source = await readFile(filePath, 'utf8');
         const original = source;
         const replacement =
-          normalizedFile === 'remoteEntry.js'
-            ? remoteEntryPublicPathRuntime
-            : '__webpack_require__.p="/"';
+          remoteEntryPublicPathRuntimes.get(normalizedFile) ?? CHUNK_PUBLIC_PATH_RUNTIME;
 
         for (const publicPath of publicPaths) {
           source = source.replace(createPublicPathAssignment(publicPath), replacement);
@@ -226,10 +226,54 @@ function normalizeHttpPrefix(value: string | undefined): string | null {
   return value.endsWith('/') ? value : `${value}/`;
 }
 
-function getRemoteEntryPublicPathRuntime(manifest: ModuleFederationManifest): string {
-  return manifest.metaData?.remoteEntry?.type === 'module'
+function getRemoteEntryPublicPathRuntimes(
+  browserManifest: ModuleFederationManifest,
+  ssgManifestFile: string | null,
+  ssgManifest: ModuleFederationManifest | null
+): Map<string, string> {
+  const runtimes = new Map<string, string>();
+  const browserRemoteEntry = remoteEntryFile(browserManifest.metaData?.remoteEntry, null);
+
+  if (browserRemoteEntry) {
+    runtimes.set(
+      browserRemoteEntry,
+      getRemoteEntryPublicPathRuntime(browserManifest.metaData?.remoteEntry)
+    );
+  }
+
+  const ssgRemoteEntry = ssgManifest
+    ? remoteEntryFile(ssgManifest.metaData?.remoteEntry, manifestDir(ssgManifestFile))
+    : remoteEntryFile(browserManifest.metaData?.ssrRemoteEntry, null);
+
+  if (ssgRemoteEntry) {
+    runtimes.set(
+      ssgRemoteEntry,
+      getRemoteEntryPublicPathRuntime(
+        ssgManifest?.metaData?.remoteEntry ?? browserManifest.metaData?.ssrRemoteEntry
+      )
+    );
+  }
+
+  return runtimes;
+}
+
+function getRemoteEntryPublicPathRuntime(entry: ManifestEntry | undefined): string {
+  return entry?.type === 'module'
     ? MODULE_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME
     : GLOBAL_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME;
+}
+
+function remoteEntryFile(
+  entry: ManifestEntry | undefined,
+  baseDir: string | null
+): string | null {
+  if (!entry?.name) {
+    return null;
+  }
+
+  return toPortablePath(
+    `${baseDir ?? ''}${normalizeManifestDir(entry.path) ?? ''}${entry.name}`
+  ).replace(/^\/+/, '');
 }
 
 function rewriteHtmlAssetPrefix(source: string, publicPath: string): string {

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -52,7 +52,7 @@ export async function rewriteRspressModuleFederationAssets(
   await writeManifest(
     outDir,
     BROWSER_MANIFEST,
-    normalizeBrowserManifest(browserManifest, ssgManifest)
+    normalizeBrowserManifest(browserManifest, ssgManifest, ssgManifestData)
   );
 
   if (ssgManifest) {
@@ -181,13 +181,18 @@ async function readManifest(
 
 function normalizeBrowserManifest(
   manifest: ModuleFederationManifest,
-  ssgManifest: string | null
+  ssgManifest: string | null,
+  ssgManifestData: ModuleFederationManifest | null
 ): ModuleFederationManifest {
   if (!manifest.metaData) {
     return manifest;
   }
 
-  const ssrRemoteEntryPath = getSsrRemoteEntryPath(manifest, ssgManifest);
+  const ssrRemoteEntryPath = getSsrRemoteEntryPath(
+    manifest,
+    ssgManifest,
+    ssgManifestData
+  );
   manifest.metaData.publicPath = 'auto';
   delete manifest.metaData.ssrPublicPath;
 
@@ -293,10 +298,14 @@ function findSsgManifestFile(
 
 function getSsrRemoteEntryPath(
   manifest: ModuleFederationManifest,
-  ssgManifest: string | null
+  ssgManifest: string | null,
+  ssgManifestData: ModuleFederationManifest | null
 ): string {
+  const ssgManifestDir = manifestDir(ssgManifest);
+
   return (
-    manifestDir(ssgManifest) ??
+    remoteEntryDir(ssgManifestData?.metaData?.remoteEntry, ssgManifestDir) ??
+    ssgManifestDir ??
     normalizeManifestDir(manifest.metaData?.ssrRemoteEntry?.path) ??
     pathFromPublicPath(manifest.metaData?.ssrPublicPath) ??
     'mf-ssg/'
@@ -311,6 +320,19 @@ function manifestFileFromPublicPath(value: string | undefined): string | null {
 function manifestFileFromEntryPath(value: string | undefined): string | null {
   const dir = normalizeManifestDir(value);
   return dir ? `${dir}mf-manifest.json` : null;
+}
+
+function remoteEntryDir(
+  entry: ManifestEntry | undefined,
+  baseDir: string | null
+): string | null {
+  if (!entry) {
+    return null;
+  }
+
+  return normalizeManifestDir(
+    `${baseDir ?? ''}${normalizeManifestDir(entry.path) ?? ''}`
+  );
 }
 
 function pathFromPublicPath(value: string | undefined): string | null {

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -296,9 +296,9 @@ function getSsrRemoteEntryPath(
   ssgManifest: string | null
 ): string {
   return (
+    manifestDir(ssgManifest) ??
     normalizeManifestDir(manifest.metaData?.ssrRemoteEntry?.path) ??
     pathFromPublicPath(manifest.metaData?.ssrPublicPath) ??
-    manifestDir(ssgManifest) ??
     'mf-ssg/'
   );
 }

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -18,11 +18,6 @@ type ModuleFederationManifest = {
 };
 
 const BROWSER_MANIFEST = 'mf-manifest.json';
-const CHUNK_PUBLIC_PATH_RUNTIME = '__webpack_require__.p="/"';
-const GLOBAL_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME =
-  '__webpack_require__.p=(()=>{var e;if(typeof document!="undefined"){var t=document.currentScript;if(t&&t.tagName==="SCRIPT")e=t.src;if(!e){var r=document.getElementsByTagName("script");if(r.length)e=r[r.length-1].src}}if(!e&&typeof location!="undefined")e=location.href;if(!e)return "/";return e.replace(/#.*$/,"").replace(/\\?.*$/,"").replace(/\\/[^\\/]*$/,"/")})()';
-const MODULE_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME =
-  '__webpack_require__.p=new URL("./",import.meta.url).href';
 
 export async function rewriteRspressModuleFederationAssets(
   outDir: string,
@@ -43,12 +38,6 @@ export async function rewriteRspressModuleFederationAssets(
     ssgManifest
   );
   await rewriteHtmlAssetPrefixes(outDir, files, publicPaths);
-  await rewriteJsPublicPaths(
-    outDir,
-    files,
-    publicPaths,
-    getRemoteEntryPublicPathRuntimes(browserManifest, ssgManifest, ssgManifestData)
-  );
   await writeManifest(
     outDir,
     BROWSER_MANIFEST,
@@ -96,10 +85,6 @@ async function rewriteHtmlAssetPrefixes(
   files: string[],
   publicPaths: string[]
 ): Promise<void> {
-  if (publicPaths.length === 0) {
-    return;
-  }
-
   await Promise.all(
     files
       .filter((file) => toPortablePath(file).endsWith('.html'))
@@ -111,38 +96,7 @@ async function rewriteHtmlAssetPrefixes(
         for (const publicPath of publicPaths) {
           source = rewriteHtmlAssetPrefix(source, publicPath);
         }
-
-        if (source !== original) {
-          await writeFile(filePath, source);
-        }
-      })
-  );
-}
-
-async function rewriteJsPublicPaths(
-  outDir: string,
-  files: string[],
-  publicPaths: string[],
-  remoteEntryPublicPathRuntimes: Map<string, string>
-): Promise<void> {
-  if (publicPaths.length === 0) {
-    return;
-  }
-
-  await Promise.all(
-    files
-      .filter((file) => toPortablePath(file).endsWith('.js'))
-      .map(async (file) => {
-        const normalizedFile = toPortablePath(file);
-        const filePath = resolveOutputPath(outDir, file);
-        let source = await readFile(filePath, 'utf8');
-        const original = source;
-        const replacement =
-          remoteEntryPublicPathRuntimes.get(normalizedFile) ?? CHUNK_PUBLIC_PATH_RUNTIME;
-
-        for (const publicPath of publicPaths) {
-          source = source.replace(createPublicPathAssignment(publicPath), replacement);
-        }
+        source = rewriteAbsoluteRspressAssetUrls(source);
 
         if (source !== original) {
           await writeFile(filePath, source);
@@ -223,62 +177,20 @@ function normalizeHttpPrefix(value: string | undefined): string | null {
   return value.endsWith('/') ? value : `${value}/`;
 }
 
-function getRemoteEntryPublicPathRuntimes(
-  browserManifest: ModuleFederationManifest,
-  ssgManifestFile: string | null,
-  ssgManifest: ModuleFederationManifest | null
-): Map<string, string> {
-  const runtimes = new Map<string, string>();
-  const browserRemoteEntry = remoteEntryFile(browserManifest.metaData?.remoteEntry, null);
-
-  if (browserRemoteEntry) {
-    runtimes.set(
-      browserRemoteEntry,
-      getRemoteEntryPublicPathRuntime(browserManifest.metaData?.remoteEntry)
-    );
-  }
-
-  const ssgRemoteEntry = ssgManifest
-    ? remoteEntryFile(ssgManifest.metaData?.remoteEntry, manifestDir(ssgManifestFile))
-    : remoteEntryFile(browserManifest.metaData?.ssrRemoteEntry, null);
-
-  if (ssgRemoteEntry) {
-    runtimes.set(
-      ssgRemoteEntry,
-      getRemoteEntryPublicPathRuntime(
-        ssgManifest?.metaData?.remoteEntry ?? browserManifest.metaData?.ssrRemoteEntry
-      )
-    );
-  }
-
-  return runtimes;
-}
-
-function getRemoteEntryPublicPathRuntime(entry: ManifestEntry | undefined): string {
-  return entry?.type === 'module'
-    ? MODULE_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME
-    : GLOBAL_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME;
-}
-
-function remoteEntryFile(
-  entry: ManifestEntry | undefined,
-  baseDir: string | null
-): string | null {
-  if (!entry?.name) {
-    return null;
-  }
-
-  return toPortablePath(
-    `${baseDir ?? ''}${normalizeManifestDir(entry.path) ?? ''}${entry.name}`
-  ).replace(/^\/+/, '');
-}
-
 function rewriteHtmlAssetPrefix(source: string, publicPath: string): string {
   return source.replace(createHtmlAssetUrl(publicPath), '$1/');
 }
 
+function rewriteAbsoluteRspressAssetUrls(source: string): string {
+  return source.replace(createAbsoluteRspressAssetUrl(), '$1/');
+}
+
 function createHtmlAssetUrl(publicPath: string): RegExp {
   return new RegExp(`(\\b(?:href|src)\\s*=\\s*["'])${escapeRegExp(publicPath)}`, 'g');
+}
+
+function createAbsoluteRspressAssetUrl(): RegExp {
+  return /(<(?:link|script)\b[^>]*\b(?:href|src)\s*=\s*["'])https?:\/\/[^"']+\/(?=static\/)/g;
 }
 
 function findSsgManifestFile(
@@ -367,13 +279,6 @@ function normalizeManifestDir(value: string | undefined): string | null {
   }
 
   return normalized.endsWith('/') ? normalized : `${normalized}/`;
-}
-
-function createPublicPathAssignment(publicPath: string): RegExp {
-  return new RegExp(
-    `__webpack_require__\\.p\\s*=\\s*${escapeRegExp(JSON.stringify(publicPath))}`,
-    'g'
-  );
 }
 
 function escapeRegExp(value: string): string {

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -18,8 +18,10 @@ type ModuleFederationManifest = {
 };
 
 const BROWSER_MANIFEST = 'mf-manifest.json';
-const AUTO_PUBLIC_PATH_RUNTIME =
+const GLOBAL_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME =
   '__webpack_require__.p=(()=>{var e;if(typeof document!="undefined"){var t=document.currentScript;if(t&&t.tagName==="SCRIPT")e=t.src;if(!e){var r=document.getElementsByTagName("script");if(r.length)e=r[r.length-1].src}}if(!e&&typeof location!="undefined")e=location.href;if(!e)return "/";return e.replace(/#.*$/,"").replace(/\\?.*$/,"").replace(/\\/[^\\/]*$/,"/")})()';
+const MODULE_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME =
+  '__webpack_require__.p=new URL("./",import.meta.url).href';
 
 export async function rewriteRspressModuleFederationAssets(
   outDir: string,
@@ -39,7 +41,12 @@ export async function rewriteRspressModuleFederationAssets(
     ssgManifest
   );
   await rewriteHtmlAssetPrefixes(outDir, files, publicPaths);
-  await rewriteJsPublicPaths(outDir, files, publicPaths);
+  await rewriteJsPublicPaths(
+    outDir,
+    files,
+    publicPaths,
+    getRemoteEntryPublicPathRuntime(browserManifest)
+  );
   await writeManifest(
     outDir,
     BROWSER_MANIFEST,
@@ -100,7 +107,7 @@ async function rewriteHtmlAssetPrefixes(
         const original = source;
 
         for (const publicPath of publicPaths) {
-          source = source.split(publicPath).join('/');
+          source = rewriteHtmlAssetPrefix(source, publicPath);
         }
 
         if (source !== original) {
@@ -113,7 +120,8 @@ async function rewriteHtmlAssetPrefixes(
 async function rewriteJsPublicPaths(
   outDir: string,
   files: string[],
-  publicPaths: string[]
+  publicPaths: string[],
+  remoteEntryPublicPathRuntime: string
 ): Promise<void> {
   if (publicPaths.length === 0) {
     return;
@@ -129,7 +137,7 @@ async function rewriteJsPublicPaths(
         const original = source;
         const replacement =
           normalizedFile === 'remoteEntry.js'
-            ? AUTO_PUBLIC_PATH_RUNTIME
+            ? remoteEntryPublicPathRuntime
             : '__webpack_require__.p="/"';
 
         for (const publicPath of publicPaths) {
@@ -216,6 +224,20 @@ function normalizeHttpPrefix(value: string | undefined): string | null {
   }
 
   return value.endsWith('/') ? value : `${value}/`;
+}
+
+function getRemoteEntryPublicPathRuntime(manifest: ModuleFederationManifest): string {
+  return manifest.metaData?.remoteEntry?.type === 'module'
+    ? MODULE_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME
+    : GLOBAL_REMOTE_ENTRY_PUBLIC_PATH_RUNTIME;
+}
+
+function rewriteHtmlAssetPrefix(source: string, publicPath: string): string {
+  return source.replace(createHtmlAssetUrl(publicPath), '$1/');
+}
+
+function createHtmlAssetUrl(publicPath: string): RegExp {
+  return new RegExp(`(\\b(?:href|src)\\s*=\\s*["'])${escapeRegExp(publicPath)}`, 'g');
 }
 
 function findSsgManifestFile(

--- a/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/rewriteRspressModuleFederationAssets.ts
@@ -18,7 +18,6 @@ type ModuleFederationManifest = {
 };
 
 const BROWSER_MANIFEST = 'mf-manifest.json';
-const SSG_MANIFEST = 'mf-ssg/mf-manifest.json';
 const AUTO_PUBLIC_PATH_RUNTIME =
   '__webpack_require__.p=(()=>{var e;if(typeof document!="undefined"){var t=document.currentScript;if(t&&t.tagName==="SCRIPT")e=t.src;if(!e){var r=document.getElementsByTagName("script");if(r.length)e=r[r.length-1].src}}if(!e&&typeof location!="undefined")e=location.href;if(!e)return "/";return e.replace(/#.*$/,"").replace(/\\?.*$/,"").replace(/\\/[^\\/]*$/,"/")})()';
 
@@ -32,23 +31,36 @@ export async function rewriteRspressModuleFederationAssets(
     return;
   }
 
-  const publicPaths = await collectManifestPublicPaths(outDir, normalizedFiles);
+  const browserManifest = await readManifest(outDir, BROWSER_MANIFEST);
+  const ssgManifest = findSsgManifestFile(browserManifest, normalizedFiles);
+  const publicPaths = await collectManifestPublicPaths(
+    outDir,
+    normalizedFiles,
+    ssgManifest
+  );
   await rewriteHtmlAssetPrefixes(outDir, files, publicPaths);
   await rewriteJsPublicPaths(outDir, files, publicPaths);
-  await rewriteManifest(outDir, BROWSER_MANIFEST, normalizeBrowserManifest);
+  await writeManifest(
+    outDir,
+    BROWSER_MANIFEST,
+    normalizeBrowserManifest(browserManifest, ssgManifest)
+  );
 
-  if (normalizedFiles.has(SSG_MANIFEST)) {
-    await rewriteManifest(outDir, SSG_MANIFEST, normalizeSsgManifest);
+  if (ssgManifest) {
+    await rewriteManifest(outDir, ssgManifest, normalizeSsgManifest);
   }
 }
 
 async function collectManifestPublicPaths(
   outDir: string,
-  files: Set<string>
+  files: Set<string>,
+  ssgManifest: string | null
 ): Promise<string[]> {
   const publicPaths = new Set<string>();
 
-  for (const file of [BROWSER_MANIFEST, SSG_MANIFEST]) {
+  for (const file of [BROWSER_MANIFEST, ssgManifest].filter((value): value is string =>
+    Boolean(value)
+  )) {
     if (!files.has(file)) {
       continue;
     }
@@ -121,9 +133,7 @@ async function rewriteJsPublicPaths(
             : '__webpack_require__.p="/"';
 
         for (const publicPath of publicPaths) {
-          source = source
-            .split(`__webpack_require__.p=${JSON.stringify(publicPath)}`)
-            .join(replacement);
+          source = source.replace(createPublicPathAssignment(publicPath), replacement);
         }
 
         if (source !== original) {
@@ -140,6 +150,14 @@ async function rewriteManifest(
 ): Promise<void> {
   const manifest = await readManifest(outDir, file);
   normalize(manifest);
+  await writeManifest(outDir, file, manifest);
+}
+
+async function writeManifest(
+  outDir: string,
+  file: string,
+  manifest: ModuleFederationManifest
+): Promise<void> {
   await writeFile(
     resolveOutputPath(outDir, file),
     `${JSON.stringify(manifest, null, 2)}\n`
@@ -153,21 +171,27 @@ async function readManifest(
   return JSON.parse(await readFile(resolveOutputPath(outDir, file), 'utf8'));
 }
 
-function normalizeBrowserManifest(manifest: ModuleFederationManifest): void {
+function normalizeBrowserManifest(
+  manifest: ModuleFederationManifest,
+  ssgManifest: string | null
+): ModuleFederationManifest {
   if (!manifest.metaData) {
-    return;
+    return manifest;
   }
 
+  const ssrRemoteEntryPath = getSsrRemoteEntryPath(manifest, ssgManifest);
   manifest.metaData.publicPath = 'auto';
   delete manifest.metaData.ssrPublicPath;
 
   if (manifest.metaData.ssrRemoteEntry) {
     manifest.metaData.ssrRemoteEntry = {
       ...manifest.metaData.ssrRemoteEntry,
-      path: 'mf-ssg/',
+      path: ssrRemoteEntryPath,
       type: 'commonjs-module',
     };
   }
+
+  return manifest;
 }
 
 function normalizeSsgManifest(manifest: ModuleFederationManifest): void {
@@ -192,6 +216,88 @@ function normalizeHttpPrefix(value: string | undefined): string | null {
   }
 
   return value.endsWith('/') ? value : `${value}/`;
+}
+
+function findSsgManifestFile(
+  browserManifest: ModuleFederationManifest,
+  files: Set<string>
+): string | null {
+  const candidates = [
+    manifestFileFromPublicPath(browserManifest.metaData?.ssrPublicPath),
+    manifestFileFromEntryPath(browserManifest.metaData?.ssrRemoteEntry?.path),
+    ...[...files]
+      .filter((file) => file !== BROWSER_MANIFEST && file.endsWith('/mf-manifest.json'))
+      .sort(),
+  ];
+
+  return candidates.find((candidate) => candidate && files.has(candidate)) ?? null;
+}
+
+function getSsrRemoteEntryPath(
+  manifest: ModuleFederationManifest,
+  ssgManifest: string | null
+): string {
+  return (
+    normalizeManifestDir(manifest.metaData?.ssrRemoteEntry?.path) ??
+    pathFromPublicPath(manifest.metaData?.ssrPublicPath) ??
+    manifestDir(ssgManifest) ??
+    'mf-ssg/'
+  );
+}
+
+function manifestFileFromPublicPath(value: string | undefined): string | null {
+  const dir = pathFromPublicPath(value);
+  return dir ? `${dir}mf-manifest.json` : null;
+}
+
+function manifestFileFromEntryPath(value: string | undefined): string | null {
+  const dir = normalizeManifestDir(value);
+  return dir ? `${dir}mf-manifest.json` : null;
+}
+
+function pathFromPublicPath(value: string | undefined): string | null {
+  if (!value || !/^https?:\/\//.test(value)) {
+    return null;
+  }
+
+  try {
+    return normalizeManifestDir(new URL(value).pathname);
+  } catch {
+    return null;
+  }
+}
+
+function manifestDir(file: string | null): string | null {
+  if (!file || !file.includes('/')) {
+    return null;
+  }
+
+  return normalizeManifestDir(file.slice(0, file.lastIndexOf('/') + 1));
+}
+
+function normalizeManifestDir(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = toPortablePath(value).replace(/^\/+/, '');
+
+  if (!normalized || normalized === '.') {
+    return null;
+  }
+
+  return normalized.endsWith('/') ? normalized : `${normalized}/`;
+}
+
+function createPublicPathAssignment(publicPath: string): RegExp {
+  return new RegExp(
+    `__webpack_require__\\.p\\s*=\\s*${escapeRegExp(JSON.stringify(publicPath))}`,
+    'g'
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function resolveOutputPath(outDir: string, file: string): string {

--- a/libs/zephyr-rspress-plugin/src/with-zephyr.ts
+++ b/libs/zephyr-rspress-plugin/src/with-zephyr.ts
@@ -3,6 +3,7 @@ import {
   type ZephyrBuildHooks,
 } from 'zephyr-rsbuild-plugin';
 import { zephyrRspressSSGPlugin } from './zephyrRspressSSGPlugin';
+import { moduleFederationPublicPathPlugin } from './internal/assets/moduleFederationPublicPathPlugin';
 import type {
   SSGConfig,
   RspressUserConfig,
@@ -59,12 +60,28 @@ function isSsgEnabled(
 export function withZephyr<TConfig extends RspressUserConfig = RspressUserConfig>(
   options?: ZephyrRspressOptions
 ): RspressPlugin<TConfig> {
+  const zephyrModuleFederationPublicPathPlugin = moduleFederationPublicPathPlugin();
+
   return {
     name: 'zephyr-rspress-plugin',
     async config(config, { addPlugin }) {
       const { ssg } = config;
 
       if (isSsgEnabled(ssg)) {
+        if (isRspressV1(config)) {
+          config.builderPlugins = [
+            ...config.builderPlugins,
+            zephyrModuleFederationPublicPathPlugin,
+          ];
+        } else {
+          const existingPlugins = config.builderConfig?.plugins ?? [];
+          const newBuilderConfig: BuilderConfigWithPlugins = {
+            ...config.builderConfig,
+            plugins: [...existingPlugins, zephyrModuleFederationPublicPathPlugin],
+          };
+          (config as { builderConfig?: BuilderConfigWithPlugins }).builderConfig =
+            newBuilderConfig;
+        }
         addPlugin(zephyrRspressSSGPlugin(config, options) as RspressPlugin<TConfig>);
       } else {
         // Support both rspress v1 (builderPlugins) and v2 (builderConfig.plugins)

--- a/libs/zephyr-rspress-plugin/src/zephyrRspressSSGPlugin.ts
+++ b/libs/zephyr-rspress-plugin/src/zephyrRspressSSGPlugin.ts
@@ -7,6 +7,7 @@ import {
   type ZephyrBuildHooks,
 } from 'zephyr-agent';
 import { setupZeDeploy } from './internal/assets/setupZeDeploy';
+import { rewriteRspressModuleFederationAssets } from './internal/assets/rewriteRspressModuleFederationAssets';
 import { showFiles } from './internal/files/showFiles';
 import { walkFiles } from './internal/files/walkFiles';
 import type { RspressUserConfig, RspressPlugin } from './types';
@@ -34,6 +35,7 @@ export const zephyrRspressSSGPlugin = <
           return;
         }
 
+        await rewriteRspressModuleFederationAssets(outDir, files);
         await showFiles(outDir, files);
 
         await setupZeDeploy({


### PR DESCRIPTION
### What's added in this PR?

Adds a Rspress SSG upload normalization step for Module Federation remotes before Zephyr collects assets.

The new rewrite keeps normal Rspress sites untouched unless `mf-manifest.json` exists, then:

- rewrites generated HTML asset URLs from build-time absolute origins to root-relative `/static/...` URLs
- normalizes browser and SSG federation manifests to deploy-safe public path metadata
- rewrites browser `remoteEntry.js` runtime public path to infer from its own script URL
- rewrites standalone Rspress app JS public path to `/`
- adds focused unit coverage for the Rspress MF output rewrite and SSG plugin integration

#### Screenshots

N/A

### What's the issues or discussion related to this PR ?

Rspress Module Federation docs remotes built with an absolute local asset prefix could deploy through Zephyr with `localhost` URLs in HTML, manifest metadata, and browser runtime public path assignments. Hosts with strict CSP then block those styles/scripts, and federated chunks can try to load from the build machine origin instead of the immutable Zephyr deployment URL.

This was reproduced with a Rspress MF docs remote consumed by the Module Federation docs site.

### What are the steps to test this PR?

- `pnpm nx run zephyr-rspress-plugin:test`
- `pnpm nx run zephyr-rspress-plugin:lint`
- `pnpm nx run zephyr-rspress-plugin:build`
- Verified a linked local plugin build in `mf-vite` deployed a Rspress MF remote without `localhost:4178` in deployed HTML/runtime assets
- Verified the official Module Federation docs build can consume the deployed remote manifest

### Documentation update for this PR (if applicable)?

N/A. This fixes deploy artifact normalization in the Rspress plugin without changing user-facing configuration.

### (Optional) What's left to be done for this PR?

N/A

### (Optional) What's the potential risk and how to mitigate it?

Risk is limited to Rspress SSG builds that emit `mf-manifest.json`. Non-MF Rspress sites return early. The rewrite is covered by unit tests and runs before Zephyr builds the upload asset map.

<!-- ### Who do you wish to review this PR other than required reviewers? -->

<!-- @valorkin @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
