### PR TITLE
ci: publish on github-hosted runners for npm provenance

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -31,7 +31,7 @@ jobs:
   publish-canary:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_type == 'canary'
     environment: canary-publishing # For security approval
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -89,7 +89,7 @@ jobs:
   # Automatic prerelease publishing
   publish-prerelease:
     if: github.event_name == 'release' && github.event.action == 'prereleased'
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -161,7 +161,7 @@ jobs:
   # Automatic release publishing
   publish-release:
     if: github.event_name == 'release' && github.event.action == 'released'
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Problem

Canary publishing failed with:

> Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: \"self-hosted\". Only \"github-hosted\" runners are supported when publishing with provenance.

## Root cause

The publish jobs ran on `depot-ubuntu-latest` (Depot self-hosted runners). npm's sigstore provenance verification only trusts runners that report `RUNNER_ENVIRONMENT=github-hosted`. Depot runners report as `self-hosted`, so provenance bundle verification is rejected — while every package sets `"provenance": true` and the jobs pass `--provenance` / `NPM_CONFIG_PROVENANCE`.

## Fix

Switch the three publish jobs (`publish-canary`, `publish-prerelease`, `publish-release`) from `depot-ubuntu-latest` to GitHub-hosted `ubuntu-latest` so provenance attestations succeed.

Only the publish jobs are affected; other workflows continue to use Depot runners.