### PR TITLE
feat(agent): send addressMode from application config in snapshot upload

### DIFF
--- a/libs/zephyr-agent/src/lib/node-persist/upload-provider-options.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/upload-provider-options.ts
@@ -1,9 +1,12 @@
 // libs/api/builder-packages-api/src/lib/builder-packages-api.service.ts
+export type AddressMode = 'hostname' | 'path';
+
 export interface ZeApplicationConfig {
   application_uid: string;
   BUILD_ID_ENDPOINT: string;
   EDGE_URL: string;
   DELIMITER: string;
+  ADDRESS_MODE?: AddressMode;
   PLATFORM: UploadProviderType;
   ENVIRONMENTS?: Record<string, EnvironmentConfig>;
   fetched_at?: number;
@@ -34,5 +37,6 @@ export interface EnvironmentConfig {
   type: UploadProviderType;
   edgeUrl: string;
   delimiter: string;
+  addressMode?: AddressMode;
   remote_host: string;
 }

--- a/libs/zephyr-agent/src/lib/transformers/ze-build-snapshot.ts
+++ b/libs/zephyr-agent/src/lib/transformers/ze-build-snapshot.ts
@@ -40,6 +40,7 @@ export async function createSnapshot(
     email: (await zephyr_engine.application_configuration).email,
     applicationProperties: zephyr_engine.applicationProperties,
     edge_url: (await zephyr_engine.application_configuration).EDGE_URL,
+    address_mode: (await zephyr_engine.application_configuration).ADDRESS_MODE,
     gitProperties: zephyr_engine.gitProperties,
     mfConfig: mfConfig,
   };
@@ -64,6 +65,7 @@ export async function createSnapshot(
       })
     ),
     domain: options.edge_url,
+    ...(options.address_mode === 'path' && { addressMode: 'path' as const }),
     uid: {
       build: options.buildId,
       app_name: options.applicationProperties.name,

--- a/libs/zephyr-edge-contract/src/lib/snapshot.ts
+++ b/libs/zephyr-edge-contract/src/lib/snapshot.ts
@@ -13,6 +13,8 @@ export interface Snapshot {
   snapshot_id: string;
   // default domain url
   domain: string;
+  // how the edge worker should address this deployment; worker defaults to 'hostname'
+  addressMode?: 'hostname' | 'path';
   // snapshot type (e.g., 'ssr' for server-side rendering, 'csr' for client-side rendering)
   type?: 'ssr' | 'csr';
   // server entry file path for SSR applications (relative path)


### PR DESCRIPTION
### What's added in this PR?

The agent now forwards the integration's address mode to the edge worker when uploading a snapshot:

- `ZeApplicationConfig` models `ADDRESS_MODE?: 'hostname' | 'path'` and `EnvironmentConfig` models `addressMode?` — previously these fields were returned by the application-config API but silently dropped when the response was parsed.
- The `Snapshot` contract gains an optional `addressMode` field (mirrors the worker's `AddressedSnapshotUpload` type in zephyr-mono).
- `createSnapshot` sets `addressMode: 'path'` on the upload body when the application config resolves to path mode. Hostname-mode integrations are untouched (field omitted, worker defaults to hostname).

#### Screenshots

N/A — CLI/plugin behavior.

### What's the issues or discussion related to this PR ?

Path-addressed worker URLs shipped in zephyr-mono (#522) and the cloud slice (#3531), but the worker only emits a path-addressed version URL — and only writes the `route:v1:version:<key>` route pointer — when the snapshot upload body carries `addressMode: 'path'`. The worker does not read the integration's `ADDRESS_MODE` config, and the agent never sent the field.

Result today for a path-mode integration: builds deploy to a subdomain URL (e.g. `https://<user>-<build>-...-ze.<edge-domain>`), while the dashboard shows the path URL (`https://<edge-domain>/__zephyr/v1/v/...`) which 404s because the route pointer was never stored.

### What are the steps to test this PR?

1. Provision a path-mode integration from the dashboard (`addressMode: path`).
2. Build any example (e.g. `examples/vite-react-ts`) with `WITH_ZE=true` against that integration.
3. The snapshot upload response `urls.version` should now be `https://<edge>/__zephyr/v1/v/<route-key>` and the printed deploy URL should load (route pointer stored by the worker).
4. Build against a hostname-mode integration and confirm the subdomain URL behavior is unchanged.

Note: requires the target edge worker to include zephyr-mono#522 (path-addressed worker URLs).

### Documentation update for this PR (if applicable)?

`docs/path-addressed-worker-urls.md` already documents path-mode URL consumption; this PR adds the missing producer side. Public docs update to follow if needed.

### (Optional) What's left to be done for this PR?

- zephyr-mono: worker version bump so deployments with path support are distinguishable from pre-path `0.2.2` builds (separate PR).
- zephyr-cloud-io: env/tag CRUD handlers drop `addressMode` when building `remote_host` (separate fix).

### (Optional) What's the potential risk and how to mitigate it?

Low. The field is additive and only sent when config explicitly says `path`. Older workers ignore unknown snapshot fields, so sending `addressMode` to a pre-#522 worker is a no-op (still returns hostname URLs).

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [ ] I have written new tests (if applicable)
- [ ] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
