### PR TITLE
fix: resolve assets under the deployment prefix for path-addressed builds

### DIFF
--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.spec.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.spec.ts
@@ -63,4 +63,92 @@ describe('vite-plugin-zephyr', () => {
       ]);
     });
   });
+
+  describe('config hook base handling', () => {
+    interface ZephyrVitePlugin {
+      name?: string;
+      config?: (
+        config: Record<string, unknown>,
+        env: { command: string; mode: string }
+      ) => Promise<unknown>;
+    }
+
+    function loadPluginWithAddressMode(addressMode?: string): {
+      plugin: ZephyrVitePlugin;
+      zephyr_defer_create: jest.Mock;
+    } {
+      let plugin: ZephyrVitePlugin | undefined;
+      const zephyr_defer_create = jest.fn();
+
+      jest.isolateModules(() => {
+        jest.doMock('vite', () => ({
+          loadEnv: jest.fn(() => ({})),
+        }));
+
+        const actual = jest.requireActual('zephyr-agent') as Record<string, unknown>;
+        jest.doMock('zephyr-agent', () => ({
+          ...actual,
+          ZephyrEngine: {
+            defer_create: jest.fn(() => ({
+              zephyr_engine_defer: Promise.resolve({
+                application_configuration: Promise.resolve({
+                  ADDRESS_MODE: addressMode,
+                }),
+              }),
+              zephyr_defer_create,
+            })),
+          },
+        }));
+
+        const { withZephyr } = require('./vite-plugin-zephyr') as {
+          withZephyr: () => ZephyrVitePlugin[];
+        };
+
+        plugin = withZephyr()[0];
+      });
+
+      if (!plugin) {
+        throw new Error('withZephyr did not return a plugin');
+      }
+
+      return { plugin, zephyr_defer_create };
+    }
+
+    test('sets a relative base for path-addressed builds without a user base', async () => {
+      const { plugin, zephyr_defer_create } = loadPluginWithAddressMode('path');
+
+      const result = await plugin.config?.({}, { command: 'build', mode: 'production' });
+
+      expect(result).toEqual({ base: './' });
+      expect(zephyr_defer_create).toHaveBeenCalledTimes(1);
+    });
+
+    test('keeps a user-provided base untouched for path-addressed builds', async () => {
+      const { plugin } = loadPluginWithAddressMode('path');
+
+      const result = await plugin.config?.(
+        { base: '/my-app/' },
+        { command: 'build', mode: 'production' }
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test('does not change base for hostname-addressed builds', async () => {
+      const { plugin } = loadPluginWithAddressMode('hostname');
+
+      const result = await plugin.config?.({}, { command: 'build', mode: 'production' });
+
+      expect(result).toBeNull();
+    });
+
+    test('does not start the engine or change base during dev server', async () => {
+      const { plugin, zephyr_defer_create } = loadPluginWithAddressMode('path');
+
+      const result = await plugin.config?.({}, { command: 'serve', mode: 'development' });
+
+      expect(result).toBeNull();
+      expect(zephyr_defer_create).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
@@ -1,7 +1,14 @@
 import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import MagicString from 'magic-string';
 import type { NormalizedOutputOptions, OutputBundle } from 'rollup';
-import { loadEnv, type Plugin, type ResolvedConfig, type UserConfig } from 'vite';
+import {
+  loadEnv,
+  type ConfigEnv,
+  type Plugin,
+  type ResolvedConfig,
+  type UserConfig,
+} from 'vite';
 import {
   createManifestContent,
   handleGlobalError,
@@ -70,18 +77,55 @@ function withZephyrCore(options: WithZephyrOptions = {}): Plugin {
   let cachedSpecifier: string | undefined;
   let entrypoint: string;
   let mfConfig = options.mfConfig;
+  let engine_create_started = false;
 
   return {
     name: 'with-zephyr',
     // Run before Vite's env replacement so ZE_PUBLIC_* reads can be rewritten first.
     enforce: 'pre',
 
-    config: (config: UserConfig) => {
+    config: async (config: UserConfig, env: ConfigEnv) => {
       // If MF was configured separately, inject the Zephyr runtime plugin before MF emits.
       const detectedMfConfig = extract_mf_plugin(config.plugins ?? [])?._options;
       if (detectedMfConfig) {
         mfConfig = ensureRuntimePlugin(detectedMfConfig);
       }
+
+      if (env.command !== 'build') {
+        return null;
+      }
+
+      try {
+        // The engine has to start here (not configResolved) because `base` can
+        // only be changed before the config is resolved.
+        zephyr_defer_create({
+          builder: 'vite',
+          context: config.root ? resolve(config.root) : process.cwd(),
+        });
+        engine_create_started = true;
+
+        const zephyr_engine = await zephyr_engine_defer;
+        const { ADDRESS_MODE } = await zephyr_engine.application_configuration;
+
+        // Path-addressed applications are served under a URL prefix that is not
+        // known at build time (version, tag and environment routes share one
+        // build), so asset URLs must resolve relative to the loaded document
+        // instead of the origin root.
+        if (ADDRESS_MODE === 'path') {
+          if (config.base == null) {
+            return { base: './' };
+          }
+
+          if (config.base.startsWith('/')) {
+            ze_log.init(
+              `Vite 'base' is set to '${config.base}', but this application uses path-based addressing. Origin-absolute asset URLs will not resolve under the deployment path prefix; use a relative base (e.g. './') instead.`
+            );
+          }
+        }
+      } catch (error) {
+        handleGlobalError(error);
+      }
+
       return null;
     },
 
@@ -90,11 +134,15 @@ function withZephyrCore(options: WithZephyrOptions = {}): Plugin {
       // Normalize the entrypoint early so uploads use the same path in serve/build.
       entrypoint = extractEntrypoint(config);
 
-      // Initialize the Zephyr engine in both serve and build flows.
-      zephyr_defer_create({
-        builder: 'vite',
-        context: root,
-      });
+      // Initialize the Zephyr engine in both serve and build flows. Build flows
+      // already started it in the config hook to decide the base option.
+      if (!engine_create_started) {
+        zephyr_defer_create({
+          builder: 'vite',
+          context: root,
+        });
+        engine_create_started = true;
+      }
 
       resolve_vite_internal_options({
         root,

--- a/libs/zephyr-agent/src/lib/utils/get-global.ts
+++ b/libs/zephyr-agent/src/lib/utils/get-global.ts
@@ -4,7 +4,7 @@
  */
 declare global {
   // `var` is required here: `let`/`const` cannot augment the global/globalThis type.
-  // eslint-disable-next-line no-var
+   
   var NX_GRAPH_CREATION: boolean | undefined;
 }
 

--- a/libs/zephyr-agent/src/lib/utils/warn-path-mode-absolute-urls.test.ts
+++ b/libs/zephyr-agent/src/lib/utils/warn-path-mode-absolute-urls.test.ts
@@ -1,0 +1,103 @@
+import type { ZeBuildAssetsMap } from 'zephyr-edge-contract';
+import type { ZephyrEngine } from '../../zephyr-engine';
+import { warnPathModeAbsoluteUrls } from './warn-path-mode-absolute-urls';
+
+function createEngine(addressMode: string | undefined, logger: jest.Mock): ZephyrEngine {
+  return {
+    application_configuration: Promise.resolve({ ADDRESS_MODE: addressMode }),
+    logger: Promise.resolve(logger),
+  } as unknown as ZephyrEngine;
+}
+
+function createHtmlAsset(path: string, html: string): ZeBuildAssetsMap[string] {
+  return { path, extname: '.html', hash: 'hash', size: html.length, buffer: html };
+}
+
+describe('warnPathModeAbsoluteUrls', () => {
+  it('warns about origin-absolute src and href URLs in HTML assets', async () => {
+    const logger = jest.fn();
+    const assetsMap: ZeBuildAssetsMap = {
+      a: createHtmlAsset(
+        'index.html',
+        '<script src="/assets/index-abc.js"></script><link href="/assets/index.css">'
+      ),
+    };
+
+    await warnPathModeAbsoluteUrls(createEngine('path', logger), assetsMap);
+
+    expect(logger).toHaveBeenCalledTimes(1);
+    const { level, message } = logger.mock.calls[0][0];
+    expect(level).toBe('warn');
+    expect(message).toContain('index.html: src="/assets/index-abc.js"');
+    expect(message).toContain('index.html: href="/assets/index.css"');
+  });
+
+  it('does not warn for relative or protocol-relative URLs', async () => {
+    const logger = jest.fn();
+    const assetsMap: ZeBuildAssetsMap = {
+      a: createHtmlAsset(
+        'index.html',
+        '<script src="./assets/app.js"></script><link href="//cdn.example.com/x.css"><img src="https://example.com/logo.png">'
+      ),
+    };
+
+    await warnPathModeAbsoluteUrls(createEngine('path', logger), assetsMap);
+
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for hostname-addressed applications', async () => {
+    const logger = jest.fn();
+    const assetsMap: ZeBuildAssetsMap = {
+      a: createHtmlAsset('index.html', '<script src="/assets/app.js"></script>'),
+    };
+
+    await warnPathModeAbsoluteUrls(createEngine('hostname', logger), assetsMap);
+
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-HTML assets', async () => {
+    const logger = jest.fn();
+    const assetsMap: ZeBuildAssetsMap = {
+      a: {
+        path: 'assets/app.js',
+        extname: '.js',
+        hash: 'hash',
+        size: 10,
+        buffer: 'fetch("/api/data")',
+      },
+    };
+
+    await warnPathModeAbsoluteUrls(createEngine('path', logger), assetsMap);
+
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('caps the reported URL list and mentions the remainder', async () => {
+    const logger = jest.fn();
+    const links = Array.from(
+      { length: 12 },
+      (_, i) => `<link href="/assets/chunk-${i}.css">`
+    ).join('');
+    const assetsMap: ZeBuildAssetsMap = {
+      a: createHtmlAsset('index.html', links),
+    };
+
+    await warnPathModeAbsoluteUrls(createEngine('path', logger), assetsMap);
+
+    const { message } = logger.mock.calls[0][0];
+    expect(message).toContain('...and 2 more');
+  });
+
+  it('never throws when the configuration lookup fails', async () => {
+    const logger = jest.fn();
+    const engine = {
+      application_configuration: Promise.reject(new Error('offline')),
+      logger: Promise.resolve(logger),
+    } as unknown as ZephyrEngine;
+
+    await expect(warnPathModeAbsoluteUrls(engine, {})).resolves.toBeUndefined();
+    expect(logger).not.toHaveBeenCalled();
+  });
+});

--- a/libs/zephyr-agent/src/lib/utils/warn-path-mode-absolute-urls.ts
+++ b/libs/zephyr-agent/src/lib/utils/warn-path-mode-absolute-urls.ts
@@ -1,0 +1,62 @@
+import type { ZeBuildAssetsMap } from 'zephyr-edge-contract';
+import type { ZephyrEngine } from '../../zephyr-engine';
+import { ze_log } from '../logging';
+
+const ORIGIN_ABSOLUTE_URL_REGEX = /(?:src|href)\s*=\s*["']\/(?!\/)[^"']*["']/gi;
+const MAX_REPORTED_URLS = 10;
+
+/**
+ * Path-addressed applications are served under a URL prefix (`/__zephyr/v1/...`), so
+ * origin-absolute URLs baked into HTML resolve outside the prefix and 404. Bundler
+ * plugins fix their own defaults (Vite base, webpack/rspack publicPath), but hardcoded
+ * absolute references in app HTML are out of their reach — surface them as a build
+ * warning so the 404s are not a mystery after deploy.
+ *
+ * Protocol-relative (`//host/...`) and full URLs are not flagged. This check never fails
+ * the build.
+ */
+export async function warnPathModeAbsoluteUrls(
+  zephyr_engine: ZephyrEngine,
+  assetsMap: ZeBuildAssetsMap
+): Promise<void> {
+  try {
+    const { ADDRESS_MODE } = await zephyr_engine.application_configuration;
+    if (ADDRESS_MODE !== 'path') {
+      return;
+    }
+
+    const findings: string[] = [];
+    for (const asset of Object.values(assetsMap)) {
+      if (asset.extname !== '.html') {
+        continue;
+      }
+
+      const html =
+        typeof asset.buffer === 'string' ? asset.buffer : asset.buffer.toString('utf8');
+      const matches = html.match(ORIGIN_ABSOLUTE_URL_REGEX);
+      if (!matches) {
+        continue;
+      }
+
+      for (const match of matches) {
+        findings.push(`  - ${asset.path}: ${match}`);
+      }
+    }
+
+    if (findings.length === 0) {
+      return;
+    }
+
+    const shown = findings.slice(0, MAX_REPORTED_URLS);
+    const hidden = findings.length - shown.length;
+    const logger = await zephyr_engine.logger;
+    logger({
+      level: 'warn',
+      action: 'build:warn:path-mode-absolute-urls',
+      message: `This application uses path-based addressing, but its HTML references origin-absolute URLs that will not resolve under the deployment path prefix:\n${shown.join('\n')}${hidden > 0 ? `\n  ...and ${hidden} more` : ''}\nUse relative URLs, or a runtime-resolved public path (Vite: base './', webpack/rspack: output.publicPath 'auto').`,
+    });
+  } catch (error) {
+    // A diagnostics check must never break the upload
+    ze_log.upload(`Skipped path-mode absolute URL check: ${error}`);
+  }
+}

--- a/libs/zephyr-agent/src/zephyr-engine/index.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/index.ts
@@ -35,6 +35,7 @@ import {
   convertResolvedDependencies,
   createManifestContent,
 } from '../lib/transformers/ze-create-manifest';
+import { warnPathModeAbsoluteUrls } from '../lib/utils/warn-path-mode-absolute-urls';
 import { maybeShowOutdatedPluginWarning } from '../lib/version/outdated-plugin-warning';
 import { resolveZephyrPluginPackageName } from '../lib/version/plugin-package-name';
 import { getZephyrAgentVersion } from '../lib/version/zephyr-agent-version';
@@ -512,6 +513,8 @@ https://docs.zephyr-cloud.io/features/remote-dependencies`,
     };
     const manifestAsset = zeBuildAssets(manifest);
     assetsMap[manifestAsset.hash] = manifestAsset;
+
+    await warnPathModeAbsoluteUrls(zephyr_engine, assetsMap);
 
     if (!zephyr_engine.application_uid || !zephyr_engine.build_id) {
       ze_log.upload('Failed to upload assets: missing application_uid or build_id');

--- a/libs/zephyr-rspack-plugin/src/rspack-plugin/with-zephyr.ts
+++ b/libs/zephyr-rspack-plugin/src/rspack-plugin/with-zephyr.ts
@@ -4,6 +4,7 @@ import {
   extractFederatedDependencyPairs,
   extractLibraryType,
   makeCopyOfModuleFederationOptions,
+  mutPathModePublicPath,
   mutWebpackFederatedRemotesConfig,
 } from 'zephyr-xpack-internal';
 import type { ZephyrRspackPluginOptions } from '../types';
@@ -43,6 +44,9 @@ async function _zephyr_configuration(
     );
 
     mutWebpackFederatedRemotesConfig(zephyr_engine, config, resolved_dependency_pairs);
+
+    // Path-addressed apps cannot use an origin-absolute publicPath
+    await mutPathModePublicPath(zephyr_engine, config);
 
     // inject the ZephyrRspackPlugin
     config.plugins?.push(

--- a/libs/zephyr-webpack-plugin/src/webpack-plugin/with-zephyr.ts
+++ b/libs/zephyr-webpack-plugin/src/webpack-plugin/with-zephyr.ts
@@ -4,6 +4,7 @@ import {
   extractFederatedDependencyPairs,
   extractLibraryType,
   makeCopyOfModuleFederationOptions,
+  mutPathModePublicPath,
   mutWebpackFederatedRemotesConfig,
 } from 'zephyr-xpack-internal';
 import type { ZephyrWebpackPluginOptions } from '../types';
@@ -40,6 +41,9 @@ async function _zephyr_configuration(
     );
 
     mutWebpackFederatedRemotesConfig(zephyr_engine, config, resolved_dependency_pairs);
+
+    // Path-addressed apps cannot use an origin-absolute publicPath
+    await mutPathModePublicPath(zephyr_engine, config);
 
     const mfConfig = makeCopyOfModuleFederationOptions(config);
 

--- a/libs/zephyr-xpack-internal/src/index.ts
+++ b/libs/zephyr-xpack-internal/src/index.ts
@@ -5,6 +5,7 @@ export {
   extractFederatedDependencyPairs,
   extractLibraryType,
   makeCopyOfModuleFederationOptions,
+  mutPathModePublicPath,
   mutWebpackFederatedRemotesConfig,
   xpack_delegate_module_template,
 } from './xpack-extract';

--- a/libs/zephyr-xpack-internal/src/xpack-extract/index.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/index.ts
@@ -11,5 +11,6 @@ export { extractLibraryType } from './extract-library-type';
 export { isModuleFederationPlugin } from './is-module-federation-plugin';
 export { iterateFederationConfig } from './iterate-federation-config';
 export { makeCopyOfModuleFederationOptions } from './make-copy-of-module-federation-options';
+export { mutPathModePublicPath } from './mut-path-mode-public-path';
 export { mutWebpackFederatedRemotesConfig } from './mut-webpack-federated-remotes-config';
 export { createZephyrRuntimePlugin } from './runtime-plugin';

--- a/libs/zephyr-xpack-internal/src/xpack-extract/mut-path-mode-public-path.ts
+++ b/libs/zephyr-xpack-internal/src/xpack-extract/mut-path-mode-public-path.ts
@@ -1,0 +1,38 @@
+import type { ZephyrEngine } from 'zephyr-agent';
+import { ze_log } from 'zephyr-agent';
+import type { XPackConfiguration } from '../xpack.types';
+
+/**
+ * Path-addressed applications are served under a URL prefix that is not known at build
+ * time (version, tag and environment routes share one build), so an origin-absolute
+ * `output.publicPath` like `/` bakes asset URLs that 404 under the deployment path
+ * prefix. Webpack and Rspack support `publicPath: 'auto'`, which resolves from the
+ * loading script URL at runtime and works under any prefix — override to it and let the
+ * user know.
+ *
+ * Full URLs (`https://...`) and protocol-relative (`//...`) public paths are left
+ * untouched: they point at explicit hosts on purpose.
+ */
+export async function mutPathModePublicPath<Compiler>(
+  zephyr_engine: ZephyrEngine,
+  config: XPackConfiguration<Compiler>
+): Promise<void> {
+  const { ADDRESS_MODE } = await zephyr_engine.application_configuration;
+  if (ADDRESS_MODE !== 'path') {
+    return;
+  }
+
+  const publicPath: unknown = config.output?.publicPath;
+  if (
+    typeof publicPath !== 'string' ||
+    !publicPath.startsWith('/') ||
+    publicPath.startsWith('//')
+  ) {
+    return;
+  }
+
+  ze_log.misc(
+    `output.publicPath '${publicPath}' is origin-absolute, but this application uses path-based addressing. Overriding it to 'auto' so assets resolve under the deployment path prefix.`
+  );
+  config.output = { ...config.output, publicPath: 'auto' };
+}

--- a/libs/zephyr-xpack-internal/tests/mut-path-mode-public-path.test.ts
+++ b/libs/zephyr-xpack-internal/tests/mut-path-mode-public-path.test.ts
@@ -1,0 +1,63 @@
+import type { ZephyrEngine } from 'zephyr-agent';
+import type { XPackConfiguration } from '../src/xpack.types';
+import { mutPathModePublicPath } from '../src/xpack-extract/mut-path-mode-public-path';
+
+function createEngine(addressMode?: string): ZephyrEngine {
+  return {
+    application_configuration: Promise.resolve({ ADDRESS_MODE: addressMode }),
+  } as unknown as ZephyrEngine;
+}
+
+describe('mutPathModePublicPath', () => {
+  it('overrides an origin-absolute publicPath to auto for path-addressed apps', async () => {
+    const config: XPackConfiguration<unknown> = { output: { publicPath: '/' } };
+
+    await mutPathModePublicPath(createEngine('path'), config);
+
+    expect(config.output?.publicPath).toBe('auto');
+  });
+
+  it('keeps other output options when overriding publicPath', async () => {
+    const config: XPackConfiguration<unknown> = {
+      output: { publicPath: '/static/', library: 'my-lib' },
+    };
+
+    await mutPathModePublicPath(createEngine('path'), config);
+
+    expect(config.output).toEqual({ publicPath: 'auto', library: 'my-lib' });
+  });
+
+  it('leaves full URLs and protocol-relative publicPath untouched', async () => {
+    const withFullUrl: XPackConfiguration<unknown> = {
+      output: { publicPath: 'https://cdn.example.com/' },
+    };
+    const withProtocolRelative: XPackConfiguration<unknown> = {
+      output: { publicPath: '//cdn.example.com/' },
+    };
+
+    await mutPathModePublicPath(createEngine('path'), withFullUrl);
+    await mutPathModePublicPath(createEngine('path'), withProtocolRelative);
+
+    expect(withFullUrl.output?.publicPath).toBe('https://cdn.example.com/');
+    expect(withProtocolRelative.output?.publicPath).toBe('//cdn.example.com/');
+  });
+
+  it('leaves auto and unset publicPath untouched', async () => {
+    const withAuto: XPackConfiguration<unknown> = { output: { publicPath: 'auto' } };
+    const withoutOutput: XPackConfiguration<unknown> = {};
+
+    await mutPathModePublicPath(createEngine('path'), withAuto);
+    await mutPathModePublicPath(createEngine('path'), withoutOutput);
+
+    expect(withAuto.output?.publicPath).toBe('auto');
+    expect(withoutOutput.output).toBeUndefined();
+  });
+
+  it('does nothing for hostname-addressed apps', async () => {
+    const config: XPackConfiguration<unknown> = { output: { publicPath: '/' } };
+
+    await mutPathModePublicPath(createEngine('hostname'), config);
+
+    expect(config.output?.publicPath).toBe('/');
+  });
+});

--- a/libs/zephyr-xpack-internal/tsconfig.spec.json
+++ b/libs/zephyr-xpack-internal/tsconfig.spec.json
@@ -8,7 +8,8 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "tests/**/*.test.ts"
   ],
   "exclude": ["dist"]
 }


### PR DESCRIPTION
### What's added in this PR?

Three build-side guards so path-addressed applications (`ADDRESS_MODE: 'path'`) resolve their assets under the deployment URL prefix:

1. **vite-plugin-zephyr** sets Vite's `base` to `'./'` (relative base) at build time, unless the user has explicitly configured a `base` themselves.
2. **zephyr-webpack-plugin / zephyr-rspack-plugin** (and rsbuild, which delegates to the rspack plugin): an explicitly configured origin-absolute `output.publicPath` (e.g. `'/'`) is overridden to `'auto'`, which resolves from the loading script URL at runtime. Webpack 5/Rspack already default to `'auto'`, so unconfigured apps were fine; full URLs and protocol-relative public paths are left untouched. Shared helper `mutPathModePublicPath` lives in zephyr-xpack-internal.
3. **zephyr-agent** warns at upload time when HTML in a path-addressed build still references origin-absolute `src`/`href` URLs (hardcoded favicons, logos, etc. that no bundler setting can fix), listing the offending URLs so post-deploy 404s aren't a mystery. The check never fails the build.

Details worth reviewing (Vite part):

- The Zephyr engine bootstrap moved from `configResolved` to the `config` hook for **build** runs, because `base` can only be influenced before Vite resolves the config. `configResolved` keeps a guarded fallback so dev-server runs behave exactly as before, and the engine is never created twice.
- If the user has explicitly set an origin-absolute `base` (e.g. `/my-app/`) on a path-addressed application, we leave it untouched and log a warning through `ze_log`, since that build will 404 under the deployment prefix.
- Hostname-addressed applications are unaffected: the hook returns `null` and no config is merged.

### What's the issues or discussion related to this PR ?

Path-addressed deployments (e.g. `https://ze.ze.dev/__zephyr/v1/v/<version>`) serve the app under a URL prefix that is not known at build time — version, tag and environment routes all share one build. Vite's default `base: '/'` bakes origin-absolute URLs (`/assets/index-*.js`) into the HTML **and** into JS chunks (`__vite__mapDeps` preload arrays, CSS/asset URLs), so the browser requests `https://ze.ze.dev/assets/...`, which falls outside the prefix and 404s.

A relative base makes Vite resolve every asset via the document URL / `import.meta.url`, which works under any prefix (and still works for hostname-addressed serving). Serve-time HTML rewriting was rejected because it cannot fix the absolute paths embedded in content-addressed JS chunks.

Companion PR in zephyr-mono (ZephyrCloudIO/zephyr-mono#536) extends the serve worker so SPA deep links keep working with relative-base builds (relative asset URLs resolve against the current route path).

### What are the steps to test this PR?

| Step | Expected result |
|------|-----------------|
| Set the application's address mode to `path`, run `vite build` with the plugin | Built `dist/index.html` references `./assets/index-*.js` instead of `/assets/...` |
| Deploy and open `https://<host>/__zephyr/v1/v/<version>` | App loads; asset requests stay under the `/__zephyr/v1/v/<version>/` prefix, no 404s |
| Same build served on a hostname-addressed URL | Still loads correctly (relative URLs resolve at root too) |
| Hostname-mode app, `vite build` | `base` untouched, output identical to before |
| `vite dev` | No behavior change |
| webpack/rspack app with `output.publicPath: '/'`, path address mode | Built assets load via runtime-resolved URLs (publicPath 'auto') |
| Path-mode build whose HTML hardcodes `<img src="/logo.png">` | Upload prints a warning listing the absolute URLs |

### Documentation update for this PR (if applicable)?

Worth a note in the path-based addressing docs that Vite builds automatically switch to a relative base. Will follow up in zephyr-documentation once this merges.

### (Optional) What's left to be done for this PR?

- Parcel/Astro/Rspress/Lume plugins have origin-absolute base defaults too; follow-ups per plugin if/when path mode is used with them (the new agent warning will flag those builds in the meantime).

### (Optional) What's the potential risk and how to mitigate it?

- Relative base changes asset URL shapes for existing path-mode Vite users — that is the point of the fix; hostname-mode users are untouched.
- Engine creation now starts slightly earlier in the Vite lifecycle for builds; failures are routed through the same `handleGlobalError` path as before.
- Apps must be rebuilt/redeployed to pick this up — existing snapshots have `'/'` baked in.

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
