### PR TITLE
fix(vite-plugin-zephyr): dedupe mfConfig against injected MF plugin

### DIFF
--- a/libs/vite-plugin-zephyr/src/lib/internal/mf-vite-etl/federation-metadata.ts
+++ b/libs/vite-plugin-zephyr/src/lib/internal/mf-vite-etl/federation-metadata.ts
@@ -65,7 +65,11 @@ function stableJson(value: unknown): string {
     .join(',')}}`;
 }
 
-function getConfigIdentities(config: ModuleFederationOptions): string[] {
+/**
+ * A Vite MF container is publicly identified by its `name` and emitted entry `filename`.
+ * Two configs that share either identity describe the same container.
+ */
+export function getConfigIdentities(config: ModuleFederationOptions): string[] {
   return [
     nonEmptyString(config.name) ? `name:${config.name}` : undefined,
     nonEmptyString(config.filename) ? `entry:${config.filename}` : undefined,

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.spec.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.spec.ts
@@ -458,6 +458,69 @@ describe('vite-plugin-zephyr', () => {
     ]);
   });
 
+  test('does not conflict when withZephyr({ mfConfig }) also surfaces a normalized MF plugin', async () => {
+    // Regression: `withZephyr({ mfConfig })` injects the @module-federation/vite
+    // plugin from the same config. That plugin later reports a normalized `_options`
+    // (expanded `exposes`/`shared`, extra MF defaults) that shares the container
+    // identity of the source config. Registering both must not trip the publication
+    // conflict guard. https://github.com/ZephyrCloudIO/zephyr-packages (mfConfig dedupe)
+    const mfConfig = {
+      name: 'vite_remote',
+      filename: 'remoteEntry.js',
+      exposes: { './Button': './src/Button' },
+      shared: {
+        react: { singleton: true },
+        'react-dom': { singleton: true },
+      },
+    };
+    // Model @module-federation/vite normalizing the config it was handed.
+    mocks.federation.mockImplementation((config) => [
+      {
+        name: 'module-federation-vite',
+        _options: {
+          name: config.name,
+          filename: config.filename,
+          exposes: { './Button': { import: './src/Button' } },
+          shared: {
+            react: {
+              name: 'react',
+              version: '19.2.5',
+              shareConfig: { singleton: true, requiredVersion: '^19.2.5' },
+            },
+            'react-dom': {
+              name: 'react-dom',
+              version: '19.2.5',
+              shareConfig: { singleton: true, requiredVersion: '^19.2.5' },
+            },
+          },
+          runtimePlugins: config.runtimePlugins,
+          shareScope: 'default',
+          manifest: false,
+        },
+      },
+    ]);
+
+    const plugins = withZephyr({ mfConfig }) as Plugin[];
+    const plugin = plugins.find((candidate) => candidate.name === 'with-zephyr')!;
+    const config = resolvedConfig({
+      client: { consumer: 'client', build: { outDir: 'dist/client' } },
+    });
+    // The federation plugin injected by withZephyr() is present in the resolved config,
+    // reporting the normalized `_options` for the same container.
+    config.plugins = plugins.filter(
+      (candidate) => candidate.name === 'module-federation-vite'
+    );
+
+    // Before the fix this rejected with
+    // "Conflicting Vite Module Federation configuration for name:vite_remote".
+    await expect(
+      (plugin.configResolved as (config: ResolvedConfig) => void | Promise<void>)(config)
+    ).resolves.not.toThrow();
+
+    // withZephyr() injected the federation plugin exactly once from `mfConfig`.
+    expect(mocks.federation).toHaveBeenCalledTimes(1);
+  });
+
   test('rejects noncanonical TAP output paths instead of repairing and rehashing them', async () => {
     process.env['ZE_FAIL_BUILD'] = 'true';
     const plugin = withZephyr({ target: 'tap-app' })[0] as Plugin;

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
@@ -43,6 +43,7 @@ import {
 import { extract_remotes_dependencies } from './internal/mf-vite-etl/extract-mf-vite-remotes';
 import {
   createViteModuleFederationPublicationMetadata,
+  getConfigIdentities,
   type ViteModuleFederationPublicationMetadata,
 } from './internal/mf-vite-etl/federation-metadata';
 import type { ZephyrInternalOptions } from './internal/types/zephyr-internal-options';
@@ -354,6 +355,15 @@ function withZephyrCore(options: WithZephyrOptions = {}): Plugin {
   const mfConfigSources = toModuleFederationConfigArray(options.mfConfig).map(
     configureModuleFederationRuntime
   );
+  // When `mfConfig` is provided, `withZephyr()` injects the @module-federation/vite
+  // plugin from that same config. That plugin later surfaces a normalized `_options`
+  // (expanded `exposes`/`shared`, extra MF defaults) that describes the very same
+  // container as the source config above. Auto-registering it too would push two
+  // divergent configs sharing one identity, which the publication merge rejects as a
+  // conflict. Record the owned identities so those already-known plugins are skipped.
+  const ownedConfigIdentities = new Set(
+    mfConfigSources.flatMap((config) => getConfigIdentities(config))
+  );
   let environmentNames: string[] = [];
   let environmentMetadata = new Map<string, ViteEnvironmentMetadata>();
   let sharedOutputRoot: string | undefined;
@@ -368,9 +378,19 @@ function withZephyrCore(options: WithZephyrOptions = {}): Plugin {
     configs: readonly ModuleFederationOptions[]
   ) => {
     for (const config of configs) {
+      // Skip plugins whose container identity was already provided via
+      // `options.mfConfig`; `withZephyr()` injected them, so their normalized
+      // `_options` is a duplicate of a source config we already hold.
+      const identities = getConfigIdentities(config);
+      if (identities.some((identity) => ownedConfigIdentities.has(identity))) {
+        continue;
+      }
       const runtimeConfigured = configureModuleFederationRuntime(config);
       if (!mfConfigSources.includes(runtimeConfigured)) {
         mfConfigSources.push(runtimeConfigured);
+        for (const identity of getConfigIdentities(runtimeConfigured)) {
+          ownedConfigIdentities.add(identity);
+        }
       }
     }
   };


### PR DESCRIPTION
## Problem

Every Vite remote using the `withZephyr({ mfConfig })` shorthand fails at build time with:

```
Error: Failed to deploy local build.
Conflicting Vite Module Federation configuration for name:<remote>.
    at mergeViteModuleFederationConfigs (.../mf-vite-etl/federation-metadata.mjs)
```

This was surfaced by a canary of `vite-plugin-zephyr` in the `react-vite-rspack-webpack` example (the Vite remote `withZephyr({ mfConfig })`); rspack/webpack remotes are unaffected.

## Root cause

`withZephyr({ mfConfig })` injects the `@module-federation/vite` plugin built from the provided `mfConfig`. In `withZephyrCore`, MF configs are collected from **two** sources:

1. `options.mfConfig` — the **raw** config (after `ensureRuntimePlugin`), seeded into `mfConfigSources`.
2. `extract_mf_plugins(config.plugins).map(p => p._options)` — the **same** config after `@module-federation/vite` **normalizes** it (`exposes` → `{ import }`, `shared` gets resolved versions/`shareConfig`, plus defaults like `shareScope`, `implementation`, `manifest`, …).

Both share the container identity (`name` / `filename`) but have different fingerprints, so `mergeViteModuleFederationConfigs` treats them as two conflicting remotes and throws.

Introduced by #488 (tap-app federation publishing), which added the dual-source registration and the identity-conflict guard. The guard only skips **exact-fingerprint** duplicates, never the legitimate raw-vs-normalized pair that the `withZephyr({ mfConfig })` path always produces.

## Fix

Track the container identities owned by `options.mfConfig` and skip auto-extracted plugin configs whose identity matches — `withZephyr()` injected those plugins itself, so their normalized `_options` is a duplicate of a source config we already hold. Separately-registered MF plugins (TAP / user-added `@module-federation/vite`) are still picked up, and genuine conflicts between distinct plugins still throw.

- `getConfigIdentities` is exported from `federation-metadata.ts` and reused (no duplicated identity logic).
- `registerModuleFederationConfigs` skips configs whose identity is already owned, and records identities of newly registered configs.

## Testing

- New regression test reproduces the raw-vs-normalized collision; it fails on `main` (throws the conflict) and passes with this fix.
- `turbo run test --filter=vite-plugin-zephyr`: 72 tests pass.
- Verified end-to-end by overlaying the rebuilt `dist` into the failing example: the Vite remote and the full `pnpm build` (webpack + rspack + remote + host) build and deploy to Zephyr's edge, with the host resolving all three remotes.