### PR TITLE
feat(tap-runtime): add lifecycle runtime plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Plugins within this repository are built for applications to deploy with Zephyr.
 - [`zephyr-repack-plugin`](libs/zephyr-repack-plugin/README.md) - A Rspack plugin for deploying with Zephyr building with React Native and Re.Pack
 - [`zephyr-rolldown-plugin`](libs/zephyr-rolldown-plugin/README.md) - A Rolldown plugin for deploying with Zephyr
 - [`zephyr-rspack-plugin`](libs/zephyr-rspack-plugin/README.md) - A Rspack plugin for deploying with Zephyr
+- [`zephyr-tap-runtime`](libs/zephyr-tap-runtime/README.md) - A host-owned TAP lifecycle runtime plugin for Module Federation
 - [`zephyr-webpack-plugin`](libs/zephyr-webpack-plugin/README.md) - A Webpack plugin for deploying with Zephyr
 
 ### Utility Packages

--- a/libs/zephyr-tap-runtime/LICENSE
+++ b/libs/zephyr-tap-runtime/LICENSE
@@ -1,0 +1,39 @@
+ Apache License
+   Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+   ...
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same line as the copyright notice for each file. The "copyright"
+  word should be left as is (without quotes).
+
+   Copyright [2023] [Zephyr Cloud]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libs/zephyr-tap-runtime/README.md
+++ b/libs/zephyr-tap-runtime/README.md
@@ -1,0 +1,21 @@
+# zephyr-tap-runtime
+
+`zephyr-tap-runtime` is a host-only Module Federation runtime plugin that
+attaches a typed, serial TAP pause/resume coordinator to a federation instance.
+
+The host supplies authorization, checkpoint, and persistence operations through
+the required platform adapter. The package only coordinates those calls and
+publishes lifecycle observations; it does not own package state or policy.
+
+```ts
+import { createTapLifecycleRuntimePlugin } from 'zephyr-tap-runtime';
+import { tapPlatformAdapter } from './tap-platform-adapter';
+
+const lifecycle = createTapLifecycleRuntimePlugin({
+  platform: tapPlatformAdapter,
+});
+```
+
+Register the plugin in the trusted host runtime. Its `apply(instance)` method is
+idempotent, and exposes `instance.tapLifecycle.pause()` and
+`instance.tapLifecycle.resume()`.

--- a/libs/zephyr-tap-runtime/package.json
+++ b/libs/zephyr-tap-runtime/package.json
@@ -15,6 +15,7 @@
   "files": [
     "dist",
     "README.md",
+    "LICENSE",
     "!dist/**/*.map"
   ],
   "type": "commonjs",

--- a/libs/zephyr-tap-runtime/package.json
+++ b/libs/zephyr-tap-runtime/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "zephyr-tap-runtime",
+  "version": "1.1.2",
+  "description": "Host-owned TAP lifecycle runtime plugin for Module Federation",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "ZephyrCloudIO",
+    "url": "https://github.com/ZephyrCloudIO"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ZephyrCloudIO/zephyr-packages.git",
+    "directory": "libs/zephyr-tap-runtime"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "!dist/**/*.map"
+  ],
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "rslib build",
+    "dev": "rslib build --watch",
+    "patch-version": "pnpm version",
+    "test": "rstest run",
+    "typecheck": "tsc -b"
+  },
+  "devDependencies": {
+    "@module-federation/runtime": "catalog:module-federation",
+    "@module-federation/runtime-core": "^2.7.0",
+    "@rslib/core": "catalog:rslib",
+    "@rstest/core": "catalog:rstest",
+    "@types/node": "catalog:typescript",
+    "typescript": "catalog:typescript"
+  },
+  "peerDependencies": {
+    "@module-federation/runtime": "^2.7.0",
+    "@module-federation/runtime-core": "^2.7.0"
+  }
+}

--- a/libs/zephyr-tap-runtime/rslib.config.mts
+++ b/libs/zephyr-tap-runtime/rslib.config.mts
@@ -1,0 +1,59 @@
+import { defineConfig } from '@rslib/core';
+
+const entry = [
+  './src/**',
+  '!./src/**/*.test.ts',
+  '!./src/**/*.spec.ts',
+  '!./src/**/__test__/**',
+  '!./src/**/__tests__/**',
+];
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      bundle: false,
+      dts: {
+        autoExtension: true,
+      },
+      redirect: {
+        dts: {
+          extension: true,
+        },
+      },
+      source: {
+        entry: { index: entry },
+      },
+      output: {
+        target: 'node',
+        distPath: {
+          root: './dist',
+        },
+        sourceMap: {
+          js: 'source-map',
+        },
+      },
+    },
+    {
+      format: 'cjs',
+      syntax: 'es2022',
+      bundle: false,
+      dts: {
+        autoExtension: true,
+      },
+      source: {
+        entry: { index: entry },
+      },
+      output: {
+        target: 'node',
+        distPath: {
+          root: './dist',
+        },
+        sourceMap: {
+          js: 'source-map',
+        },
+      },
+    },
+  ],
+});

--- a/libs/zephyr-tap-runtime/rstest.config.mts
+++ b/libs/zephyr-tap-runtime/rstest.config.mts
@@ -1,0 +1,6 @@
+import { defineProject } from '@rstest/core';
+import { createProjectConfig } from '../../rstest.project.mts';
+
+export default defineProject(
+  createProjectConfig({ name: 'zephyr-tap-runtime', root: import.meta.dirname })
+);

--- a/libs/zephyr-tap-runtime/src/__tests__/tap-lifecycle.spec.ts
+++ b/libs/zephyr-tap-runtime/src/__tests__/tap-lifecycle.spec.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it } from '@rstest/core';
+import type { ModuleFederation } from '@module-federation/runtime';
+import {
+  createTapLifecycleRuntimePlugin,
+  TapLifecycleCoordinator,
+  type TapLifecyclePlatformAdapter,
+  type TapLifecycleRequest,
+} from '../index';
+
+const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function request(overrides: Partial<TapLifecycleRequest> = {}): TapLifecycleRequest {
+  return {
+    scope: 'mount',
+    scopeId: 'mini-app:primary',
+    reason: 'host-request',
+    force: false,
+    deadline: Date.now() + 1_000,
+    ...overrides,
+  };
+}
+
+function platform(
+  overrides: Partial<TapLifecyclePlatformAdapter> = {}
+): TapLifecyclePlatformAdapter {
+  return {
+    authorize: async () => ({ allowed: true }),
+    createCheckpoint: async () => undefined,
+    persistPaused: async () => undefined,
+    loadCheckpoint: async () => undefined,
+    persistResumed: async () => undefined,
+    ...overrides,
+  };
+}
+
+describe('zephyr-tap-runtime', () => {
+  it('attaches one typed lifecycle coordinator when core calls apply repeatedly', async () => {
+    let prePauseCalls = 0;
+    const plugin = createTapLifecycleRuntimePlugin({
+      platform: platform(),
+      hooks: {
+        prePause: () => {
+          prePauseCalls += 1;
+          return { kind: 'continue' };
+        },
+      },
+    });
+    const instance = { name: 'host' } as unknown as ModuleFederation;
+
+    plugin.apply(instance);
+    const first = instance.tapLifecycle;
+    plugin.apply(instance);
+    plugin.apply(instance);
+
+    expect(first).toBeDefined();
+    expect(instance.tapLifecycle).toBe(first);
+    expect(Object.keys(instance)).not.toContain('tapLifecycle');
+
+    const result = await first!.pause(request());
+    expect(result.status).toBe('completed');
+    expect(prePauseCalls).toBe(1);
+  });
+
+  it('serializes one scope and stamps unique IDs with monotonic epochs', async () => {
+    const order: string[] = [];
+    const lifecycle = new TapLifecycleCoordinator({
+      platform: platform({
+        createCheckpoint: async ({ transition }) => {
+          order.push(`checkpoint:${transition.lifecycleEpoch}:start`);
+          await wait(12);
+          order.push(`checkpoint:${transition.lifecycleEpoch}:end`);
+          return { checkpointReference: `cp-${transition.lifecycleEpoch}` };
+        },
+        persistPaused: async ({ transition }) => {
+          order.push(`persist:${transition.lifecycleEpoch}`);
+        },
+      }),
+    });
+
+    const first = lifecycle.pause(request());
+    const second = lifecycle.pause(request());
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.status).toBe('completed');
+    expect(secondResult.status).toBe('completed');
+    expect(firstResult.transition.lifecycleEpoch).toBe(0);
+    expect(secondResult.transition.lifecycleEpoch).toBe(1);
+    expect(firstResult.transition.transitionId).not.toBe(
+      secondResult.transition.transitionId
+    );
+    expect(order).toEqual([
+      'checkpoint:0:start',
+      'checkpoint:0:end',
+      'persist:0',
+      'checkpoint:1:start',
+      'checkpoint:1:end',
+      'persist:1',
+    ]);
+
+    await expect(lifecycle.pause(request({ lifecycleEpoch: 1 }))).rejects.toThrow(
+      'must be greater than 1'
+    );
+  });
+
+  it('allows independent scopes to progress concurrently', async () => {
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    let markSecondStarted!: () => void;
+    const secondStarted = new Promise<void>((resolve) => {
+      markSecondStarted = resolve;
+    });
+    const lifecycle = new TapLifecycleCoordinator({
+      platform: platform({
+        createCheckpoint: async ({ transition }) => {
+          if (transition.scopeId === 'first') {
+            markFirstStarted();
+            await firstGate;
+            return { checkpointReference: 'first-checkpoint' };
+          }
+          markSecondStarted();
+          return { checkpointReference: 'second-checkpoint' };
+        },
+      }),
+    });
+
+    const first = lifecycle.pause(request({ scopeId: 'first' }));
+    await firstStarted;
+    const second = lifecycle.pause(request({ scopeId: 'second' }));
+    await Promise.race([
+      secondStarted,
+      wait(100).then(() => {
+        throw new Error('the second scope was incorrectly queued behind the first');
+      }),
+    ]);
+    releaseFirst();
+
+    expect((await first).status).toBe('completed');
+    expect((await second).status).toBe('completed');
+  });
+
+  it('aggregates bounded deferrals and ignores voluntary deferrals when forced', async () => {
+    const lifecycle = new TapLifecycleCoordinator({
+      platform: platform(),
+      preDecision: { aggregation: 'max-delay', maxDelayMs: 20 },
+    });
+    lifecycle.on('prePause', () => ({ kind: 'defer', delayMs: 70 }));
+    lifecycle.on('prePause', () => ({ kind: 'defer', delayMs: 10 }));
+
+    const startedAt = Date.now();
+    const bounded = await lifecycle.pause(request());
+    const elapsed = Date.now() - startedAt;
+
+    expect(bounded.status).toBe('completed');
+    expect(bounded.decision).toEqual({
+      aggregation: 'max-delay',
+      kind: 'defer',
+      delayMs: 20,
+      honored: false,
+    });
+    expect(bounded.decisions.map((entry) => entry.honored)).toEqual([false, true]);
+    expect(elapsed).toBeGreaterThanOrEqual(15);
+
+    const forced = await lifecycle.pause(request({ force: true }));
+    expect(forced.status).toBe('completed');
+    expect(forced.decision).toEqual({
+      aggregation: 'max-delay',
+      kind: 'continue',
+      honored: false,
+    });
+    expect(forced.decisions.map((entry) => entry.honored)).toEqual([false, false]);
+  });
+
+  it('requires every pre-listener to defer when using all-decision aggregation', async () => {
+    const lifecycle = new TapLifecycleCoordinator({
+      platform: platform(),
+      preDecision: { aggregation: 'all', maxDelayMs: 20 },
+    });
+    lifecycle.on('prePause', () => ({ kind: 'defer', delayMs: 5 }));
+    lifecycle.on('prePause', () => ({ kind: 'continue' }));
+
+    const result = await lifecycle.pause(request());
+
+    expect(result.status).toBe('completed');
+    expect(result.decision).toEqual({
+      aggregation: 'all',
+      kind: 'continue',
+      honored: false,
+    });
+    expect(result.decisions.map((entry) => entry.honored)).toEqual([false, true]);
+  });
+
+  it('composes host cancellation with its own signal and reports a deadline once', async () => {
+    let entered!: () => void;
+    const enteredPrePause = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    let lifecycleSignal: AbortSignal | undefined;
+    const lifecycle = new TapLifecycleCoordinator({ platform: platform() });
+    lifecycle.on('prePause', async ({ transition }) => {
+      lifecycleSignal = transition.signal;
+      entered();
+      await new Promise<void>(() => undefined);
+      return { kind: 'continue' };
+    });
+
+    const external = new AbortController();
+    const pending = lifecycle.pause(request({ signal: external.signal }));
+    await enteredPrePause;
+    external.abort(new Error('host shutdown'));
+    const cancelled = await pending;
+
+    expect(cancelled.status).toBe('cancelled');
+    expect(cancelled.transition.signal).not.toBe(external.signal);
+    expect(lifecycleSignal).toBe(cancelled.transition.signal);
+    expect(cancelled.transition.signal.aborted).toBe(true);
+
+    const errors: string[] = [];
+    const deadlineLifecycle = new TapLifecycleCoordinator({
+      platform: platform({
+        authorize: async () => new Promise(() => undefined),
+      }),
+    });
+    deadlineLifecycle.on('lifecycleError', (event) => {
+      errors.push(event.kind);
+    });
+
+    const timedOut = await deadlineLifecycle.pause(
+      request({ deadline: Date.now() + 15 })
+    );
+    expect(timedOut.status).toBe('timed_out');
+    expect(timedOut.errors.filter((error) => error.kind === 'deadline')).toHaveLength(1);
+    expect(errors).toEqual(['deadline']);
+  });
+
+  it('does not run a queued transition after its absolute deadline expires', async () => {
+    let authorizations = 0;
+    const lifecycle = new TapLifecycleCoordinator({
+      platform: platform({
+        authorize: async () => {
+          authorizations += 1;
+          return { allowed: true };
+        },
+      }),
+    });
+    lifecycle.on('prePause', async () => {
+      await wait(30);
+      return { kind: 'continue' };
+    });
+
+    const first = lifecycle.pause(request({ deadline: Date.now() + 200 }));
+    await wait(2);
+    const queued = lifecycle.pause(request({ deadline: Date.now() + 10 }));
+    const [, expired] = await Promise.all([first, queued]);
+
+    expect(expired.status).toBe('timed_out');
+    expect(authorizations).toBe(1);
+  });
+
+  it('fans out committed and error observers serially without losing a checkpoint on resume', async () => {
+    const order: string[] = [];
+    const persistedReferences: string[] = [];
+    const lifecycle = new TapLifecycleCoordinator({
+      platform: platform({
+        createCheckpoint: async () => ({
+          checkpointReference: 'checkpoint:42',
+          value: { openPanels: ['settings'] },
+        }),
+        persistPaused: async ({ checkpointReference }) => {
+          persistedReferences.push(`paused:${checkpointReference}`);
+        },
+        loadCheckpoint: async ({ checkpointReference }) => {
+          persistedReferences.push(`loaded:${checkpointReference}`);
+          return { value: { openPanels: ['settings'] } };
+        },
+        persistResumed: async ({ checkpointReference }) => {
+          persistedReferences.push(`resumed:${checkpointReference}`);
+        },
+      }),
+    });
+    lifecycle.on('pause', async () => {
+      order.push('pause:one:start');
+      await wait(4);
+      order.push('pause:one:end');
+      throw new Error('first observer failed');
+    });
+    lifecycle.on('pause', () => {
+      order.push('pause:two');
+    });
+    lifecycle.on('lifecycleError', async () => {
+      order.push('error:one:start');
+      await wait(4);
+      order.push('error:one:end');
+      throw new Error('error observer failed');
+    });
+    lifecycle.on('lifecycleError', () => {
+      order.push('error:two');
+    });
+    lifecycle.on('resume', ({ checkpointReference }) => {
+      order.push(`resume:${checkpointReference}`);
+    });
+
+    const paused = await lifecycle.pause(request());
+    const resumed = await lifecycle.resume(request());
+
+    expect(paused.status).toBe('completed');
+    expect(paused.checkpointReference).toBe('checkpoint:42');
+    expect(resumed.status).toBe('completed');
+    expect(resumed.checkpointReference).toBe('checkpoint:42');
+    expect(persistedReferences).toEqual([
+      'paused:checkpoint:42',
+      'loaded:checkpoint:42',
+      'resumed:checkpoint:42',
+    ]);
+    expect(order).toEqual([
+      'pause:one:start',
+      'pause:one:end',
+      'error:one:start',
+      'error:one:end',
+      'error:two',
+      'pause:two',
+      'resume:checkpoint:42',
+    ]);
+    expect(paused.errors).toHaveLength(2);
+    expect(paused.errors.map((error) => error.phase)).toEqual([
+      'pause',
+      'lifecycleError',
+    ]);
+  });
+});

--- a/libs/zephyr-tap-runtime/src/index.ts
+++ b/libs/zephyr-tap-runtime/src/index.ts
@@ -1,0 +1,48 @@
+import type { TapLifecycle } from './types';
+
+declare module '@module-federation/runtime-core' {
+  interface ModuleFederation {
+    /** Installed by `createTapLifecycleRuntimePlugin` on trusted TAP hosts. */
+    tapLifecycle?: TapLifecycle;
+  }
+}
+
+declare module '@module-federation/runtime' {
+  interface ModuleFederation {
+    /** Installed by `createTapLifecycleRuntimePlugin` on trusted TAP hosts. */
+    tapLifecycle?: TapLifecycle;
+  }
+}
+
+export {
+  createTapLifecycleRuntimePlugin,
+  type TapLifecycleRuntimePlugin,
+} from './runtime-plugin';
+export { TapLifecycleCoordinator } from './tap-lifecycle';
+export type {
+  TapCheckpoint,
+  TapCommittedLifecycleListener,
+  TapLifecycle,
+  TapLifecycleAuthorizationContext,
+  TapLifecycleAuthorizationResult,
+  TapLifecycleContext,
+  TapLifecycleError,
+  TapLifecycleErrorKind,
+  TapLifecycleErrorListener,
+  TapLifecycleHooks,
+  TapLifecycleKind,
+  TapLifecyclePhase,
+  TapLifecyclePlatformAdapter,
+  TapLifecyclePluginOptions,
+  TapLifecycleRequest,
+  TapLifecycleResult,
+  TapLifecycleScope,
+  TapLifecycleStatus,
+  TapLifecycleTransition,
+  TapPreDecision,
+  TapPreDecisionAggregation,
+  TapPreDecisionPolicy,
+  TapPreDecisionRecord,
+  TapPreLifecycleListener,
+  TapResolvedPreDecision,
+} from './types';

--- a/libs/zephyr-tap-runtime/src/runtime-plugin.ts
+++ b/libs/zephyr-tap-runtime/src/runtime-plugin.ts
@@ -1,0 +1,57 @@
+import type {
+  ModuleFederation,
+  ModuleFederationRuntimePlugin,
+} from '@module-federation/runtime';
+import { TapLifecycleCoordinator } from './tap-lifecycle';
+import type { TapLifecycle, TapLifecyclePluginOptions } from './types';
+
+const lifecycleAttachment = Symbol.for('zephyr-tap-runtime.lifecycle');
+
+type HostWithTapLifecycle = ModuleFederation & {
+  tapLifecycle?: TapLifecycle;
+  [lifecycleAttachment]?: TapLifecycle;
+};
+
+export type TapLifecycleRuntimePlugin = ModuleFederationRuntimePlugin & {
+  apply(instance: ModuleFederation): void;
+};
+
+/**
+ * A runtime plugin intentionally limited to the trusted TAP host. Core may invoke `apply`
+ * once per hook group, so the non-enumerable attachment symbol makes registration
+ * idempotent for each Module Federation instance.
+ */
+export function createTapLifecycleRuntimePlugin(
+  options: TapLifecyclePluginOptions
+): TapLifecycleRuntimePlugin {
+  return {
+    name: 'zephyr-tap-runtime',
+    apply(instance: ModuleFederation) {
+      const host = instance as HostWithTapLifecycle;
+      if (host[lifecycleAttachment]) {
+        return;
+      }
+      if (host.tapLifecycle) {
+        throw new Error(
+          'A TAP lifecycle coordinator is already attached to this Module Federation instance.'
+        );
+      }
+
+      const lifecycle = new TapLifecycleCoordinator(options);
+      Object.defineProperty(host, lifecycleAttachment, {
+        configurable: false,
+        enumerable: false,
+        value: lifecycle,
+        writable: false,
+      });
+      Object.defineProperty(host, 'tapLifecycle', {
+        configurable: false,
+        enumerable: false,
+        value: lifecycle,
+        writable: false,
+      });
+    },
+  };
+}
+
+export default createTapLifecycleRuntimePlugin;

--- a/libs/zephyr-tap-runtime/src/tap-lifecycle.ts
+++ b/libs/zephyr-tap-runtime/src/tap-lifecycle.ts
@@ -1,0 +1,832 @@
+import type {
+  TapCheckpoint,
+  TapCommittedLifecycleListener,
+  TapLifecycle,
+  TapLifecycleContext,
+  TapLifecycleError,
+  TapLifecycleErrorKind,
+  TapLifecycleErrorListener,
+  TapLifecycleKind,
+  TapLifecyclePlatformAdapter,
+  TapLifecyclePluginOptions,
+  TapLifecycleRequest,
+  TapLifecycleResult,
+  TapLifecycleScope,
+  TapLifecycleStatus,
+  TapLifecycleTransition,
+  TapPreDecision,
+  TapPreDecisionAggregation,
+  TapPreDecisionRecord,
+  TapPreDecisionPolicy,
+  TapPreLifecycleListener,
+  TapResolvedPreDecision,
+} from './types';
+
+type ActiveStatus = Exclude<TapLifecycleStatus, 'completed' | 'denied' | 'failed'>;
+
+type ListenerOutcome<T> =
+  | { type: 'value'; value: T }
+  | { type: 'error'; error: unknown }
+  | { type: 'terminal'; status: ActiveStatus };
+
+type TransitionRuntime = {
+  readonly kind: TapLifecycleKind;
+  readonly scopeKey: string;
+  readonly transition: TapLifecycleTransition;
+  readonly controller: AbortController;
+  readonly cleanup: () => void;
+  timedOut: boolean;
+  deadlineReported: boolean;
+};
+
+type MutableResult = {
+  status: TapLifecycleStatus;
+  transition: TapLifecycleTransition;
+  checkpointReference?: string;
+  decision: TapResolvedPreDecision;
+  decisions: MutableDecisionRecord[];
+  errors: TapLifecycleError[];
+  denialReason?: string;
+};
+
+type MutableDecisionRecord = {
+  phase: TapPreDecisionRecord['phase'];
+  decision: TapPreDecision;
+  honored: boolean;
+};
+
+const VALID_SCOPES = new Set<TapLifecycleScope>([
+  'installation',
+  'realm',
+  'contribution',
+  'mount',
+]);
+
+let systemSequence = 0;
+let transitionSequence = 0;
+
+function createSystemId(): string {
+  const crypto = globalThis.crypto;
+  if (typeof crypto?.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  systemSequence += 1;
+  return `${Date.now().toString(36)}-${systemSequence.toString(36)}`;
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return (signal as AbortSignal & { reason?: unknown }).reason;
+}
+
+function isPreDecision(value: unknown): value is TapPreDecision {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'kind' in value &&
+    (value.kind === 'continue' || value.kind === 'defer')
+  );
+}
+
+function validateCheckpoint(value: unknown): TapCheckpoint | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('Checkpoint callbacks must return an object or undefined.');
+  }
+  const checkpoint = value as TapCheckpoint;
+  if (
+    checkpoint.checkpointReference !== undefined &&
+    (typeof checkpoint.checkpointReference !== 'string' ||
+      !checkpoint.checkpointReference.trim())
+  ) {
+    throw new TypeError('checkpointReference must be a non-empty string.');
+  }
+  return checkpoint;
+}
+
+function validateAuthorization(value: unknown): asserts value is {
+  allowed: boolean;
+  reason?: string;
+} {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    typeof (value as { allowed?: unknown }).allowed !== 'boolean'
+  ) {
+    throw new TypeError(
+      'authorize must return an explicit { allowed: boolean } decision.'
+    );
+  }
+  const reason = (value as { reason?: unknown }).reason;
+  if (reason !== undefined && typeof reason !== 'string') {
+    throw new TypeError('An authorization denial reason must be a string.');
+  }
+}
+
+function normalizeDecision(value: unknown): TapPreDecision {
+  if (value === undefined) {
+    return { kind: 'continue' };
+  }
+  if (!isPreDecision(value)) {
+    throw new TypeError(
+      'Lifecycle pre-listeners must return { kind: "continue" }, { kind: "defer", delayMs }, or undefined.'
+    );
+  }
+  if (value.kind === 'continue') {
+    return value;
+  }
+  if (
+    !Number.isSafeInteger(value.delayMs) ||
+    value.delayMs < 0 ||
+    (value.reason !== undefined && typeof value.reason !== 'string')
+  ) {
+    throw new TypeError(
+      'Lifecycle defer decisions require a non-negative integer delayMs and an optional string reason.'
+    );
+  }
+  return value;
+}
+
+function defaultDecision(
+  aggregation: TapPreDecisionAggregation,
+  honored = true
+): TapResolvedPreDecision {
+  return { aggregation, kind: 'continue', honored };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Host-only pause/resume coordinator. It deliberately does not model package state,
+ * persistence, authorization, or revocation; those operations remain supplied by the TAP
+ * platform adapter.
+ */
+export class TapLifecycleCoordinator implements TapLifecycle {
+  private readonly platform: TapLifecyclePlatformAdapter;
+  private readonly aggregation: TapPreDecisionAggregation;
+  private readonly maxDelayMs: number;
+  private readonly systemId = createSystemId();
+  private readonly queues = new Map<string, Promise<void>>();
+  private readonly epochs = new Map<string, number>();
+  private readonly checkpointReferences = new Map<string, string | undefined>();
+  private readonly prePauseListeners: TapPreLifecycleListener[] = [];
+  private readonly pauseListeners: TapCommittedLifecycleListener[] = [];
+  private readonly preResumeListeners: TapPreLifecycleListener[] = [];
+  private readonly resumeListeners: TapCommittedLifecycleListener[] = [];
+  private readonly errorListeners: TapLifecycleErrorListener[] = [];
+
+  constructor(options: TapLifecyclePluginOptions) {
+    if (!options?.platform) {
+      throw new TypeError('zephyr-tap-runtime requires a platform adapter.');
+    }
+    this.platform = options.platform;
+    const policy: TapPreDecisionPolicy = options.preDecision ?? {};
+    this.aggregation = policy.aggregation ?? 'max-delay';
+    this.maxDelayMs = policy.maxDelayMs ?? 0;
+    if (this.aggregation !== 'max-delay' && this.aggregation !== 'all') {
+      throw new TypeError('preDecision.aggregation must be "max-delay" or "all".');
+    }
+    if (!Number.isSafeInteger(this.maxDelayMs) || this.maxDelayMs < 0) {
+      throw new TypeError('preDecision.maxDelayMs must be a non-negative integer.');
+    }
+
+    const hooks = options.hooks;
+    if (hooks?.prePause) this.on('prePause', hooks.prePause);
+    if (hooks?.pause) this.on('pause', hooks.pause);
+    if (hooks?.preResume) this.on('preResume', hooks.preResume);
+    if (hooks?.resume) this.on('resume', hooks.resume);
+    if (hooks?.lifecycleError) this.on('lifecycleError', hooks.lifecycleError);
+  }
+
+  on(phase: 'prePause' | 'preResume', listener: TapPreLifecycleListener): () => void;
+  on(phase: 'pause' | 'resume', listener: TapCommittedLifecycleListener): () => void;
+  on(phase: 'lifecycleError', listener: TapLifecycleErrorListener): () => void;
+  on(
+    phase: 'prePause' | 'pause' | 'preResume' | 'resume' | 'lifecycleError',
+    listener:
+      | TapPreLifecycleListener
+      | TapCommittedLifecycleListener
+      | TapLifecycleErrorListener
+  ): () => void {
+    if (typeof listener !== 'function') {
+      throw new TypeError(`A ${phase} lifecycle listener must be a function.`);
+    }
+    const listeners = this.listenersFor(phase);
+    if (!listeners.includes(listener as never)) {
+      listeners.push(listener as never);
+    }
+    return () => {
+      const index = listeners.indexOf(listener as never);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    };
+  }
+
+  pause(request: TapLifecycleRequest): Promise<TapLifecycleResult> {
+    return this.start('pause', request);
+  }
+
+  resume(request: TapLifecycleRequest): Promise<TapLifecycleResult> {
+    return this.start('resume', request);
+  }
+
+  private start(
+    kind: TapLifecycleKind,
+    request: TapLifecycleRequest
+  ): Promise<TapLifecycleResult> {
+    try {
+      const runtime = this.createRuntime(kind, request);
+      return this.enqueue(runtime.scopeKey, () => this.execute(runtime));
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  private async execute(runtime: TransitionRuntime): Promise<TapLifecycleResult> {
+    const result = this.createResult(runtime.transition);
+    let checkpointReference = runtime.transition.checkpointReference;
+
+    try {
+      if (await this.finishIfTerminal(runtime, result)) {
+        return result;
+      }
+
+      const authorization = await this.invoke(
+        runtime,
+        () => this.platform.authorize(this.contextFor(runtime, checkpointReference)),
+        'authorize'
+      );
+      if (authorization.type === 'terminal') {
+        await this.finishTerminal(runtime, result, authorization.status);
+        return result;
+      }
+      if (authorization.type === 'error') {
+        await this.failPlatform(runtime, result, 'authorize', authorization.error);
+        return result;
+      }
+      try {
+        validateAuthorization(authorization.value);
+      } catch (error) {
+        await this.failPlatform(runtime, result, 'authorize', error);
+        return result;
+      }
+      if (!authorization.value.allowed) {
+        result.status = 'denied';
+        result.denialReason = authorization.value.reason;
+        return result;
+      }
+
+      if (runtime.kind === 'resume' && checkpointReference === undefined) {
+        checkpointReference = this.checkpointReferences.get(runtime.scopeKey);
+      }
+
+      const preStatus = await this.dispatchPre(runtime, result, checkpointReference);
+      if (preStatus) {
+        await this.finishTerminal(runtime, result, preStatus);
+        return result;
+      }
+
+      const resolvedDecision = result.decision;
+      if (resolvedDecision.kind === 'defer' && resolvedDecision.delayMs) {
+        const deferred = await this.invoke(
+          runtime,
+          () => delay(resolvedDecision.delayMs),
+          'prePause'
+        );
+        if (deferred.type === 'terminal') {
+          await this.finishTerminal(runtime, result, deferred.status);
+          return result;
+        }
+        if (deferred.type === 'error') {
+          await this.failPlatform(runtime, result, 'prePause', deferred.error);
+          return result;
+        }
+      }
+
+      if (await this.finishIfTerminal(runtime, result)) {
+        return result;
+      }
+
+      if (runtime.kind === 'pause') {
+        const checkpointOutcome = await this.invoke(
+          runtime,
+          () =>
+            this.platform.createCheckpoint(this.contextFor(runtime, checkpointReference)),
+          'checkpoint'
+        );
+        if (checkpointOutcome.type === 'terminal') {
+          await this.finishTerminal(runtime, result, checkpointOutcome.status);
+          return result;
+        }
+        if (checkpointOutcome.type === 'error') {
+          await this.failPlatform(runtime, result, 'checkpoint', checkpointOutcome.error);
+          return result;
+        }
+
+        let checkpoint: TapCheckpoint | undefined;
+        try {
+          checkpoint = validateCheckpoint(checkpointOutcome.value);
+        } catch (error) {
+          await this.failPlatform(runtime, result, 'checkpoint', error);
+          return result;
+        }
+        checkpointReference = checkpoint?.checkpointReference ?? checkpointReference;
+        const persisted = await this.invoke(
+          runtime,
+          () =>
+            this.platform.persistPaused(
+              this.contextFor(runtime, checkpointReference, checkpoint)
+            ),
+          'persistPaused'
+        );
+        if (persisted.type === 'terminal') {
+          await this.finishTerminal(runtime, result, persisted.status);
+          return result;
+        }
+        if (persisted.type === 'error') {
+          await this.failPlatform(runtime, result, 'persistPaused', persisted.error);
+          return result;
+        }
+        this.checkpointReferences.set(runtime.scopeKey, checkpointReference);
+        result.checkpointReference = checkpointReference;
+        await this.dispatchCommitted(
+          runtime,
+          result,
+          'pause',
+          this.contextFor(runtime, checkpointReference, checkpoint)
+        );
+      } else {
+        const restored = await this.invoke(
+          runtime,
+          () =>
+            this.platform.loadCheckpoint(this.contextFor(runtime, checkpointReference)),
+          'restoreCheckpoint'
+        );
+        if (restored.type === 'terminal') {
+          await this.finishTerminal(runtime, result, restored.status);
+          return result;
+        }
+        if (restored.type === 'error') {
+          await this.failPlatform(runtime, result, 'restoreCheckpoint', restored.error);
+          return result;
+        }
+
+        let checkpoint: TapCheckpoint | undefined;
+        try {
+          checkpoint = validateCheckpoint(restored.value);
+        } catch (error) {
+          await this.failPlatform(runtime, result, 'restoreCheckpoint', error);
+          return result;
+        }
+        checkpointReference = checkpoint?.checkpointReference ?? checkpointReference;
+        const persisted = await this.invoke(
+          runtime,
+          () =>
+            this.platform.persistResumed(
+              this.contextFor(runtime, checkpointReference, checkpoint)
+            ),
+          'persistResumed'
+        );
+        if (persisted.type === 'terminal') {
+          await this.finishTerminal(runtime, result, persisted.status);
+          return result;
+        }
+        if (persisted.type === 'error') {
+          await this.failPlatform(runtime, result, 'persistResumed', persisted.error);
+          return result;
+        }
+        // Resume must not lose a reference merely because loadCheckpoint only
+        // returns a value; the committed event/result retains the prior one.
+        result.checkpointReference = checkpointReference;
+        await this.dispatchCommitted(
+          runtime,
+          result,
+          'resume',
+          this.contextFor(runtime, checkpointReference, checkpoint)
+        );
+      }
+
+      await this.finishIfTerminal(runtime, result);
+      return result;
+    } finally {
+      runtime.cleanup();
+    }
+  }
+
+  private async dispatchPre(
+    runtime: TransitionRuntime,
+    result: MutableResult,
+    checkpointReference: string | undefined
+  ): Promise<ActiveStatus | undefined> {
+    const phase = runtime.kind === 'pause' ? 'prePause' : 'preResume';
+    const listeners =
+      runtime.kind === 'pause' ? this.prePauseListeners : this.preResumeListeners;
+    const context = this.contextFor(runtime, checkpointReference);
+
+    for (const listener of listeners.slice()) {
+      const outcome = await this.invoke(runtime, () => listener(context), phase);
+      if (outcome.type === 'terminal') {
+        return outcome.status;
+      }
+      if (outcome.type === 'error') {
+        await this.recordError(result, runtime, phase, 'callback', outcome.error);
+        result.decisions.push({ phase, decision: { kind: 'continue' }, honored: true });
+        continue;
+      }
+      try {
+        result.decisions.push({
+          phase,
+          decision: normalizeDecision(outcome.value),
+          honored: true,
+        });
+      } catch (error) {
+        await this.recordError(result, runtime, phase, 'invalid-decision', error);
+        result.decisions.push({ phase, decision: { kind: 'continue' }, honored: true });
+      }
+    }
+
+    result.decision = this.resolveDecision(runtime, result.decisions);
+    return undefined;
+  }
+
+  private async dispatchCommitted(
+    runtime: TransitionRuntime,
+    result: MutableResult,
+    phase: 'pause' | 'resume',
+    context: TapLifecycleContext
+  ): Promise<void> {
+    const listeners = phase === 'pause' ? this.pauseListeners : this.resumeListeners;
+    for (const listener of listeners.slice()) {
+      const outcome = await this.invoke(runtime, () => listener(context), phase);
+      if (outcome.type === 'terminal') {
+        await this.finishTerminal(runtime, result, outcome.status);
+        return;
+      }
+      if (outcome.type === 'error') {
+        await this.recordError(result, runtime, phase, 'callback', outcome.error);
+      }
+    }
+  }
+
+  private resolveDecision(
+    runtime: TransitionRuntime,
+    records: MutableDecisionRecord[]
+  ): TapResolvedPreDecision {
+    const deferrals = records.filter((record) => record.decision.kind === 'defer');
+    if (!deferrals.length) {
+      return defaultDecision(this.aggregation);
+    }
+    if (runtime.transition.force) {
+      for (const record of deferrals) record.honored = false;
+      return defaultDecision(this.aggregation, false);
+    }
+    if (this.aggregation === 'all' && deferrals.length !== records.length) {
+      for (const record of deferrals) record.honored = false;
+      return defaultDecision(this.aggregation, false);
+    }
+    const requested = Math.max(
+      ...deferrals.map((record) =>
+        record.decision.kind === 'defer' ? record.decision.delayMs : 0
+      )
+    );
+    const bounded = Math.min(
+      requested,
+      this.maxDelayMs,
+      Math.max(0, runtime.transition.deadline - Date.now())
+    );
+    for (const record of deferrals) {
+      record.honored =
+        record.decision.kind === 'defer' &&
+        bounded > 0 &&
+        record.decision.delayMs <= bounded;
+    }
+    if (!bounded) {
+      return defaultDecision(this.aggregation, false);
+    }
+    return {
+      aggregation: this.aggregation,
+      kind: 'defer',
+      delayMs: bounded,
+      honored: bounded === requested,
+    };
+  }
+
+  private async failPlatform(
+    runtime: TransitionRuntime,
+    result: MutableResult,
+    phase: Exclude<TapLifecycleError['phase'], 'lifecycleError'>,
+    error: unknown
+  ): Promise<void> {
+    result.status = 'failed';
+    await this.recordError(result, runtime, phase, 'platform', error);
+  }
+
+  private async finishIfTerminal(
+    runtime: TransitionRuntime,
+    result: MutableResult
+  ): Promise<boolean> {
+    const status = this.statusOf(runtime);
+    if (!status) return false;
+    await this.finishTerminal(runtime, result, status);
+    return true;
+  }
+
+  private async finishTerminal(
+    runtime: TransitionRuntime,
+    result: MutableResult,
+    status: ActiveStatus
+  ): Promise<void> {
+    if (result.status !== 'completed') return;
+    result.status = status;
+    result.decision = defaultDecision(this.aggregation, false);
+    if (status !== 'timed_out' || runtime.deadlineReported) return;
+
+    runtime.deadlineReported = true;
+    await this.recordError(
+      result,
+      runtime,
+      'lifecycleError',
+      'deadline',
+      new Error(
+        `TAP ${runtime.kind} transition "${runtime.transition.transitionId}" exceeded its deadline.`
+      )
+    );
+  }
+
+  private async recordError(
+    result: MutableResult | undefined,
+    runtime: TransitionRuntime,
+    phase: TapLifecycleError['phase'],
+    kind: TapLifecycleErrorKind,
+    error: unknown
+  ): Promise<void> {
+    const event: TapLifecycleError = {
+      phase,
+      transition: runtime.transition,
+      kind,
+      error,
+    };
+    result?.errors.push(event);
+
+    for (const listener of this.errorListeners.slice()) {
+      const outcome = await this.invoke(
+        runtime,
+        () => listener(event),
+        'lifecycleError',
+        true
+      );
+      if (outcome.type === 'error') {
+        result?.errors.push({
+          phase: 'lifecycleError',
+          transition: runtime.transition,
+          kind: 'callback',
+          error: outcome.error,
+        });
+      }
+    }
+  }
+
+  private async invoke<T>(
+    runtime: TransitionRuntime,
+    callback: () => T | Promise<T>,
+    phase: Exclude<TapLifecycleError['phase'], 'lifecycleError'> | 'lifecycleError',
+    allowTerminalStart = false
+  ): Promise<ListenerOutcome<T>> {
+    const initial = this.statusOf(runtime);
+    if (initial && !allowTerminalStart) {
+      return { type: 'terminal', status: initial };
+    }
+
+    let pending: Promise<Exclude<ListenerOutcome<T>, { type: 'terminal' }>>;
+    try {
+      pending = Promise.resolve(callback()).then(
+        (value) => ({ type: 'value', value }) as const,
+        (error) => ({ type: 'error', error }) as const
+      );
+    } catch (error) {
+      pending = Promise.resolve({ type: 'error', error });
+    }
+
+    const afterStart = this.statusOf(runtime);
+    if (afterStart) {
+      this.observeLateFailure(runtime, pending, phase);
+      return { type: 'terminal', status: afterStart };
+    }
+
+    const terminal = this.waitForTerminal(runtime);
+    const outcome = await Promise.race([pending, terminal.promise]);
+    terminal.cleanup();
+    if (outcome.type === 'terminal') {
+      this.observeLateFailure(runtime, pending, phase);
+    }
+    return outcome;
+  }
+
+  private observeLateFailure<T>(
+    runtime: TransitionRuntime,
+    pending: Promise<Exclude<ListenerOutcome<T>, { type: 'terminal' }>>,
+    phase: TapLifecycleError['phase']
+  ): void {
+    void pending.then((outcome) => {
+      if (outcome.type === 'error' && phase !== 'lifecycleError') {
+        void this.recordError(undefined, runtime, phase, 'callback', outcome.error);
+      }
+    });
+  }
+
+  private waitForTerminal(runtime: TransitionRuntime): {
+    promise: Promise<{ type: 'terminal'; status: ActiveStatus }>;
+    cleanup: () => void;
+  } {
+    let resolved = false;
+    let resolveTerminal!: (outcome: { type: 'terminal'; status: ActiveStatus }) => void;
+    const promise = new Promise<{ type: 'terminal'; status: ActiveStatus }>((resolve) => {
+      resolveTerminal = resolve;
+    });
+    const onAbort = () => {
+      const status = this.statusOf(runtime);
+      if (!status || resolved) return;
+      resolved = true;
+      resolveTerminal({ type: 'terminal', status });
+    };
+    runtime.transition.signal.addEventListener('abort', onAbort, { once: true });
+    onAbort();
+    return {
+      promise,
+      cleanup: () => runtime.transition.signal.removeEventListener('abort', onAbort),
+    };
+  }
+
+  private statusOf(runtime: TransitionRuntime): ActiveStatus | undefined {
+    if (!runtime.timedOut && Date.now() >= runtime.transition.deadline) {
+      runtime.timedOut = true;
+      runtime.controller.abort(
+        new Error(
+          `TAP ${runtime.kind} transition "${runtime.transition.transitionId}" exceeded its deadline.`
+        )
+      );
+    }
+    if (runtime.timedOut) return 'timed_out';
+    return runtime.transition.signal.aborted ? 'cancelled' : undefined;
+  }
+
+  private contextFor(
+    runtime: TransitionRuntime,
+    checkpointReference: string | undefined,
+    checkpoint?: TapCheckpoint
+  ): TapLifecycleContext {
+    return {
+      kind: runtime.kind,
+      transition: runtime.transition,
+      checkpointReference,
+      checkpoint,
+    };
+  }
+
+  private createRuntime(
+    kind: TapLifecycleKind,
+    request: TapLifecycleRequest
+  ): TransitionRuntime {
+    this.validateRequest(request);
+    const scopeKey = `${request.scope}\u0000${request.scopeId}`;
+    const previousEpoch = this.epochs.get(scopeKey);
+    const lifecycleEpoch = request.lifecycleEpoch ?? (previousEpoch ?? -1) + 1;
+    if (previousEpoch !== undefined && lifecycleEpoch <= previousEpoch) {
+      throw new RangeError(
+        `lifecycleEpoch for ${request.scope}:${request.scopeId} must be greater than ${previousEpoch}.`
+      );
+    }
+    this.epochs.set(scopeKey, lifecycleEpoch);
+
+    const controller = new AbortController();
+    const requestedAt = Date.now();
+    transitionSequence += 1;
+    const transition = Object.freeze({
+      scope: request.scope,
+      scopeId: request.scopeId,
+      reason: request.reason,
+      force: request.force,
+      deadline: request.deadline,
+      checkpointReference: request.checkpointReference,
+      context: request.context,
+      transitionId: `tap:${this.systemId}:${transitionSequence.toString(36)}`,
+      lifecycleEpoch,
+      requestedAt,
+      signal: controller.signal,
+    }) as TapLifecycleTransition;
+
+    let cleanedUp = false;
+    const onExternalAbort = () => controller.abort(getAbortReason(request.signal!));
+    if (request.signal?.aborted) {
+      onExternalAbort();
+    } else {
+      request.signal?.addEventListener('abort', onExternalAbort, { once: true });
+    }
+    let runtime!: TransitionRuntime;
+    const timeout = setTimeout(
+      () => {
+        runtime.timedOut = true;
+        controller.abort(
+          new Error(
+            `TAP ${kind} transition "${transition.transitionId}" exceeded its deadline.`
+          )
+        );
+      },
+      Math.max(0, request.deadline - requestedAt)
+    );
+
+    runtime = {
+      kind,
+      scopeKey,
+      transition,
+      controller,
+      timedOut: false,
+      deadlineReported: false,
+      cleanup: () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        clearTimeout(timeout);
+        request.signal?.removeEventListener('abort', onExternalAbort);
+      },
+    };
+    return runtime;
+  }
+
+  private validateRequest(request: TapLifecycleRequest): void {
+    if (!VALID_SCOPES.has(request.scope)) {
+      throw new TypeError('A valid TAP lifecycle scope is required.');
+    }
+    if (typeof request.scopeId !== 'string' || !request.scopeId.trim()) {
+      throw new TypeError('scopeId must be a non-empty string.');
+    }
+    if (typeof request.reason !== 'string' || !request.reason.trim()) {
+      throw new TypeError('reason must be a non-empty string.');
+    }
+    if (typeof request.force !== 'boolean') {
+      throw new TypeError('force must be a boolean.');
+    }
+    if (!Number.isFinite(request.deadline)) {
+      throw new TypeError('deadline must be a finite absolute timestamp.');
+    }
+    if (
+      request.lifecycleEpoch !== undefined &&
+      (!Number.isSafeInteger(request.lifecycleEpoch) || request.lifecycleEpoch < 0)
+    ) {
+      throw new TypeError('lifecycleEpoch must be a non-negative integer.');
+    }
+    if (
+      request.checkpointReference !== undefined &&
+      (typeof request.checkpointReference !== 'string' ||
+        !request.checkpointReference.trim())
+    ) {
+      throw new TypeError('checkpointReference must be a non-empty string.');
+    }
+  }
+
+  private createResult(transition: TapLifecycleTransition): MutableResult {
+    return {
+      status: 'completed',
+      transition,
+      decision: defaultDecision(this.aggregation),
+      decisions: [],
+      errors: [],
+    };
+  }
+
+  private enqueue<T>(scopeKey: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.queues.get(scopeKey) ?? Promise.resolve();
+    const queued = previous.catch(() => undefined).then(task);
+    const tail = queued.then(
+      () => undefined,
+      () => undefined
+    );
+    this.queues.set(scopeKey, tail);
+    void tail.then(() => {
+      if (this.queues.get(scopeKey) === tail) this.queues.delete(scopeKey);
+    });
+    return queued;
+  }
+
+  private listenersFor(
+    phase: 'prePause' | 'pause' | 'preResume' | 'resume' | 'lifecycleError'
+  ): Array<
+    TapPreLifecycleListener | TapCommittedLifecycleListener | TapLifecycleErrorListener
+  > {
+    switch (phase) {
+      case 'prePause':
+        return this.prePauseListeners;
+      case 'pause':
+        return this.pauseListeners;
+      case 'preResume':
+        return this.preResumeListeners;
+      case 'resume':
+        return this.resumeListeners;
+      case 'lifecycleError':
+        return this.errorListeners;
+    }
+  }
+}

--- a/libs/zephyr-tap-runtime/src/types.ts
+++ b/libs/zephyr-tap-runtime/src/types.ts
@@ -1,0 +1,188 @@
+/**
+ * Host-owned scopes. A scope is part of the lock key, so pausing one mounted contribution
+ * cannot block an unrelated realm or mount.
+ */
+export type TapLifecycleScope = 'installation' | 'realm' | 'contribution' | 'mount';
+
+export type TapLifecycleKind = 'pause' | 'resume';
+
+export type TapLifecyclePhase =
+  | 'authorize'
+  | 'prePause'
+  | 'checkpoint'
+  | 'persistPaused'
+  | 'preResume'
+  | 'restoreCheckpoint'
+  | 'persistResumed'
+  | 'pause'
+  | 'resume'
+  | 'lifecycleError';
+
+export type TapLifecycleStatus =
+  | 'completed'
+  | 'cancelled'
+  | 'timed_out'
+  | 'denied'
+  | 'failed';
+
+/**
+ * An absolute-deadline transition request issued by the trusted host. Package code never
+ * supplies IDs, timestamps, or a mutable cancellation signal.
+ */
+export interface TapLifecycleRequest {
+  scope: TapLifecycleScope;
+  scopeId: string;
+  reason: string;
+  force: boolean;
+  /** Absolute Unix time in milliseconds. */
+  deadline: number;
+  /** Optional host cancellation composed with the transition deadline. */
+  signal?: AbortSignal;
+  /** A host-restored epoch must strictly increase inside its scope. */
+  lifecycleEpoch?: number;
+  /** An explicit checkpoint takes precedence over the last committed pause. */
+  checkpointReference?: string;
+  context?: Readonly<Record<string, unknown>>;
+}
+
+export interface TapLifecycleTransition extends Omit<
+  TapLifecycleRequest,
+  'lifecycleEpoch' | 'signal'
+> {
+  readonly transitionId: string;
+  readonly lifecycleEpoch: number;
+  readonly requestedAt: number;
+  readonly signal: AbortSignal;
+}
+
+export type TapPreDecision =
+  | { kind: 'continue' }
+  | { kind: 'defer'; delayMs: number; reason?: string };
+
+export type TapPreDecisionAggregation = 'max-delay' | 'all';
+
+/**
+ * `all` only delays when every listener asks to defer. In that case the longest requested
+ * delay is used, subject to the same host cap/deadline as `max-delay`.
+ */
+export interface TapPreDecisionPolicy {
+  aggregation?: TapPreDecisionAggregation;
+  /** Voluntary deferral cap, in milliseconds. Defaults to zero. */
+  maxDelayMs?: number;
+}
+
+export interface TapCheckpoint {
+  checkpointReference?: string;
+  value?: unknown;
+}
+
+export interface TapLifecycleContext {
+  readonly kind: TapLifecycleKind;
+  readonly transition: TapLifecycleTransition;
+  readonly checkpointReference?: string;
+  readonly checkpoint?: TapCheckpoint;
+}
+
+export interface TapLifecycleAuthorizationContext extends Omit<
+  TapLifecycleContext,
+  'checkpoint'
+> {}
+
+export type TapLifecycleAuthorizationResult =
+  | { allowed: true }
+  | { allowed: false; reason?: string };
+
+/**
+ * The platform remains the authority for authorization and durable state. The runtime
+ * package only orders these callbacks and publishes observations.
+ */
+export interface TapLifecyclePlatformAdapter {
+  authorize(
+    context: TapLifecycleAuthorizationContext
+  ): TapLifecycleAuthorizationResult | Promise<TapLifecycleAuthorizationResult>;
+  createCheckpoint(
+    context: TapLifecycleContext
+  ): TapCheckpoint | undefined | Promise<TapCheckpoint | undefined>;
+  persistPaused(context: TapLifecycleContext): void | Promise<void>;
+  loadCheckpoint(
+    context: TapLifecycleContext
+  ): TapCheckpoint | undefined | Promise<TapCheckpoint | undefined>;
+  persistResumed(context: TapLifecycleContext): void | Promise<void>;
+}
+
+export type TapPreLifecycleListener = (
+  context: TapLifecycleContext
+) => TapPreDecision | undefined | Promise<TapPreDecision | undefined>;
+
+export type TapCommittedLifecycleListener = (
+  context: TapLifecycleContext
+) => void | Promise<void>;
+
+export type TapLifecycleErrorKind =
+  | 'callback'
+  | 'invalid-decision'
+  | 'platform'
+  | 'deadline';
+
+export interface TapLifecycleError {
+  readonly phase: TapLifecyclePhase;
+  readonly transition: TapLifecycleTransition;
+  readonly kind: TapLifecycleErrorKind;
+  readonly error: unknown;
+}
+
+export type TapLifecycleErrorListener = (
+  event: TapLifecycleError
+) => void | Promise<void>;
+
+export interface TapLifecycleHooks {
+  prePause?: TapPreLifecycleListener;
+  pause?: TapCommittedLifecycleListener;
+  preResume?: TapPreLifecycleListener;
+  resume?: TapCommittedLifecycleListener;
+  lifecycleError?: TapLifecycleErrorListener;
+}
+
+export interface TapPreDecisionRecord {
+  readonly phase: 'prePause' | 'preResume';
+  readonly decision: TapPreDecision;
+  readonly honored: boolean;
+}
+
+export type TapResolvedPreDecision =
+  | {
+      readonly aggregation: TapPreDecisionAggregation;
+      readonly kind: 'continue';
+      readonly honored: boolean;
+    }
+  | {
+      readonly aggregation: TapPreDecisionAggregation;
+      readonly kind: 'defer';
+      readonly honored: boolean;
+      readonly delayMs: number;
+    };
+
+export interface TapLifecycleResult {
+  readonly status: TapLifecycleStatus;
+  readonly transition: TapLifecycleTransition;
+  /** Retained for a successful resume even when the loader returns no new ref. */
+  readonly checkpointReference?: string;
+  readonly decision: TapResolvedPreDecision;
+  readonly decisions: ReadonlyArray<TapPreDecisionRecord>;
+  readonly errors: ReadonlyArray<TapLifecycleError>;
+  readonly denialReason?: string;
+}
+
+export interface TapLifecyclePluginOptions {
+  platform: TapLifecyclePlatformAdapter;
+  hooks?: TapLifecycleHooks;
+  preDecision?: TapPreDecisionPolicy;
+}
+
+export interface TapLifecycle {
+  pause(request: TapLifecycleRequest): Promise<TapLifecycleResult>;
+  resume(request: TapLifecycleRequest): Promise<TapLifecycleResult>;
+  on(phase: 'prePause' | 'preResume', listener: TapPreLifecycleListener): () => void;
+  on(phase: 'pause' | 'resume', listener: TapCommittedLifecycleListener): () => void;
+  on(phase: 'lifecycleError', listener: TapLifecycleErrorListener): () => void;
+}

--- a/libs/zephyr-tap-runtime/tsconfig.json
+++ b/libs/zephyr-tap-runtime/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "lib": ["ES2022"],
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "stripInternal": true,
+    "target": "ES2022",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "composite": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "types": ["node"],
+    "rootDir": "./src",
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2230,6 +2230,27 @@ importers:
         specifier: catalog:typescript
         version: 5.9.3
 
+  libs/zephyr-tap-runtime:
+    devDependencies:
+      '@module-federation/runtime':
+        specifier: catalog:module-federation
+        version: 2.7.0
+      '@module-federation/runtime-core':
+        specifier: ^2.7.0
+        version: 2.7.0
+      '@rslib/core':
+        specifier: catalog:rslib
+        version: 0.23.2(@module-federation/runtime-tools@2.7.0)(core-js@3.49.0)(typescript@5.9.3)
+      '@rstest/core':
+        specifier: catalog:rstest
+        version: 0.11.1(@module-federation/runtime-tools@2.7.0)(core-js@3.49.0)(jsdom@29.1.1)
+      '@types/node':
+        specifier: catalog:typescript
+        version: 24.13.3
+      typescript:
+        specifier: catalog:typescript
+        version: 5.9.3
+
   libs/zephyr-nuxt-module:
     dependencies:
       nuxt:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,9 @@
       "path": "./libs/zephyr-rspress-plugin/tsconfig.json"
     },
     {
+      "path": "./libs/zephyr-tap-runtime/tsconfig.json"
+    },
+    {
       "path": "./libs/zephyr-webpack-plugin/tsconfig.json"
     },
     {


### PR DESCRIPTION
### What's added in this PR?

Adds `zephyr-tap-runtime`, a public, host-only Module Federation RuntimePlugin for TAP pause/resume coordination.

- Installs `instance.tapLifecycle` through an idempotent `apply(instance)` attachment; it is never auto-injected into remote builds.
- Owns typed, scope-serial pause/resume transitions with monotonic epochs, unique IDs, absolute deadlines, cancellation, forced-transition handling, and bounded pre-transition deferrals.
- Explicitly aggregates pre-transition decisions and serially fans out committed/error observers without allowing one observer failure to suppress later observers.
- Keeps authorization, checkpoint creation/loading, and durable state persistence in a required host-supplied adapter.
- Retains `checkpointReference` on the committed resume observation/result.

#### Screenshots

Not applicable — runtime-only package.

### What's the issues or discussion related to this PR ?

This moves the TAP-specific lifecycle model out of [module-federation/core#4891](https://github.com/module-federation/core/pull/4891) in response to maintainer feedback. It is intentionally separate from [#488](https://github.com/ZephyrCloudIO/zephyr-packages/pull/488), which remains focused on `tap-app` publication and manifest integrity.

### What are the steps to test this PR?

- `pnpm --filter zephyr-tap-runtime run test`
- `pnpm --filter zephyr-tap-runtime run typecheck`
- `pnpm --filter zephyr-tap-runtime run build`
- `pnpm exec turbo run test --filter=zephyr-tap-runtime --force`
- `pnpm lint`
- `pnpm exec oxfmt --check libs/zephyr-tap-runtime tsconfig.json pnpm-lock.yaml`

The test suite covers repeated `apply`, same- and distinct-scope ordering, cancellation/deadlines, decision aggregation, forced transitions, observer isolation, and checkpoint-preserving resume.

### Documentation update for this PR (if applicable)?

Package usage and host-ownership constraints are documented in `libs/zephyr-tap-runtime/README.md`. No external documentation PR is needed before this draft is reviewed.

### (Optional) What's left to be done for this PR?

The TAP host must explicitly register the plugin and provide its authorization/checkpoint/persistence adapter; this package intentionally does not inject itself into application builds.

### (Optional) What's the potential risk and how to mitigate it?

The plugin only changes behavior when a trusted host registers it. Its adapter is required and typed, transition work is scope-isolated and bounded, and tests cover cancellation, deadlines, and observer failures.

### (Required) Pre-PR/Merge checklist

- [ ] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test