### PR TITLE
fix(zephyr-agent): run git reads per-command to fix Windows CI git info

### DIFF
--- a/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-ci.test.ts
+++ b/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-ci.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import type { Mock } from '@rstest/core';
 
-import { exec as node_exec } from 'node:child_process';
+import { execFile as node_execFile } from 'node:child_process';
 import { getGitInfo } from '../ze-util-get-git-info';
 
 rs.mock('node:child_process', () => ({
-  exec: rs.fn(),
+  execFile: rs.fn(),
 }));
 
 rs.mock('../../node-persist/secret-token', () => ({
@@ -27,23 +27,48 @@ rs.mock('is-ci', () => ({ default: true }));
 
 let originalEnv: NodeJS.ProcessEnv;
 
+/**
+ * Maps a git subcommand (arg list) to the stdout it should produce.
+ *
+ * Any command not present in the map resolves to empty output, which mirrors a git
+ * command that exited non-zero (the source treats that as "unavailable").
+ */
+type GitOutputs = Record<string, string>;
+
 describe('getGitInfo - CI environments', () => {
-  const mockExec = node_exec as unknown as Mock;
+  const mockExecFile = node_execFile as unknown as Mock;
   type ExecCallback = (error: Error | null, stdout?: unknown, stderr?: string) => void;
-  const mockExecWithCallback = (
-    implementation: (command: string, callback: ExecCallback) => unknown
+
+  /**
+   * ExecFile is called as execFile('git', args, options, callback). This helper lets each
+   * test respond based on the git args instead of a single chained shell string, matching
+   * the per-command implementation.
+   */
+  const mockGit = (
+    resolve: (args: string[]) => { stdout?: string; error?: Error } | undefined
   ) => {
-    mockExec.mockImplementation(
-      (command: string, optionsOrCallback: unknown, callback?: ExecCallback) => {
-        const resolvedCallback =
-          typeof optionsOrCallback === 'function'
-            ? (optionsOrCallback as ExecCallback)
-            : callback;
-        if (!resolvedCallback) throw new Error('expected child_process.exec callback');
-        return implementation(command, resolvedCallback);
+    mockExecFile.mockImplementation(
+      (_file: string, args: string[], _options: unknown, callback?: ExecCallback) => {
+        const cb = (typeof _options === 'function' ? _options : callback) as ExecCallback;
+        if (!cb) throw new Error('expected child_process.execFile callback');
+        const result = resolve(args) ?? { error: new Error('command failed') };
+        if (result.error) {
+          cb(result.error, '', 'fatal: command failed');
+        } else {
+          cb(null, { stdout: result.stdout ?? '', stderr: '' });
+        }
+        return undefined;
       }
     );
   };
+
+  /** Convenience builder for the common "git is available" scenario. */
+  const gitAvailable = (outputs: GitOutputs) =>
+    mockGit((args) => {
+      const key = args.join(' ');
+      if (key in outputs) return { stdout: outputs[key] };
+      return { stdout: '' };
+    });
 
   beforeEach(() => {
     rs.clearAllMocks();
@@ -67,28 +92,16 @@ describe('getGitInfo - CI environments', () => {
   });
 
   it('should fail immediately in CI when git info is not available', async () => {
-    mockExecWithCallback((cmd, callback) => {
-      if (typeof callback === 'function') {
-        callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-      } else {
-        return Promise.reject(new Error('Not a git repository'));
-      }
-    });
+    // Every git command fails => not a git repository.
+    mockGit(() => ({ error: new Error('Not a git repository') }));
 
-    await expect(getGitInfo()).rejects.toThrow();
-    try {
-      await getGitInfo();
-    } catch (error) {
-      expect((error as Error).message).toContain(
-        'Stable Git branch and commit information is required in CI environments'
-      );
-    }
+    await expect(getGitInfo()).rejects.toThrow(
+      'Stable Git branch and commit information is required in CI environments'
+    );
   });
 
   it('does not let configured identity create timestamp metadata in CI', async () => {
-    mockExecWithCallback((_cmd, callback) => {
-      callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-    });
+    mockGit(() => ({ error: new Error('Not a git repository') }));
 
     await expect(
       getGitInfo('/workspace/configured-no-git', {
@@ -99,22 +112,18 @@ describe('getGitInfo - CI environments', () => {
       'Stable Git branch and commit information is required in CI environments'
     );
     expect(
-      mockExec.mock.calls.some(([command]) => String(command).includes('--global'))
+      mockExecFile.mock.calls.some(([, args]) => (args as string[]).includes('--global'))
     ).toBe(false);
   });
 
   it('should work normally in CI when git is available', async () => {
-    mockExecWithCallback((cmd, callback) => {
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'CI User',
-        'ci@example.com',
-        'https://github.com/example/repo.git',
-        'main',
-        'abc123def456',
-        'v1.0.0',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'CI User',
+      'log -1 --pretty=format:%ae': 'ci@example.com',
+      'config --get remote.origin.url': 'https://github.com/example/repo.git',
+      'symbolic-ref --short HEAD': 'main',
+      'rev-parse HEAD': 'abc123def456',
+      'tag --points-at HEAD': 'v1.0.0',
     });
 
     const result = await getGitInfo();
@@ -130,18 +139,12 @@ describe('getGitInfo - CI environments', () => {
 
   it('uses configured identity when CI has commit metadata but no origin', async () => {
     const context = '/workspace/apps/configured-ci';
-    mockExecWithCallback((cmd, callback) => {
-      if (cmd.includes('git tag --points-at HEAD')) {
-        callback(null, { stdout: '', stderr: '' });
-        return;
-      }
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      callback(null, {
-        stdout: ['CI User', 'ci@example.com', '', 'main', 'abc123def456'].join(
-          `\n${delimiter}\n`
-        ),
-        stderr: '',
-      });
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'CI User',
+      'log -1 --pretty=format:%ae': 'ci@example.com',
+      'symbolic-ref --short HEAD': 'main',
+      'rev-parse HEAD': 'abc123def456',
+      // no origin, no tags
     });
 
     const result = await getGitInfo(context, {
@@ -154,38 +157,35 @@ describe('getGitInfo - CI environments', () => {
       project: 'configured-project',
     });
     expect(result.git.commit).toBe('abc123def456');
-    for (const call of mockExec.mock.calls) {
-      expect(call[1]).toEqual({ cwd: context });
+    for (const call of mockExecFile.mock.calls) {
+      expect(call[2]).toEqual({ cwd: context });
     }
   });
 
   it('should use last commit author in CI instead of git config', async () => {
-    let capturedCommand = '';
-    mockExecWithCallback((cmd, callback) => {
-      if (cmd.includes('git tag --points-at HEAD')) {
-        callback(null, { stdout: 'v1.0.0\n', stderr: '' });
-        return;
-      }
-      capturedCommand = cmd;
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'Last Committer',
-        'committer@example.com',
-        'https://github.com/example/repo.git',
-        'main',
-        'abc123def456',
-        'v1.0.0',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    const capturedArgs: string[][] = [];
+    mockGit((args) => {
+      capturedArgs.push(args);
+      const outputs: GitOutputs = {
+        'log -1 --pretty=format:%an': 'Last Committer',
+        'log -1 --pretty=format:%ae': 'committer@example.com',
+        'config --get remote.origin.url': 'https://github.com/example/repo.git',
+        'symbolic-ref --short HEAD': 'main',
+        'rev-parse HEAD': 'abc123def456',
+        'tag --points-at HEAD': 'v1.0.0',
+      };
+      const key = args.join(' ');
+      return { stdout: key in outputs ? outputs[key] : '' };
     });
 
     await getGitInfo();
 
+    const joined = capturedArgs.map((args) => args.join(' '));
     // In CI, should use git log instead of git config for user info
-    expect(capturedCommand).toContain("git log -1 --pretty=format:'%an'");
-    expect(capturedCommand).toContain("git log -1 --pretty=format:'%ae'");
-    expect(capturedCommand).not.toContain('git config user.name');
-    expect(capturedCommand).not.toContain('git config user.email');
+    expect(joined).toContain('log -1 --pretty=format:%an');
+    expect(joined).toContain('log -1 --pretty=format:%ae');
+    expect(joined).not.toContain('config user.name');
+    expect(joined).not.toContain('config user.email');
   });
 
   it('should detect branch from GitHub Actions env vars when git returns HEAD', async () => {
@@ -194,17 +194,12 @@ describe('getGitInfo - CI environments', () => {
     process.env.GITHUB_REF_NAME = 'feature/ci-branch';
     process.env.GITHUB_REF = 'refs/heads/feature/ci-branch';
 
-    mockExecWithCallback((cmd, callback) => {
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'CI User',
-        'ci@example.com',
-        'https://github.com/example/repo.git',
-        'HEAD', // Detached HEAD state in CI
-        'abc123def456',
-        '',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'CI User',
+      'log -1 --pretty=format:%ae': 'ci@example.com',
+      'config --get remote.origin.url': 'https://github.com/example/repo.git',
+      'symbolic-ref --short HEAD': 'HEAD', // Detached HEAD state in CI
+      'rev-parse HEAD': 'abc123def456',
     });
 
     const result = await getGitInfo();
@@ -223,17 +218,12 @@ describe('getGitInfo - CI environments', () => {
     process.env.CI_COMMIT_BRANCH = 'develop';
     process.env.CI_COMMIT_REF_NAME = 'develop';
 
-    mockExecWithCallback((cmd, callback) => {
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'GitLab Runner',
-        'runner@gitlab.com',
-        'https://gitlab.com/example/project.git',
-        'HEAD', // Detached HEAD state
-        'def456abc123',
-        '',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'GitLab Runner',
+      'log -1 --pretty=format:%ae': 'runner@gitlab.com',
+      'config --get remote.origin.url': 'https://gitlab.com/example/project.git',
+      'symbolic-ref --short HEAD': 'HEAD', // Detached HEAD state
+      'rev-parse HEAD': 'def456abc123',
     });
 
     const result = await getGitInfo();
@@ -249,17 +239,13 @@ describe('getGitInfo - CI environments', () => {
     process.env.BUILD_SOURCEBRANCHNAME = 'feature/azure';
     process.env.BUILD_SOURCEBRANCH = 'refs/heads/feature/azure';
 
-    mockExecWithCallback((cmd, callback) => {
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'Azure Runner',
-        'runner@dev.azure.com',
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'Azure Runner',
+      'log -1 --pretty=format:%ae': 'runner@dev.azure.com',
+      'config --get remote.origin.url':
         'git@ssh.dev.azure.com:v3/BusinessDomain/AddSecure/AddSecure',
-        'HEAD',
-        'azure123abc',
-        '',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+      'symbolic-ref --short HEAD': 'HEAD',
+      'rev-parse HEAD': 'azure123abc',
     });
 
     const result = await getGitInfo();
@@ -277,17 +263,12 @@ describe('getGitInfo - CI environments', () => {
     process.env.GITHUB_BASE_REF = 'main';
     process.env.GITHUB_REF = 'refs/pull/123/merge';
 
-    mockExecWithCallback((cmd, callback) => {
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'PR Author',
-        'author@example.com',
-        'https://github.com/example/repo.git',
-        'HEAD', // PR merge refs are detached
-        'merge123abc',
-        '',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'PR Author',
+      'log -1 --pretty=format:%ae': 'author@example.com',
+      'config --get remote.origin.url': 'https://github.com/example/repo.git',
+      'symbolic-ref --short HEAD': 'HEAD', // PR merge refs are detached
+      'rev-parse HEAD': 'merge123abc',
     });
 
     const result = await getGitInfo();
@@ -298,17 +279,12 @@ describe('getGitInfo - CI environments', () => {
 
   it('should use git branch when CI env vars are not available', async () => {
     // No CI env vars set, only is-ci returns true
-    mockExecWithCallback((cmd, callback) => {
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'Developer',
-        'dev@example.com',
-        'https://github.com/example/repo.git',
-        'feature/actual-branch', // Git can still resolve branch sometimes
-        'abc123',
-        '',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'Developer',
+      'log -1 --pretty=format:%ae': 'dev@example.com',
+      'config --get remote.origin.url': 'https://github.com/example/repo.git',
+      'symbolic-ref --short HEAD': 'feature/actual-branch',
+      'rev-parse HEAD': 'abc123',
     });
 
     const result = await getGitInfo();
@@ -317,20 +293,12 @@ describe('getGitInfo - CI environments', () => {
   });
 
   it('fails closed when detached CI has no provider branch metadata', async () => {
-    mockExecWithCallback((cmd, callback) => {
-      if (cmd.includes('git tag --points-at HEAD')) {
-        callback(null, { stdout: '', stderr: '' });
-        return;
-      }
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'CI User',
-        'ci@example.com',
-        'https://github.com/example/repo.git',
-        'HEAD',
-        'abc123def456',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'CI User',
+      'log -1 --pretty=format:%ae': 'ci@example.com',
+      'config --get remote.origin.url': 'https://github.com/example/repo.git',
+      'symbolic-ref --short HEAD': 'HEAD',
+      'rev-parse HEAD': 'abc123def456',
     });
 
     await expect(getGitInfo()).rejects.toThrow(
@@ -339,21 +307,40 @@ describe('getGitInfo - CI environments', () => {
   });
 
   it('should fail in CI when repository has no commits yet', async () => {
-    mockExecWithCallback((_cmd, callback) => {
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'CI User',
-        'ci@example.com',
-        'https://github.com/example/repo.git',
-        'main',
-        'no-git-commit',
-        '',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    // rev-parse HEAD fails on an unborn branch (no commits).
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'CI User',
+      'log -1 --pretty=format:%ae': 'ci@example.com',
+      'config --get remote.origin.url': 'https://github.com/example/repo.git',
+      'symbolic-ref --short HEAD': 'main',
+      // no 'rev-parse HEAD' entry => empty => no-git-commit
     });
 
     await expect(getGitInfo()).rejects.toThrow(
       'Stable Git branch and commit information is required in CI environments'
     );
+  });
+
+  it('reads the commit hash even when other subcommands emit unusual output (windows regression)', async () => {
+    // Regression for a shell-precedence bug where chaining git reads with
+    // `&&`/`||` in a single cmd.exe command dropped the commit hash on Windows.
+    // Running each command independently keeps the commit populated.
+    gitAvailable({
+      'log -1 --pretty=format:%an': 'CI User',
+      'log -1 --pretty=format:%ae': 'ci@example.com',
+      'config --get remote.origin.url': 'https://github.com/example/repo.git',
+      'symbolic-ref --short HEAD': 'main',
+      'rev-parse HEAD': 'deadbeefcafe1234',
+    });
+
+    const result = await getGitInfo();
+
+    expect(result.git.commit).toBe('deadbeefcafe1234');
+    expect(result.git.branch).toBe('main');
+    // Each read is a discrete execFile call - never a single chained shell string.
+    for (const call of mockExecFile.mock.calls) {
+      expect(call[0]).toBe('git');
+      expect(Array.isArray(call[1])).toBe(true);
+    }
   });
 });

--- a/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-non-git.test.ts
+++ b/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-non-git.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, rs } from '@rstest/core';
 import type { Mock } from '@rstest/core';
 
-import { exec as node_exec } from 'node:child_process';
+import { execFile as node_execFile } from 'node:child_process';
 import { getGitInfo } from '../ze-util-get-git-info';
 
 rs.mock('node:child_process', () => ({
-  exec: rs.fn(),
+  execFile: rs.fn(),
 }));
 
 rs.mock('../../node-persist/secret-token', () => ({
@@ -45,23 +45,52 @@ rs.mock('../detect-monorepo', () => ({
   getMonorepoRootPackageJson: rs.fn().mockResolvedValue(null),
 }));
 
+type GitOutputs = Record<string, string>;
+
 describe('getGitInfo - non-git environments', () => {
-  const mockExec = node_exec as unknown as Mock;
+  const mockExecFile = node_execFile as unknown as Mock;
   type ExecCallback = (error: Error | null, stdout?: unknown, stderr?: string) => void;
-  const mockExecWithCallback = (
-    implementation: (command: string, callback: ExecCallback) => unknown
+
+  /**
+   * ExecFile is called as execFile('git', args, options, callback). Tests reply
+   * per-command using the git args, matching the per-command implementation.
+   */
+  const mockGit = (
+    resolve: (args: string[]) => { stdout?: string; error?: Error } | undefined
   ) => {
-    mockExec.mockImplementation(
-      (command: string, optionsOrCallback: unknown, callback?: ExecCallback) => {
-        const resolvedCallback =
-          typeof optionsOrCallback === 'function'
-            ? (optionsOrCallback as ExecCallback)
-            : callback;
-        if (!resolvedCallback) throw new Error('expected child_process.exec callback');
-        return implementation(command, resolvedCallback);
+    mockExecFile.mockImplementation(
+      (_file: string, args: string[], _options: unknown, callback?: ExecCallback) => {
+        const cb = (typeof _options === 'function' ? _options : callback) as ExecCallback;
+        if (!cb) throw new Error('expected child_process.execFile callback');
+        const result = resolve(args) ?? { error: new Error('command failed') };
+        if (result.error) {
+          cb(result.error, '', 'fatal: command failed');
+        } else {
+          cb(null, { stdout: result.stdout ?? '', stderr: '' });
+        }
+        return undefined;
       }
     );
   };
+
+  /** Every git command fails => no local repository at all. */
+  const noGitRepo = () => mockGit(() => ({ error: new Error('Not a git repository') }));
+
+  /** Local repo unavailable, but global config resolves. */
+  const globalGitOnly = (outputs: GitOutputs) =>
+    mockGit((args) => {
+      const key = args.join(' ');
+      if (key in outputs) return { stdout: outputs[key] };
+      return { error: new Error('Not a git repository') };
+    });
+
+  const gitAvailable = (outputs: GitOutputs) =>
+    mockGit((args) => {
+      const key = args.join(' ');
+      if (key in outputs) return { stdout: outputs[key] };
+      return { stdout: '' };
+    });
+
   let mockGitLog: Mock;
   let mockLogFn: Mock;
   let mockGetPackageJson: Mock;
@@ -112,26 +141,9 @@ describe('getGitInfo - non-git environments', () => {
   });
 
   it('should fall back to global git config when local repo not available', async () => {
-    mockExecWithCallback((cmd, callback) => {
-      if (typeof callback === 'function') {
-        // Mock exec with callback
-        if (cmd.includes('git config --global user.name')) {
-          callback(null, { stdout: 'Global User\n', stderr: '' });
-        } else if (cmd.includes('git config --global user.email')) {
-          callback(null, { stdout: 'global@example.com\n', stderr: '' });
-        } else {
-          callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-        }
-      } else {
-        // Mock promisified exec
-        if (cmd.includes('git config --global user.name')) {
-          return Promise.resolve({ stdout: 'Global User\n', stderr: '' });
-        } else if (cmd.includes('git config --global user.email')) {
-          return Promise.resolve({ stdout: 'global@example.com\n', stderr: '' });
-        } else {
-          return Promise.reject(new Error('Not a git repository'));
-        }
-      }
+    globalGitOnly({
+      'config --global user.name': 'Global User',
+      'config --global user.email': 'global@example.com',
     });
 
     const result = await getGitInfo();
@@ -147,14 +159,9 @@ describe('getGitInfo - non-git environments', () => {
   it('threads an explicit context through fallback package and monorepo reads', async () => {
     const context = '/workspace/apps/context-app';
     const config = {};
-    mockExecWithCallback((cmd, callback) => {
-      if (cmd.includes('git config --global user.name')) {
-        callback(null, { stdout: 'Global User\n', stderr: '' });
-      } else if (cmd.includes('git config --global user.email')) {
-        callback(null, { stdout: 'global@example.com\n', stderr: '' });
-      } else {
-        callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-      }
+    globalGitOnly({
+      'config --global user.name': 'Global User',
+      'config --global user.email': 'global@example.com',
     });
 
     await getGitInfo(context, config);
@@ -165,13 +172,7 @@ describe('getGitInfo - non-git environments', () => {
   });
 
   it('should fall back to API user info when neither local nor global git available', async () => {
-    mockExecWithCallback((cmd, callback) => {
-      if (typeof callback === 'function') {
-        callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-      } else {
-        return Promise.reject(new Error('Not a git repository'));
-      }
-    });
+    noGitRepo();
 
     const result = await getGitInfo();
 
@@ -184,18 +185,13 @@ describe('getGitInfo - non-git environments', () => {
   });
 
   it('should still work normally when git is available', async () => {
-    mockExecWithCallback((cmd, callback) => {
-      // Extract the delimiter from the command - now it's a static string
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'John Doe',
-        'john@example.com',
-        'https://github.com/example/repo.git',
-        'main',
-        'abc123def456',
-        'v1.0.0',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    gitAvailable({
+      'config user.name': 'John Doe',
+      'config user.email': 'john@example.com',
+      'config --get remote.origin.url': 'https://github.com/example/repo.git',
+      'symbolic-ref --short HEAD': 'main',
+      'rev-parse HEAD': 'abc123def456',
+      'tag --points-at HEAD': 'v1.0.0',
     });
 
     const result = await getGitInfo();
@@ -213,18 +209,12 @@ describe('getGitInfo - non-git environments', () => {
 
   it('uses configured identity without origin and runs every local git read in context', async () => {
     const context = '/workspace/apps/configured-app';
-    mockExecWithCallback((cmd, callback) => {
-      if (cmd.includes('git tag --points-at HEAD')) {
-        callback(null, { stdout: '', stderr: '' });
-        return;
-      }
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      callback(null, {
-        stdout: ['John Doe', 'john@example.com', '', 'main', 'abc123def456'].join(
-          `\n${delimiter}\n`
-        ),
-        stderr: '',
-      });
+    gitAvailable({
+      'config user.name': 'John Doe',
+      'config user.email': 'john@example.com',
+      'symbolic-ref --short HEAD': 'main',
+      'rev-parse HEAD': 'abc123def456',
+      // no origin, no tags
     });
 
     const result = await getGitInfo(context, {
@@ -237,29 +227,19 @@ describe('getGitInfo - non-git environments', () => {
       project: 'configured-project',
     });
     expect(result.git.commit).toBe('abc123def456');
-    expect(mockExec.mock.calls).toHaveLength(2);
-    for (const call of mockExec.mock.calls) {
-      expect(call[1]).toEqual({ cwd: context });
+    for (const call of mockExecFile.mock.calls) {
+      expect(call[2]).toEqual({ cwd: context });
     }
   });
 
   it('lets a partial config override one field inferred from origin', async () => {
-    mockExecWithCallback((cmd, callback) => {
-      if (cmd.includes('git tag --points-at HEAD')) {
-        callback(null, { stdout: '', stderr: '' });
-        return;
-      }
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      callback(null, {
-        stdout: [
-          'John Doe',
-          'john@example.com',
-          'https://github.com/inferred-org/inferred-project.git',
-          'main',
-          'abc123def456',
-        ].join(`\n${delimiter}\n`),
-        stderr: '',
-      });
+    gitAvailable({
+      'config user.name': 'John Doe',
+      'config user.email': 'john@example.com',
+      'config --get remote.origin.url':
+        'https://github.com/inferred-org/inferred-project.git',
+      'symbolic-ref --short HEAD': 'main',
+      'rev-parse HEAD': 'abc123def456',
     });
 
     const result = await getGitInfo('/workspace/app', { org: 'configured-org' });
@@ -271,17 +251,12 @@ describe('getGitInfo - non-git environments', () => {
   });
 
   it('should parse remote origin even when repository has no commits yet', async () => {
-    mockExecWithCallback((_cmd, callback) => {
-      const delimiter = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
-      const output = [
-        'John Doe',
-        'john@example.com',
-        'git@github.com:nsttt/git-test.git',
-        'main',
-        'no-git-commit',
-        '',
-      ].join(`\n${delimiter}\n`);
-      callback(null, { stdout: output, stderr: '' });
+    gitAvailable({
+      'config user.name': 'John Doe',
+      'config user.email': 'john@example.com',
+      'config --get remote.origin.url': 'git@github.com:nsttt/git-test.git',
+      'symbolic-ref --short HEAD': 'main',
+      // no 'rev-parse HEAD' => commit becomes no-git-commit (allowed outside CI)
     });
 
     const result = await getGitInfo();
@@ -297,13 +272,7 @@ describe('getGitInfo - non-git environments', () => {
   });
 
   it('should use API user org and package.json project when git is not available', async () => {
-    mockExecWithCallback((cmd, callback) => {
-      if (typeof callback === 'function') {
-        callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-      } else {
-        return Promise.reject(new Error('Not a git repository'));
-      }
-    });
+    noGitRepo();
 
     const result1 = await getGitInfo();
     const result2 = await getGitInfo();
@@ -323,13 +292,7 @@ describe('getGitInfo - non-git environments', () => {
         version: '1.0.0',
       });
 
-      mockExecWithCallback((cmd, callback) => {
-        if (typeof callback === 'function') {
-          callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-        } else {
-          return Promise.reject(new Error('Not a git repository'));
-        }
-      });
+      noGitRepo();
 
       const result = await getGitInfo();
 
@@ -352,13 +315,7 @@ describe('getGitInfo - non-git environments', () => {
         },
       ]);
 
-      mockExecWithCallback((cmd, callback) => {
-        if (typeof callback === 'function') {
-          callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-        } else {
-          return Promise.reject(new Error('Not a git repository'));
-        }
-      });
+      noGitRepo();
 
       const result = await getGitInfo();
 
@@ -381,13 +338,7 @@ describe('getGitInfo - non-git environments', () => {
         },
       ]);
 
-      mockExecWithCallback((cmd, callback) => {
-        if (typeof callback === 'function') {
-          callback(new Error('Not a git repository'), '', 'fatal: not a git repository');
-        } else {
-          return Promise.reject(new Error('Not a git repository'));
-        }
-      });
+      noGitRepo();
 
       const result = await getGitInfo();
 

--- a/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
@@ -1,5 +1,5 @@
 import isCI from 'is-ci';
-import { exec as node_exec } from 'node:child_process';
+import { execFile as node_execFile } from 'node:child_process';
 import { sep } from 'node:path';
 import { promisify } from 'node:util';
 import type { ZephyrPluginOptions } from 'zephyr-edge-contract';
@@ -21,7 +21,28 @@ import {
   type ResolvedZephyrConfig,
 } from './zephyr-config';
 
-const exec = promisify(node_exec);
+const execFile = promisify(node_execFile);
+
+/**
+ * Runs a single git subcommand without a shell.
+ *
+ * Using `execFile` (instead of a shell `exec` with chained `&&`/`||` operators) avoids
+ * cross-platform shell parsing bugs. Windows spawns `cmd.exe`, which parses operator
+ * precedence and quoting differently than the POSIX `sh` used on Linux/macOS, and
+ * previously left the commit slot empty in CI.
+ *
+ * Returns the trimmed stdout, or `null` when the command exits non-zero or produces no
+ * output.
+ */
+async function runGit(args: string[], context: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile('git', args, { cwd: context });
+    const trimmed = stdout.trim();
+    return trimmed === '' ? null : trimmed;
+  } catch {
+    return null;
+  }
+}
 
 export interface ZeGitInfo {
   app: Pick<ZephyrPluginOptions['app'], 'org' | 'project'>;
@@ -60,8 +81,7 @@ async function gatherGitInfo(
   try {
     const { name, email, remoteOrigin, branch, commit, tags, stdout } = await loadGitInfo(
       hasToken,
-      context,
-      zephyrConfig
+      context
     );
 
     if (!hasToken && (!name || !email)) {
@@ -132,16 +152,20 @@ async function gatherGitInfo(
   }
 }
 
-// Static delimiter that's unique enough to avoid conflicts with git output
-const GIT_OUTPUT_DELIMITER = '---ZEPHYR-GIT-DELIMITER-8f3a2b1c---';
 const NO_GIT_COMMIT = 'no-git-commit';
-const NO_REMOTE_ORIGIN = '---ZEPHYR-NO-REMOTE-ORIGIN---';
 
-/** Loads all data in a single command to avoid multiple executions. */
+/**
+ * Loads git metadata by running each subcommand separately via `execFile`.
+ *
+ * Previously all reads were joined into a single shell command using `&&`/`||` operators
+ * and a delimiter. That relied on shell operator precedence and quoting, which `cmd.exe`
+ * (Windows) parses differently than POSIX `sh`, causing the commit hash to be dropped in
+ * Windows CI. Running each command without a shell removes that entire class of
+ * cross-platform bugs.
+ */
 async function loadGitInfo(
   hasSecretToken: boolean,
-  context: string,
-  zephyrConfig: ResolvedZephyrConfig
+  context: string
 ): Promise<{
   name: string;
   email: string;
@@ -153,114 +177,103 @@ async function loadGitInfo(
 }> {
   const automated = isCI || hasSecretToken;
 
-  const command = [
+  const [name, email, remoteOrigin, gitBranch, rawCommit, tags] = await Promise.all([
     // Inside CI environments, the last committer should be the actor
     // and not the actual logged git user which sometimes might just be a bot
-    automated ? "git log -1 --pretty=format:'%an'" : 'git config user.name',
-    automated ? "git log -1 --pretty=format:'%ae'" : 'git config user.email',
-    // A complete explicit identity does not need an origin, but retaining the command in
-    // the combined read keeps the fast one-process path when an origin does exist.
-    hasConfiguredApp(zephyrConfig)
-      ? `git config --get remote.origin.url || echo ${NO_REMOTE_ORIGIN}`
-      : 'git config --get remote.origin.url',
+    automated
+      ? runGit(['log', '-1', '--pretty=format:%an'], context)
+      : runGit(['config', 'user.name'], context),
+    automated
+      ? runGit(['log', '-1', '--pretty=format:%ae'], context)
+      : runGit(['config', 'user.email'], context),
+    // A complete explicit identity does not need an origin; a missing origin is
+    // tolerated and normalized to an empty string below.
+    runGit(['config', '--get', 'remote.origin.url'], context),
     // Handles unborn branches in fresh repositories
-    'git symbolic-ref --short HEAD || git rev-parse --abbrev-ref HEAD',
+    loadGitBranch(context),
     // No commits yet should not block local build metadata extraction
-    `git rev-parse HEAD || echo ${NO_GIT_COMMIT}`,
-  ].join(` && echo ${GIT_OUTPUT_DELIMITER} && `);
+    runGit(['rev-parse', 'HEAD'], context),
+    loadGitTags(context),
+  ]);
 
-  try {
-    const { stdout } = await exec(command, { cwd: context });
-
-    const [name, email, rawRemoteOrigin, gitBranch, commit] = stdout
-      .trim()
-      .split(GIT_OUTPUT_DELIMITER)
-      .map((x) => x.trim());
-    const remoteOrigin = rawRemoteOrigin === NO_REMOTE_ORIGIN ? '' : rawRemoteOrigin;
-    const tags = await loadGitTags(context);
-
-    // In CI environments with detached HEAD, git returns "HEAD" as branch name
-    // Try to get branch from CI environment variables first
-    let branch = gitBranch;
-    if (isCI && (gitBranch === 'HEAD' || !gitBranch)) {
-      const ciInfo = detectCIBranch();
-      if (ciInfo.branch) {
-        branch = ciInfo.branch;
-        ze_log.git(
-          `Detected branch from ${ciInfo.platform} environment variables: ${branch}`,
-          {
-            platform: ciInfo.platform,
-            branch,
-            isPR: ciInfo.isPR,
-            gitBranch,
-          }
-        );
-      } else {
-        ze_log.git(
-          `Branch detection in CI failed. Git returned: "${gitBranch}", no CI env vars available`,
-          { platform: ciInfo.platform, gitBranch }
-        );
-      }
-    }
-
-    if (isCI && (!branch || branch === 'HEAD')) {
-      throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
-        message:
-          'Git branch is required in CI environments. Configure the CI provider branch variables or check out a named branch.',
-      });
-    }
-
-    if (isCI && (!commit || commit === NO_GIT_COMMIT)) {
-      throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
-        message:
-          'Git commit hash is required in CI environments. Ensure this repository has commit history.',
-      });
-    }
-
-    return {
-      name,
-      email,
-      remoteOrigin,
-      branch,
-      commit,
-      tags,
-      stdout,
-    };
-  } catch (cause: unknown) {
-    const error = cause as Error & { stderr?: string };
+  // A completely unavailable git repository surfaces as null for the core
+  // reads; mirror the previous "not a git repository" failure so callers fall
+  // back to global/API metadata (or fail closed in CI).
+  if (name === null && email === null && gitBranch === null && rawCommit === null) {
     throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
-      cause,
-      data: { command, delimiter: GIT_OUTPUT_DELIMITER },
-      message: error?.stderr || error.message,
+      message: 'Not a git repository',
+      data: { context },
     });
   }
+
+  const commit = rawCommit ?? NO_GIT_COMMIT;
+
+  // Synthesize a combined stdout for diagnostics/downstream error messages that
+  // still expect a single blob to inspect.
+  const stdout = [name, email, remoteOrigin, gitBranch, commit].join('\n');
+
+  // In CI environments with detached HEAD, git returns "HEAD" as branch name.
+  // Try to get branch from CI environment variables first.
+  let branch = gitBranch;
+  if (isCI && (gitBranch === 'HEAD' || !gitBranch)) {
+    const ciInfo = detectCIBranch();
+    if (ciInfo.branch) {
+      branch = ciInfo.branch;
+      ze_log.git(
+        `Detected branch from ${ciInfo.platform} environment variables: ${branch}`,
+        {
+          platform: ciInfo.platform,
+          branch,
+          isPR: ciInfo.isPR,
+          gitBranch,
+        }
+      );
+    } else {
+      ze_log.git(
+        `Branch detection in CI failed. Git returned: "${gitBranch}", no CI env vars available`,
+        { platform: ciInfo.platform, gitBranch }
+      );
+    }
+  }
+
+  if (isCI && (!branch || branch === 'HEAD')) {
+    throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
+      message:
+        'Git branch is required in CI environments. Configure the CI provider branch variables or check out a named branch.',
+    });
+  }
+
+  if (isCI && (!commit || commit === NO_GIT_COMMIT)) {
+    throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
+      message:
+        'Git commit hash is required in CI environments. Ensure this repository has commit history.',
+    });
+  }
+
+  return {
+    name: name ?? '',
+    email: email ?? '',
+    remoteOrigin: remoteOrigin ?? '',
+    branch: branch ?? '',
+    commit,
+    tags,
+    stdout,
+  };
+}
+
+/** Resolve the current branch, handling unborn branches in fresh repositories. */
+async function loadGitBranch(context: string): Promise<string | null> {
+  const symbolic = await runGit(['symbolic-ref', '--short', 'HEAD'], context);
+  if (symbolic) {
+    return symbolic;
+  }
+  return runGit(['rev-parse', '--abbrev-ref', 'HEAD'], context);
 }
 
 /** Load tags pointing at HEAD. Missing commits/no tags should not fail local flow. */
 async function loadGitTags(context: string): Promise<string[]> {
-  try {
-    const { stdout } = await exec('git tag --points-at HEAD', { cwd: context });
-    return parseTagsOutput(stdout);
-  } catch {
-    return [];
-  }
-}
-
-function parseTagsOutput(stdout: string): string[] {
-  const trimmed = stdout.trim();
-
-  if (!trimmed) {
-    return [];
-  }
-
-  // Defensive parsing for mocked output that reuses the main delimiter format.
-  if (trimmed.includes(GIT_OUTPUT_DELIMITER)) {
-    const parts = trimmed.split(GIT_OUTPUT_DELIMITER).map((x) => x.trim());
-    const possibleTags = parts[parts.length - 1];
-    return possibleTags ? possibleTags.split('\n').filter(Boolean) : [];
-  }
-
-  return trimmed.split('\n').filter(Boolean);
+  const stdout = await runGit(['tag', '--points-at', 'HEAD'], context);
+  return stdout ? stdout.split('\n').filter(Boolean) : [];
 }
 
 function hasConfiguredApp(
@@ -340,13 +353,13 @@ async function loadGlobalGitInfo(
   zephyrConfig: ResolvedZephyrConfig
 ): Promise<ZeGitInfo> {
   try {
-    const [nameResult, emailResult] = await Promise.all([
-      exec('git config --global user.name').catch(() => ({ stdout: '' })),
-      exec('git config --global user.email').catch(() => ({ stdout: '' })),
+    const [globalName, globalEmail] = await Promise.all([
+      runGit(['config', '--global', 'user.name'], context),
+      runGit(['config', '--global', 'user.email'], context),
     ]);
 
-    const name = nameResult.stdout?.trim();
-    const email = emailResult.stdout?.trim();
+    const name = globalName ?? '';
+    const email = globalEmail ?? '';
 
     if (!name && !email) {
       logFn(


### PR DESCRIPTION
The combined git command chained subcommands with `&&`/`||` and delimiters. `cmd.exe` (Windows) parses that operator precedence/quoting differently than POSIX `sh`, dropping the commit hash and failing Windows CI with "Git commit hash is required in CI environments" despite valid history.

Fix: run each git read separately via `execFile` (no shell), removing the delimiter parsing and the `||` precedence bug across platforms. Tests updated to mock per-command `execFile`.