### PR TITLE
feat(create-zephyr-apps): add deterministic non-interactive scaffolding

### DIFF
--- a/libs/create-zephyr-apps/README.md
+++ b/libs/create-zephyr-apps/README.md
@@ -33,7 +33,8 @@ bunx create-zephyr-apps
 
 ### Interactive Mode
 
-Run the command without arguments to start the interactive mode:
+Run the command without arguments in a TTY to choose the directory, project
+type, template, and whether to initialize Git:
 
 ```bash
 npx create-zephyr-apps@latest
@@ -72,6 +73,100 @@ npx create-zephyr-apps@latest
 └
 ```
 
+### Non-interactive Mode
+
+Pass a project directory to scaffold without prompts. Non-interactive runs use
+the pinned `react-rsbuild` template by default and do not initialize Git,
+install dependencies, or build unless those actions are explicitly requested.
+
+The directory can be positional:
+
+```bash
+npx create-zephyr-apps@latest ./my-app --no-git
+```
+
+Or supplied with `--directory`:
+
+```bash
+npx create-zephyr-apps@latest --directory ./my-app --no-git
+```
+
+This complete example is also tested against the CLI parser:
+
+```bash
+create-zephyr-apps ./apps/example --template react-rsbuild --package-manager pnpm --no-git --install --build --json
+```
+
+`--build` implies `--install`. Install and build failures preserve the command's
+non-zero exit code.
+
+### Deterministic templates
+
+Each published CLI version pins both template repositories to exact commits.
+Use the release-compatible revision by default. To reproduce a different known
+revision, pass its full 40-character commit SHA:
+
+```bash
+npx create-zephyr-apps@latest ./my-app \
+  --template react-rsbuild \
+  --template-revision 881c3a83d2f1888720c3da72e9b7a055aae1e3c7 \
+  --no-git
+```
+
+List the template IDs and the pinned web-template revision with:
+
+```bash
+npx create-zephyr-apps@latest --list-templates
+npx create-zephyr-apps@latest --list-templates --json
+```
+
+The CLI rejects unknown template IDs and refuses to write into a non-empty
+directory.
+
+### Package manager and Git behavior
+
+Choose a package manager explicitly with `--package-manager pnpm`, `npm`,
+`yarn`, or `bun`. Otherwise, the CLI checks the copied template's
+`packageManager` field and lockfile, the invoking package-manager user agent,
+the current project, and finally falls back to pnpm.
+
+Git initialization and the initial commit only happen after an interactive
+confirmation or when `--git` is passed. Use `--no-git` to record that choice
+explicitly in scripts.
+
+### JSON output
+
+`--json` disables prompts and emits one JSON document. It includes:
+
+- The resolved output directory, project type, template repository, and exact
+  template commit.
+- The selected package manager and its version when installation is requested.
+- Created files, build artifacts, and resolved workspace/installed package
+  versions.
+- Every executed command with its stage, working directory, and exit code.
+- Structured failures. Failed install and build runs still emit JSON before
+  returning the underlying exit code.
+
+### CLI options
+
+```text
+Usage: create-zephyr-apps [directory] [options]
+
+--directory, -d <path>           Project directory (alternative to positional)
+--template, -t <id>              Web template ID (default: react-rsbuild)
+--project-type <type>            web or react-native (default: web)
+--package-manager <manager>      pnpm, npm, yarn, or bun
+--template-revision <commit>     Override the pinned template with a full SHA
+--git / --no-git                 Enable or disable Git initialization
+--install                        Install dependencies
+--build                          Install dependencies and run the build script
+--json                           Emit one machine-readable JSON result
+--yes, -y                        Use deterministic defaults without prompting
+--list-templates                 List available web template IDs
+--version, -v                    Print the CLI version
+--help, -h                       Show help
+```
+
 ## Available Templates
 
 ### Bundlers
@@ -86,6 +181,8 @@ npx create-zephyr-apps@latest
 ### Module Federation
 
 - **airbnb-clone** - Airbnb clone with React, TypeScript, and Module Federation
+- **angular-rsbuild** - Angular application with Module Federation using Rsbuild
+- **angular-vite-mf** - Angular application with Module Federation using Vite
 - **react-rsbuild** - React application with Module Federation using Rsbuild
 - **react-vite-rspack-webpack** - Federated React apps powered by Vite, Webpack, and Rspack
 - **react-webpack** - React application with Module Federation using Webpack

--- a/libs/create-zephyr-apps/package.json
+++ b/libs/create-zephyr-apps/package.json
@@ -42,6 +42,7 @@
     "dev": "rslib build --watch",
     "build": "rslib build",
     "patch-version": "pnpm version",
+    "test": "rstest run",
     "typecheck": "tsc -b"
   },
   "dependencies": {
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@rslib/core": "catalog:rslib",
+    "@rstest/core": "catalog:rstest",
     "@types/node": "catalog:typescript",
     "tsx": "catalog:typescript",
     "typescript": "catalog:typescript"

--- a/libs/create-zephyr-apps/rstest.config.mts
+++ b/libs/create-zephyr-apps/rstest.config.mts
@@ -1,0 +1,7 @@
+import path from 'node:path';
+import { createProjectConfig } from '../../rstest.project.mts';
+
+export default createProjectConfig({
+  name: 'create-zephyr-apps',
+  root: path.join(import.meta.dirname),
+});

--- a/libs/create-zephyr-apps/src/cli.spec.ts
+++ b/libs/create-zephyr-apps/src/cli.spec.ts
@@ -6,6 +6,7 @@ import {
   OperationCancelled,
   parseCliArgs,
   resolveCliOptions,
+  shouldUseInteractiveMode,
 } from './cli.js';
 import {
   DEFAULT_WEB_TEMPLATE,
@@ -53,6 +54,18 @@ describe('create-zephyr-apps CLI', () => {
       build: false,
       templateRevision: TemplateRepositories.web.revision,
     });
+  });
+
+  it('treats explicit project directories as non-interactive in a TTY', () => {
+    const terminal = { inputIsTTY: true, outputIsTTY: true };
+
+    expect(shouldUseInteractiveMode(parseCliArgs([]), terminal)).toBe(true);
+    expect(shouldUseInteractiveMode(parseCliArgs(['./positional']), terminal)).toBe(
+      false
+    );
+    expect(
+      shouldUseInteractiveMode(parseCliArgs(['--directory', './flagged']), terminal)
+    ).toBe(false);
   });
 
   it('installs dependencies when --build is requested', async () => {

--- a/libs/create-zephyr-apps/src/cli.spec.ts
+++ b/libs/create-zephyr-apps/src/cli.spec.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import {
   NON_INTERACTIVE_EXAMPLE,
   NON_INTERACTIVE_EXAMPLE_ARGS,
+  OperationCancelled,
   parseCliArgs,
   resolveCliOptions,
 } from './cli.js';
@@ -95,6 +96,28 @@ describe('create-zephyr-apps CLI', () => {
       template: 'react-rsbuild',
       initializeGit: true,
     });
+  });
+
+  it('keeps an interactive directory cancellation distinct from a missing argument', async () => {
+    await expect(
+      resolveCliOptions(parseCliArgs([]), {
+        interactive: true,
+        prompts: {
+          async directory() {
+            return undefined;
+          },
+          async projectType() {
+            return 'web';
+          },
+          async template() {
+            return 'react-rsbuild';
+          },
+          async initializeGit() {
+            return false;
+          },
+        },
+      })
+    ).rejects.toBeInstanceOf(OperationCancelled);
   });
 
   it('validates templates, project types, revisions, and Git flags', () => {

--- a/libs/create-zephyr-apps/src/cli.spec.ts
+++ b/libs/create-zephyr-apps/src/cli.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from '@rstest/core';
+import * as fs from 'node:fs';
+import {
+  NON_INTERACTIVE_EXAMPLE,
+  NON_INTERACTIVE_EXAMPLE_ARGS,
+  parseCliArgs,
+  resolveCliOptions,
+} from './cli.js';
+import {
+  DEFAULT_WEB_TEMPLATE,
+  getTemplate,
+  TemplateRepositories,
+  Templates,
+} from './templates.js';
+
+describe('create-zephyr-apps CLI', () => {
+  it('supports positional and flag-based project directories', () => {
+    expect(parseCliArgs(['./positional'])).toMatchObject({
+      directory: './positional',
+    });
+    expect(parseCliArgs(['--directory', './flagged'])).toMatchObject({
+      directory: './flagged',
+    });
+    expect(() => parseCliArgs(['./positional', '--directory', './flagged'])).toThrow(
+      'either positionally or with --directory'
+    );
+  });
+
+  it('parses the documented non-interactive example', () => {
+    expect(parseCliArgs([...NON_INTERACTIVE_EXAMPLE_ARGS])).toMatchObject({
+      directory: './apps/example',
+      template: 'react-rsbuild',
+      packageManager: 'pnpm',
+      initializeGit: false,
+      install: true,
+      build: true,
+      json: true,
+    });
+  });
+
+  it('uses deterministic non-interactive defaults', async () => {
+    const resolved = await resolveCliOptions(parseCliArgs(['./example']), {
+      interactive: false,
+    });
+
+    expect(resolved).toMatchObject({
+      directory: './example',
+      projectType: 'web',
+      template: DEFAULT_WEB_TEMPLATE,
+      initializeGit: false,
+      install: false,
+      build: false,
+      templateRevision: TemplateRepositories.web.revision,
+    });
+  });
+
+  it('installs dependencies when --build is requested', async () => {
+    const resolved = await resolveCliOptions(parseCliArgs(['./example', '--build']), {
+      interactive: false,
+    });
+
+    expect(resolved).toMatchObject({ install: true, build: true });
+  });
+
+  it('requires a directory when prompting is unavailable', async () => {
+    await expect(
+      resolveCliOptions(parseCliArgs([]), {
+        interactive: false,
+      })
+    ).rejects.toThrow('A project directory is required');
+  });
+
+  it('resolves missing values through interactive prompts', async () => {
+    const resolved = await resolveCliOptions(parseCliArgs([]), {
+      interactive: true,
+      prompts: {
+        async directory() {
+          return './interactive';
+        },
+        async projectType() {
+          return 'web';
+        },
+        async template() {
+          return 'react-rsbuild';
+        },
+        async initializeGit() {
+          return true;
+        },
+      },
+    });
+
+    expect(resolved).toMatchObject({
+      directory: './interactive',
+      projectType: 'web',
+      template: 'react-rsbuild',
+      initializeGit: true,
+    });
+  });
+
+  it('validates templates, project types, revisions, and Git flags', () => {
+    expect(() => parseCliArgs(['./app', '--template', 'missing'])).toThrow(
+      'Unknown template "missing"'
+    );
+    expect(() => parseCliArgs(['./app', '--project-type', 'desktop'])).toThrow(
+      'Unsupported project type "desktop"'
+    );
+    expect(() => parseCliArgs(['./app', '--template-revision', 'main'])).toThrow(
+      'full 40-character commit SHA'
+    );
+    expect(() => parseCliArgs(['./app', '--git', '--no-git'])).toThrow(
+      '--git and --no-git'
+    );
+  });
+
+  it('keeps the default and IDs valid in the pinned catalog', () => {
+    expect(getTemplate(DEFAULT_WEB_TEMPLATE)).toBeDefined();
+    expect(new Set(Templates.map(({ name }) => name)).size).toBe(Templates.length);
+    expect(TemplateRepositories.web.revision).toMatch(/^[a-f\d]{40}$/u);
+    expect(TemplateRepositories['react-native'].revision).toMatch(/^[a-f\d]{40}$/u);
+  });
+
+  it('tests the README example against the real parser', async () => {
+    const readme = await fs.promises.readFile(
+      new URL('../README.md', import.meta.url),
+      'utf8'
+    );
+    expect(readme).toContain(NON_INTERACTIVE_EXAMPLE);
+    expect(() => parseCliArgs([...NON_INTERACTIVE_EXAMPLE_ARGS])).not.toThrow();
+  });
+});

--- a/libs/create-zephyr-apps/src/cli.ts
+++ b/libs/create-zephyr-apps/src/cli.ts
@@ -51,6 +51,13 @@ export interface ResolveCliOptionsContext {
   prompts?: PromptAdapter;
 }
 
+export class OperationCancelled extends Error {
+  constructor() {
+    super('Operation cancelled.');
+    this.name = 'OperationCancelled';
+  }
+}
+
 export const NON_INTERACTIVE_EXAMPLE_ARGS = [
   './apps/example',
   '--template',
@@ -193,9 +200,13 @@ export async function resolveCliOptions(
   context: ResolveCliOptionsContext
 ): Promise<ResolvedCliOptions> {
   const prompts = context.prompts;
-  const directory =
-    options.directory ??
-    (context.interactive && prompts ? await prompts.directory() : undefined);
+  let directory = options.directory;
+  if (directory === undefined && context.interactive && prompts) {
+    directory = await prompts.directory();
+    if (directory === undefined) {
+      throw new OperationCancelled();
+    }
+  }
 
   if (!directory?.trim()) {
     throw new Error(
@@ -203,37 +214,32 @@ export async function resolveCliOptions(
     );
   }
 
-  const projectType =
-    options.projectType ??
-    (options.template
-      ? 'web'
-      : context.interactive && prompts
-        ? await prompts.projectType()
-        : 'web');
-
-  if (!projectType) {
-    throw new Error('Operation cancelled.');
+  let projectType = options.projectType ?? (options.template ? 'web' : undefined);
+  if (projectType === undefined && context.interactive && prompts) {
+    projectType = await prompts.projectType();
+    if (projectType === undefined) {
+      throw new OperationCancelled();
+    }
   }
+  projectType ??= 'web';
 
-  const template =
-    projectType === 'web'
-      ? (options.template ??
-        (context.interactive && prompts
-          ? await prompts.template()
-          : DEFAULT_WEB_TEMPLATE))
-      : undefined;
-
-  if (projectType === 'web' && !template) {
-    throw new Error('Operation cancelled.');
+  let template = projectType === 'web' ? options.template : undefined;
+  if (projectType === 'web' && template === undefined && context.interactive && prompts) {
+    template = await prompts.template();
+    if (template === undefined) {
+      throw new OperationCancelled();
+    }
   }
+  template ??= projectType === 'web' ? DEFAULT_WEB_TEMPLATE : undefined;
 
-  const initializeGit =
-    options.initializeGit ??
-    (context.interactive && prompts ? await prompts.initializeGit() : false);
-
-  if (initializeGit === undefined) {
-    throw new Error('Operation cancelled.');
+  let initializeGit = options.initializeGit;
+  if (initializeGit === undefined && context.interactive && prompts) {
+    initializeGit = await prompts.initializeGit();
+    if (initializeGit === undefined) {
+      throw new OperationCancelled();
+    }
   }
+  initializeGit ??= false;
 
   const repository = TemplateRepositories[projectType];
 

--- a/libs/create-zephyr-apps/src/cli.ts
+++ b/libs/create-zephyr-apps/src/cli.ts
@@ -1,0 +1,263 @@
+import { parseArgs } from 'node:util';
+import {
+  DEFAULT_WEB_TEMPLATE,
+  getTemplate,
+  type ProjectType,
+  ProjectTypes,
+  TemplateRepositories,
+  Templates,
+} from './templates.js';
+
+export const PackageManagers = ['pnpm', 'npm', 'yarn', 'bun'] as const;
+export type PackageManager = (typeof PackageManagers)[number];
+
+export interface CliOptions {
+  directory?: string;
+  template?: string;
+  projectType?: ProjectType;
+  packageManager?: PackageManager;
+  initializeGit?: boolean;
+  install: boolean;
+  build: boolean;
+  json: boolean;
+  yes: boolean;
+  templateRevision?: string;
+  listTemplates: boolean;
+  help: boolean;
+  version: boolean;
+}
+
+export interface ResolvedCliOptions {
+  directory: string;
+  template?: string;
+  projectType: ProjectType;
+  packageManager?: PackageManager;
+  initializeGit: boolean;
+  install: boolean;
+  build: boolean;
+  json: boolean;
+  templateRevision: string;
+}
+
+export interface PromptAdapter {
+  directory(): Promise<string | undefined>;
+  projectType(): Promise<ProjectType | undefined>;
+  template(): Promise<string | undefined>;
+  initializeGit(): Promise<boolean | undefined>;
+}
+
+export interface ResolveCliOptionsContext {
+  interactive: boolean;
+  prompts?: PromptAdapter;
+}
+
+export const NON_INTERACTIVE_EXAMPLE_ARGS = [
+  './apps/example',
+  '--template',
+  'react-rsbuild',
+  '--package-manager',
+  'pnpm',
+  '--no-git',
+  '--install',
+  '--build',
+  '--json',
+] as const;
+
+export const NON_INTERACTIVE_EXAMPLE = `create-zephyr-apps ${NON_INTERACTIVE_EXAMPLE_ARGS.join(
+  ' '
+)}`;
+
+export const HELP_TEXT = `
+Usage: create-zephyr-apps [directory] [options]
+
+Create a Zephyr application from a version-pinned template.
+
+Options:
+  --directory, -d <path>           Project directory (alternative to positional)
+  --template, -t <id>              Web template ID (default: ${DEFAULT_WEB_TEMPLATE})
+  --project-type <type>            web or react-native (default: web)
+  --package-manager <manager>      pnpm, npm, yarn, or bun
+  --template-revision <commit>     Override the pinned template with a full commit SHA
+  --git                            Initialize Git and create an initial commit
+  --no-git                         Do not initialize Git
+  --install                        Install dependencies
+  --build                          Install dependencies and run the build script
+  --json                           Emit one machine-readable JSON result
+  --yes, -y                        Use deterministic defaults without prompting
+  --list-templates                 List available web template IDs
+  --version, -v                    Print the CLI version
+  --help, -h                       Show this help
+
+Example:
+  ${NON_INTERACTIVE_EXAMPLE}
+`.trim();
+
+export function parseCliArgs(args: string[]): CliOptions {
+  const parsed = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: true,
+    options: {
+      directory: { type: 'string', short: 'd' },
+      template: { type: 'string', short: 't' },
+      'project-type': { type: 'string' },
+      'package-manager': { type: 'string' },
+      'template-revision': { type: 'string' },
+      git: { type: 'boolean' },
+      'no-git': { type: 'boolean' },
+      install: { type: 'boolean' },
+      build: { type: 'boolean' },
+      json: { type: 'boolean' },
+      yes: { type: 'boolean', short: 'y' },
+      'list-templates': { type: 'boolean' },
+      version: { type: 'boolean', short: 'v' },
+      help: { type: 'boolean', short: 'h' },
+    },
+  });
+
+  if (parsed.positionals.length > 1) {
+    throw new Error('Only one positional project directory is supported.');
+  }
+
+  const positionalDirectory = parsed.positionals[0];
+  const flagDirectory = parsed.values.directory;
+  if (positionalDirectory && flagDirectory) {
+    throw new Error(
+      'Provide the project directory either positionally or with --directory, not both.'
+    );
+  }
+
+  if (parsed.values.git && parsed.values['no-git']) {
+    throw new Error('--git and --no-git cannot be used together.');
+  }
+
+  const projectType = parsed.values['project-type'];
+  if (
+    projectType !== undefined &&
+    !ProjectTypes.some((candidate) => candidate.value === projectType)
+  ) {
+    throw new Error(
+      `Unsupported project type "${projectType}". Expected web or react-native.`
+    );
+  }
+
+  const packageManager = parsed.values['package-manager'];
+  if (
+    packageManager !== undefined &&
+    !PackageManagers.includes(packageManager as PackageManager)
+  ) {
+    throw new Error(
+      `Unsupported package manager "${packageManager}". Expected ${PackageManagers.join(
+        ', '
+      )}.`
+    );
+  }
+
+  const template = parsed.values.template;
+  if (template !== undefined && !getTemplate(template)) {
+    throw new Error(
+      `Unknown template "${template}". Available templates: ${Templates.map(
+        ({ name }) => name
+      ).join(', ')}.`
+    );
+  }
+
+  if (projectType === 'react-native' && template !== undefined) {
+    throw new Error('--template is only supported for web projects.');
+  }
+
+  const templateRevision = parsed.values['template-revision'];
+  if (templateRevision !== undefined && !/^[a-f\d]{40}$/iu.test(templateRevision)) {
+    throw new Error('--template-revision must be a full 40-character commit SHA.');
+  }
+
+  return {
+    directory: flagDirectory ?? positionalDirectory,
+    template,
+    projectType: projectType as ProjectType | undefined,
+    packageManager: packageManager as PackageManager | undefined,
+    initializeGit: parsed.values.git ? true : parsed.values['no-git'] ? false : undefined,
+    install: parsed.values.install ?? false,
+    build: parsed.values.build ?? false,
+    json: parsed.values.json ?? false,
+    yes: parsed.values.yes ?? false,
+    templateRevision,
+    listTemplates: parsed.values['list-templates'] ?? false,
+    help: parsed.values.help ?? false,
+    version: parsed.values.version ?? false,
+  };
+}
+
+export async function resolveCliOptions(
+  options: CliOptions,
+  context: ResolveCliOptionsContext
+): Promise<ResolvedCliOptions> {
+  const prompts = context.prompts;
+  const directory =
+    options.directory ??
+    (context.interactive && prompts ? await prompts.directory() : undefined);
+
+  if (!directory?.trim()) {
+    throw new Error(
+      'A project directory is required in non-interactive mode. Pass it positionally or with --directory.'
+    );
+  }
+
+  const projectType =
+    options.projectType ??
+    (options.template
+      ? 'web'
+      : context.interactive && prompts
+        ? await prompts.projectType()
+        : 'web');
+
+  if (!projectType) {
+    throw new Error('Operation cancelled.');
+  }
+
+  const template =
+    projectType === 'web'
+      ? (options.template ??
+        (context.interactive && prompts
+          ? await prompts.template()
+          : DEFAULT_WEB_TEMPLATE))
+      : undefined;
+
+  if (projectType === 'web' && !template) {
+    throw new Error('Operation cancelled.');
+  }
+
+  const initializeGit =
+    options.initializeGit ??
+    (context.interactive && prompts ? await prompts.initializeGit() : false);
+
+  if (initializeGit === undefined) {
+    throw new Error('Operation cancelled.');
+  }
+
+  const repository = TemplateRepositories[projectType];
+
+  return {
+    directory,
+    template,
+    projectType,
+    packageManager: options.packageManager,
+    initializeGit,
+    install: options.install || options.build,
+    build: options.build,
+    json: options.json,
+    templateRevision: options.templateRevision ?? repository.revision,
+  };
+}
+
+export function listTemplatesJson(): string {
+  return JSON.stringify(
+    {
+      default: DEFAULT_WEB_TEMPLATE,
+      revision: TemplateRepositories.web.revision,
+      templates: Templates,
+    },
+    null,
+    2
+  );
+}

--- a/libs/create-zephyr-apps/src/cli.ts
+++ b/libs/create-zephyr-apps/src/cli.ts
@@ -51,6 +51,11 @@ export interface ResolveCliOptionsContext {
   prompts?: PromptAdapter;
 }
 
+export interface TerminalContext {
+  inputIsTTY: boolean | undefined;
+  outputIsTTY: boolean | undefined;
+}
+
 export class OperationCancelled extends Error {
   constructor() {
     super('Operation cancelled.');
@@ -193,6 +198,18 @@ export function parseCliArgs(args: string[]): CliOptions {
     help: parsed.values.help ?? false,
     version: parsed.values.version ?? false,
   };
+}
+
+export function shouldUseInteractiveMode(
+  options: CliOptions,
+  terminal: TerminalContext
+): boolean {
+  return (
+    options.directory === undefined &&
+    !options.yes &&
+    !options.json &&
+    Boolean(terminal.inputIsTTY && terminal.outputIsTTY)
+  );
 }
 
 export async function resolveCliOptions(

--- a/libs/create-zephyr-apps/src/index.ts
+++ b/libs/create-zephyr-apps/src/index.ts
@@ -21,6 +21,7 @@ import {
   OperationCancelled,
   parseCliArgs,
   resolveCliOptions,
+  shouldUseInteractiveMode,
   type PromptAdapter,
 } from './cli.js';
 import { createNextSteps, formatScaffoldFailure } from './presentation.js';
@@ -64,8 +65,10 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
       return 0;
     }
 
-    const interactive =
-      !parsed.yes && !parsed.json && Boolean(process.stdin.isTTY && process.stdout.isTTY);
+    const interactive = shouldUseInteractiveMode(parsed, {
+      inputIsTTY: process.stdin.isTTY,
+      outputIsTTY: process.stdout.isTTY,
+    });
 
     if (interactive) {
       console.clear();
@@ -112,6 +115,8 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
         receipt.directory,
         receipt.packageManager.name,
         options.projectType,
+        options.template,
+        options.install,
         options.build
       );
     }
@@ -207,6 +212,8 @@ function printNextSteps(
   outputDirectory: string,
   packageManager: string,
   projectType: ProjectType,
+  template: string | undefined,
+  alreadyInstalled: boolean,
   alreadyBuilt: boolean
 ): void {
   const nextSteps = createNextSteps({
@@ -214,6 +221,8 @@ function printNextSteps(
     invocationDirectory: process.cwd(),
     packageManager,
     projectType,
+    template,
+    alreadyInstalled,
     alreadyBuilt,
   });
 

--- a/libs/create-zephyr-apps/src/index.ts
+++ b/libs/create-zephyr-apps/src/index.ts
@@ -5,256 +5,218 @@ import {
   confirm,
   intro,
   isCancel,
-  log,
   note,
   select,
   spinner,
   text,
 } from '@clack/prompts';
 import c from 'chalk-template';
-import { exec } from 'node:child_process';
 import * as fs from 'node:fs';
-import { homedir } from 'node:os';
 import path from 'node:path';
 import { setImmediate } from 'node:timers/promises';
-import { promisify } from 'node:util';
 import terminalLink from 'terminal-link';
-import { ProjectTypes, Templates } from './templates.js';
+import {
+  HELP_TEXT,
+  listTemplatesJson,
+  parseCliArgs,
+  resolveCliOptions,
+  type PromptAdapter,
+} from './cli.js';
+import { ScaffoldFailure, scaffoldProject } from './scaffold.js';
+import {
+  DEFAULT_WEB_TEMPLATE,
+  ProjectTypes,
+  Templates,
+  type ProjectType,
+} from './templates.js';
 
-const execAsync = promisify(exec);
+export async function main(args = process.argv.slice(2)): Promise<number> {
+  const jsonRequested = args.includes('--json');
 
-// Immediate is required to avoid terminal image flickering
-console.clear();
-await setImmediate();
+  try {
+    const parsed = parseCliArgs(args);
 
-if (!process.stdout.isTTY) {
-  cancel('Please run this command in a TTY terminal.');
-  process.exit(1);
-}
-
-intro(c`Bootstrap your project using {cyan Zephyr}!`);
-note(
-  c`The only sane way to do micro-frontends\n{cyan https://docs.zephyr-cloud.io/}`,
-  'Zephyr Cloud'
-);
-
-let output = await text({
-  message: 'Where should we create your project?',
-  placeholder: './my-app',
-  validate(value) {
-    if (!value?.trim().length) {
-      return 'Please enter a project name.';
+    if (parsed.help) {
+      console.log(HELP_TEXT);
+      return 0;
     }
-    return undefined;
-  },
-});
 
-if (isCancel(output)) {
-  cancel('Operation cancelled.');
-  process.exit(0);
+    if (parsed.version) {
+      console.log(await readCliVersion());
+      return 0;
+    }
+
+    if (parsed.listTemplates) {
+      if (parsed.json) {
+        console.log(listTemplatesJson());
+      } else {
+        console.log(
+          Templates.map(
+            (template) =>
+              `${template.name.padEnd(30)} ${template.label} (${template.directory})`
+          ).join('\n')
+        );
+      }
+      return 0;
+    }
+
+    const interactive =
+      !parsed.yes && !parsed.json && Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+    if (interactive) {
+      console.clear();
+      await setImmediate();
+      intro(c`Bootstrap your project using {cyan Zephyr}!`);
+      note(
+        c`The only sane way to do micro-frontends\n{cyan https://docs.zephyr-cloud.io/}`,
+        'Zephyr Cloud'
+      );
+    }
+
+    const options = await resolveCliOptions(parsed, {
+      interactive,
+      prompts: interactive ? createPromptAdapter() : undefined,
+    });
+    const loading = interactive ? spinner() : undefined;
+    let loadingStarted = false;
+
+    const receipt = await scaffoldProject(options, {
+      onProgress(_stage, message) {
+        if (loading) {
+          if (loadingStarted) {
+            loading.message(message);
+          } else {
+            loading.start(message);
+            loadingStarted = true;
+          }
+        }
+      },
+    });
+
+    if (loadingStarted) {
+      loading?.stop(
+        c`Project successfully created at {cyan ${
+          path.relative(process.cwd(), receipt.directory) || './'
+        }}!`
+      );
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(receipt, null, 2));
+    } else {
+      printNextSteps(receipt.directory, receipt.packageManager.name, options.build);
+    }
+    return 0;
+  } catch (error) {
+    if (error instanceof ScaffoldFailure) {
+      if (jsonRequested) {
+        console.log(JSON.stringify(error.receipt, null, 2));
+      } else {
+        cancel(error.message);
+      }
+      return error.exitCode;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    if (jsonRequested) {
+      console.log(
+        JSON.stringify(
+          {
+            success: false,
+            failures: [
+              {
+                stage: 'prepare',
+                message,
+                exitCode: 1,
+              },
+            ],
+          },
+          null,
+          2
+        )
+      );
+    } else {
+      cancel(message);
+    }
+    return 1;
+  }
 }
 
-output = path.resolve(output);
-const relativeOutput = path.relative(process.cwd(), output) || './';
-
-// ensures output is not a directory with contents
-if (fs.existsSync(output)) {
-  const stats = fs.statSync(output);
-
-  if (!stats.isDirectory()) {
-    cancel(c`{cyan ${relativeOutput}} is not a directory.`);
-    process.exit(1);
-  }
-
-  const files = fs.readdirSync(output);
-
-  if (files.length > 0) {
-    cancel(c`Output directory {cyan ${relativeOutput}} must be empty.`);
-    process.exit(1);
-  }
-}
-
-const projectKind = await select({
-  message: 'What type of project you are creating?',
-  initialValue: ProjectTypes[0]?.value,
-  options: ProjectTypes,
-  maxItems: 1,
-});
-
-if (isCancel(projectKind)) {
-  cancel('Operation cancelled.');
-  process.exit(0);
-}
-
-let examplesRepoName: string;
-let subfolder: string;
-
-if (projectKind === 'web') {
-  const templateName = await select({
-    message: 'Pick a template: ',
-    initialValue: 'mf-react-rsbuild',
-    options: Templates.map((temp) => ({
-      value: temp.name,
-      label: temp.label,
-      hint: temp.hint,
-    })),
-  });
-
-  if (isCancel(templateName)) {
-    cancel('Operation cancelled.');
-    process.exit(0);
-  }
-
-  const selectedTemplate = Templates.find((t) => t.name === templateName);
-
-  if (!selectedTemplate) {
-    cancel('Invalid template selected.');
-    process.exit(1);
-  }
-
-  examplesRepoName = 'zephyr-examples';
-  subfolder = `${selectedTemplate.directory}/${selectedTemplate.name}`;
-} else {
-  examplesRepoName = 'zephyr-repack-example';
-  subfolder = '';
-}
-
-const loading = spinner();
-const tmpDir = path.resolve(homedir(), '.zephyr', examplesRepoName);
-
-loading.start('Preparing temporary directory...');
-
-if (!fs.existsSync(tmpDir)) {
-  // ensures the temporary directory exists
-  await fs.promises.mkdir(tmpDir, { recursive: true });
-} else {
-  // cleans the temporary directory
-  await fs.promises.rm(tmpDir, { recursive: true, force: true });
-}
-
-loading.message('Cloning example to temporary directory...');
-
-try {
-  const { stderr } = await execAsync(
-    `git clone --quiet --depth 1 https://github.com/ZephyrCloudIO/${examplesRepoName}.git -b main ${tmpDir}`,
-    { encoding: 'utf8', timeout: 1000 * 60 * 5 }
-  );
-
-  if (stderr) {
-    loading.stop('Error cloning repository to temporary directory... ');
-    cancel(stderr);
-    process.exit(1);
-  }
-
-  const pathToCopy = path.join(tmpDir, subfolder);
-  const dotGitPath = path.join(pathToCopy, '.git');
-
-  loading.message(`Extracting template to ${relativeOutput}...`);
-
-  await fs.promises.cp(pathToCopy, output, {
-    recursive: true,
-    force: true,
-    dereference: true,
-
-    // skip .git folder
-    filter(source) {
-      return !source.startsWith(dotGitPath);
+function createPromptAdapter(): PromptAdapter {
+  return {
+    async directory() {
+      const value = await text({
+        message: 'Where should we create your project?',
+        placeholder: './my-app',
+        validate(input) {
+          return input?.trim() ? undefined : 'Please enter a project name.';
+        },
+      });
+      return isCancel(value) ? undefined : value;
     },
-  });
-
-  loading.message('Cleaning up temporary directory...');
-
-  // no need to wait this operation, as it is not critical for the user experience
-  void fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(console.error);
-
-  loading.stop(c`Project successfully created at {cyan ${relativeOutput}}!`);
-} catch (error) {
-  cancel(c`Error cloning repository to {cyan ${relativeOutput}}: ${error}`);
-  loading.error('Error!');
-  process.exit(1);
+    async projectType() {
+      const value = await select({
+        message: 'What type of project are you creating?',
+        initialValue: ProjectTypes[0].value,
+        options: [...ProjectTypes],
+        maxItems: 1,
+      });
+      return isCancel(value) ? undefined : (value as ProjectType);
+    },
+    async template() {
+      const value = await select({
+        message: 'Pick a template:',
+        initialValue: DEFAULT_WEB_TEMPLATE,
+        options: Templates.map((template) => ({
+          value: template.name,
+          label: template.label,
+          hint: template.hint,
+        })),
+      });
+      return isCancel(value) ? undefined : (value as string);
+    },
+    async initializeGit() {
+      const value = await confirm({
+        message: 'Would you like to initialize a new Git repository?',
+        initialValue: true,
+      });
+      return isCancel(value) ? undefined : value;
+    },
+  };
 }
 
-const shouldInitGit = await confirm({
-  message: 'Would you like to initialize a new Git repository?',
-  initialValue: true,
-});
+function printNextSteps(
+  outputDirectory: string,
+  packageManager: string,
+  alreadyBuilt: boolean
+): void {
+  const relativeDirectory =
+    path.relative(process.cwd(), outputDirectory) || path.basename(outputDirectory);
+  const commands = alreadyBuilt
+    ? `cd ./${relativeDirectory}`
+    : `cd ./${relativeDirectory}\n${packageManager} install\n${packageManager} run build`;
 
-if (isCancel(shouldInitGit)) {
-  cancel('Operation cancelled');
-  process.exit(0);
-}
-
-if (shouldInitGit) {
-  // Initialize the repository.
-  await execAsync('git init', { cwd: output });
-
-  // Set temporary Git user configuration.
-  await execAsync('git config user.email "zephyrbot@zephyr-cloud.io"', {
-    cwd: output,
-  });
-  await execAsync('git config user.name "Zephyr Bot"', { cwd: output });
-
-  // Stage all files and commit them.
-  await execAsync('git add .', { cwd: output });
-  await execAsync('git commit --no-gpg-sign -m "Initial commit from Zephyr"', {
-    cwd: output,
-  });
-
-  // Remove the temporary local Git configuration so that the user's global
-  // settings will be used for future commits.
-  await execAsync('git config --unset user.email', { cwd: output });
-  await execAsync('git config --unset user.name', { cwd: output });
-} else {
-  log.warn(
-    'Zephyr requires a Git repository to work properly, please create it manually afterwards.'
-  );
-}
-
-const repoName = path.basename(output);
-
-if (projectKind === 'web') {
-  note(
-    `
-cd ./${repoName}
-pnpm install
-pnpm run build
-`.trim(),
-    'Run the application!'
-  );
-} else {
+  note(commands, alreadyBuilt ? 'Project built successfully!' : 'Run the application!');
   note(
     c`
-cd ./${repoName}
-pnpm install
-git remote add origin https://github.com/{cyan <name>}/{cyan ${repoName}}.git
-{cyan ZC=1} pnpm start
-`.trim(),
-    'Run the application!'
-  );
-
-  note(
-    c`
-Make sure to commit and add a remote to the remote repository!
-Read more about how Module Federation works with Zephyr:
-- {cyan https://docs.zephyr-cloud.io/tutorials/mf-guide}
-    `.trim(),
-    'Read more about Module Federation'
-  );
-}
-
-note(
-  c`
 - {cyan ${terminalLink('Discord', 'https://zephyr-cloud.io/discord')}}
+- {cyan ${terminalLink('Documentation', 'https://docs.zephyr-cloud.io/bundlers/rsbuild')}}
 - {cyan ${terminalLink(
-    'Documentation',
-    projectKind === 'web'
-      ? 'https://docs.zephyr-cloud.io/bundlers/webpack'
-      : 'https://docs.zephyr-cloud.io/bundlers/repack'
-  )}}
-- {cyan ${terminalLink(
-    'Open an issue',
-    'https://github.com/ZephyrCloudIO/zephyr-packages/issues'
-  )}}
+      'Open an issue',
+      'https://github.com/ZephyrCloudIO/zephyr-packages/issues'
+    )}}
 `.trim(),
-  'Next steps.'
-);
+    'Next steps.'
+  );
+}
+
+async function readCliVersion(): Promise<string> {
+  const packageJson = JSON.parse(
+    await fs.promises.readFile(new URL('../package.json', import.meta.url), 'utf8')
+  ) as { version: string };
+  return packageJson.version;
+}
+
+void main().then((exitCode) => {
+  process.exitCode = exitCode;
+});

--- a/libs/create-zephyr-apps/src/index.ts
+++ b/libs/create-zephyr-apps/src/index.ts
@@ -18,10 +18,12 @@ import terminalLink from 'terminal-link';
 import {
   HELP_TEXT,
   listTemplatesJson,
+  OperationCancelled,
   parseCliArgs,
   resolveCliOptions,
   type PromptAdapter,
 } from './cli.js';
+import { createNextSteps, formatScaffoldFailure } from './presentation.js';
 import { ScaffoldFailure, scaffoldProject } from './scaffold.js';
 import {
   DEFAULT_WEB_TEMPLATE,
@@ -32,6 +34,8 @@ import {
 
 export async function main(args = process.argv.slice(2)): Promise<number> {
   const jsonRequested = args.includes('--json');
+  let loading: ReturnType<typeof spinner> | undefined;
+  let loadingStarted = false;
 
   try {
     const parsed = parseCliArgs(args);
@@ -77,8 +81,7 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
       interactive,
       prompts: interactive ? createPromptAdapter() : undefined,
     });
-    const loading = interactive ? spinner() : undefined;
-    let loadingStarted = false;
+    loading = interactive ? spinner() : undefined;
 
     const receipt = await scaffoldProject(options, {
       onProgress(_stage, message) {
@@ -99,20 +102,35 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
           path.relative(process.cwd(), receipt.directory) || './'
         }}!`
       );
+      loadingStarted = false;
     }
 
     if (options.json) {
       console.log(JSON.stringify(receipt, null, 2));
     } else {
-      printNextSteps(receipt.directory, receipt.packageManager.name, options.build);
+      printNextSteps(
+        receipt.directory,
+        receipt.packageManager.name,
+        options.projectType,
+        options.build
+      );
     }
     return 0;
   } catch (error) {
+    if (loadingStarted) {
+      loading?.error('Project creation failed.');
+    }
+
+    if (error instanceof OperationCancelled) {
+      cancel(error.message);
+      return 0;
+    }
+
     if (error instanceof ScaffoldFailure) {
       if (jsonRequested) {
         console.log(JSON.stringify(error.receipt, null, 2));
       } else {
-        cancel(error.message);
+        cancel(formatScaffoldFailure(error));
       }
       return error.exitCode;
     }
@@ -188,19 +206,25 @@ function createPromptAdapter(): PromptAdapter {
 function printNextSteps(
   outputDirectory: string,
   packageManager: string,
+  projectType: ProjectType,
   alreadyBuilt: boolean
 ): void {
-  const relativeDirectory =
-    path.relative(process.cwd(), outputDirectory) || path.basename(outputDirectory);
-  const commands = alreadyBuilt
-    ? `cd ./${relativeDirectory}`
-    : `cd ./${relativeDirectory}\n${packageManager} install\n${packageManager} run build`;
+  const nextSteps = createNextSteps({
+    outputDirectory,
+    invocationDirectory: process.cwd(),
+    packageManager,
+    projectType,
+    alreadyBuilt,
+  });
 
-  note(commands, alreadyBuilt ? 'Project built successfully!' : 'Run the application!');
+  note(nextSteps.commands, nextSteps.commandsTitle);
+  if (nextSteps.guidance) {
+    note(nextSteps.guidance.body, nextSteps.guidance.title);
+  }
   note(
     c`
 - {cyan ${terminalLink('Discord', 'https://zephyr-cloud.io/discord')}}
-- {cyan ${terminalLink('Documentation', 'https://docs.zephyr-cloud.io/bundlers/rsbuild')}}
+- {cyan ${terminalLink('Documentation', nextSteps.documentationUrl)}}
 - {cyan ${terminalLink(
       'Open an issue',
       'https://github.com/ZephyrCloudIO/zephyr-packages/issues'

--- a/libs/create-zephyr-apps/src/presentation.spec.ts
+++ b/libs/create-zephyr-apps/src/presentation.spec.ts
@@ -8,6 +8,7 @@ describe('CLI presentation', () => {
       invocationDirectory: '/workspace',
       packageManager: 'pnpm',
       projectType: 'react-native',
+      alreadyInstalled: false,
       alreadyBuilt: false,
     });
 
@@ -21,6 +22,43 @@ describe('CLI presentation', () => {
       'https://docs.zephyr-cloud.io/bundlers/repack'
     );
     expect(nextSteps.guidance?.body).toContain('Make sure to commit and add a remote');
+  });
+
+  it('does not recommend reinstalling dependencies after --install', () => {
+    const nextSteps = createNextSteps({
+      outputDirectory: '/workspace/web-app',
+      invocationDirectory: '/workspace',
+      packageManager: 'pnpm',
+      projectType: 'web',
+      template: 'react-rsbuild',
+      alreadyInstalled: true,
+      alreadyBuilt: false,
+    });
+
+    expect(nextSteps.commands).toBe('cd ./web-app\npnpm run build');
+  });
+
+  it('routes web templates to their bundler documentation', () => {
+    const documentationUrl = (template: string): string =>
+      createNextSteps({
+        outputDirectory: '/workspace/web-app',
+        invocationDirectory: '/workspace',
+        packageManager: 'pnpm',
+        projectType: 'web',
+        template,
+        alreadyInstalled: false,
+        alreadyBuilt: false,
+      }).documentationUrl;
+
+    expect(documentationUrl('react-rsbuild')).toBe(
+      'https://docs.zephyr-cloud.io/bundlers/rsbuild'
+    );
+    expect(documentationUrl('react-webpack')).toBe(
+      'https://docs.zephyr-cloud.io/bundlers/webpack'
+    );
+    expect(documentationUrl('react-vite')).toBe(
+      'https://docs.zephyr-cloud.io/bundlers/vite'
+    );
   });
 
   it('includes captured command diagnostics in plain-text failures', () => {

--- a/libs/create-zephyr-apps/src/presentation.spec.ts
+++ b/libs/create-zephyr-apps/src/presentation.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@rstest/core';
+import { createNextSteps, formatScaffoldFailure } from './presentation.js';
+
+describe('CLI presentation', () => {
+  it('preserves React Native setup commands and Re.Pack documentation', () => {
+    const nextSteps = createNextSteps({
+      outputDirectory: '/workspace/mobile-app',
+      invocationDirectory: '/workspace',
+      packageManager: 'pnpm',
+      projectType: 'react-native',
+      alreadyBuilt: false,
+    });
+
+    expect(nextSteps.commands).toContain('cd ./mobile-app');
+    expect(nextSteps.commands).toContain('pnpm install');
+    expect(nextSteps.commands).toContain(
+      'git remote add origin https://github.com/<name>/mobile-app.git'
+    );
+    expect(nextSteps.commands).toContain('ZC=1 pnpm start');
+    expect(nextSteps.documentationUrl).toBe(
+      'https://docs.zephyr-cloud.io/bundlers/repack'
+    );
+    expect(nextSteps.guidance?.body).toContain('Make sure to commit and add a remote');
+  });
+
+  it('includes captured command diagnostics in plain-text failures', () => {
+    expect(
+      formatScaffoldFailure({
+        message: 'pnpm exited with code 1.',
+        receipt: {
+          failures: [
+            {
+              stderr: 'ERR_PNPM_FETCH_404 package not found',
+            },
+          ],
+        },
+      })
+    ).toBe('pnpm exited with code 1.\n\nERR_PNPM_FETCH_404 package not found');
+  });
+});

--- a/libs/create-zephyr-apps/src/presentation.ts
+++ b/libs/create-zephyr-apps/src/presentation.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { ProjectType } from './templates.js';
+import { getTemplate, type ProjectType } from './templates.js';
 
 export interface ScaffoldFailurePresentation {
   message: string;
@@ -15,6 +15,8 @@ export interface CreateNextStepsOptions {
   invocationDirectory: string;
   packageManager: string;
   projectType: ProjectType;
+  template?: string;
+  alreadyInstalled: boolean;
   alreadyBuilt: boolean;
 }
 
@@ -33,12 +35,13 @@ export function createNextSteps(options: CreateNextStepsOptions): NextSteps {
     path.relative(options.invocationDirectory, options.outputDirectory) ||
     path.basename(options.outputDirectory);
   const changeDirectory = `cd ./${relativeDirectory}`;
+  const alreadyInstalled = options.alreadyInstalled || options.alreadyBuilt;
 
   if (options.projectType === 'react-native') {
     const repositoryName = path.basename(options.outputDirectory);
     const commands = [
       changeDirectory,
-      ...(options.alreadyBuilt ? [] : [`${options.packageManager} install`]),
+      ...(alreadyInstalled ? [] : [`${options.packageManager} install`]),
       `git remote add origin https://github.com/<name>/${repositoryName}.git`,
       `ZC=1 ${options.packageManager} start`,
     ];
@@ -58,18 +61,25 @@ export function createNextSteps(options: CreateNextStepsOptions): NextSteps {
     };
   }
 
+  const commands = [changeDirectory];
+  if (!alreadyInstalled) {
+    commands.push(`${options.packageManager} install`);
+  }
+  if (!options.alreadyBuilt) {
+    commands.push(`${options.packageManager} run build`);
+  }
+  const bundlerDocumentation = options.template
+    ? getTemplate(options.template)?.bundlerDocumentation
+    : undefined;
+
   return {
-    commands: options.alreadyBuilt
-      ? changeDirectory
-      : [
-          changeDirectory,
-          `${options.packageManager} install`,
-          `${options.packageManager} run build`,
-        ].join('\n'),
+    commands: commands.join('\n'),
     commandsTitle: options.alreadyBuilt
       ? 'Project built successfully!'
       : 'Run the application!',
-    documentationUrl: 'https://docs.zephyr-cloud.io/bundlers/rsbuild',
+    documentationUrl: bundlerDocumentation
+      ? `https://docs.zephyr-cloud.io/bundlers/${bundlerDocumentation}`
+      : 'https://docs.zephyr-cloud.io/getting-started/quick-start',
   };
 }
 

--- a/libs/create-zephyr-apps/src/presentation.ts
+++ b/libs/create-zephyr-apps/src/presentation.ts
@@ -1,0 +1,80 @@
+import path from 'node:path';
+import type { ProjectType } from './templates.js';
+
+export interface ScaffoldFailurePresentation {
+  message: string;
+  receipt: {
+    failures: Array<{
+      stderr?: string;
+    }>;
+  };
+}
+
+export interface CreateNextStepsOptions {
+  outputDirectory: string;
+  invocationDirectory: string;
+  packageManager: string;
+  projectType: ProjectType;
+  alreadyBuilt: boolean;
+}
+
+export interface NextSteps {
+  commands: string;
+  commandsTitle: string;
+  guidance?: {
+    body: string;
+    title: string;
+  };
+  documentationUrl: string;
+}
+
+export function createNextSteps(options: CreateNextStepsOptions): NextSteps {
+  const relativeDirectory =
+    path.relative(options.invocationDirectory, options.outputDirectory) ||
+    path.basename(options.outputDirectory);
+  const changeDirectory = `cd ./${relativeDirectory}`;
+
+  if (options.projectType === 'react-native') {
+    const repositoryName = path.basename(options.outputDirectory);
+    const commands = [
+      changeDirectory,
+      ...(options.alreadyBuilt ? [] : [`${options.packageManager} install`]),
+      `git remote add origin https://github.com/<name>/${repositoryName}.git`,
+      `ZC=1 ${options.packageManager} start`,
+    ];
+
+    return {
+      commands: commands.join('\n'),
+      commandsTitle: 'Run the application!',
+      guidance: {
+        body: [
+          'Make sure to commit and add a remote to the remote repository!',
+          'Read more about how Module Federation works with Zephyr:',
+          '- https://docs.zephyr-cloud.io/tutorials/mf-guide',
+        ].join('\n'),
+        title: 'Read more about Module Federation',
+      },
+      documentationUrl: 'https://docs.zephyr-cloud.io/bundlers/repack',
+    };
+  }
+
+  return {
+    commands: options.alreadyBuilt
+      ? changeDirectory
+      : [
+          changeDirectory,
+          `${options.packageManager} install`,
+          `${options.packageManager} run build`,
+        ].join('\n'),
+    commandsTitle: options.alreadyBuilt
+      ? 'Project built successfully!'
+      : 'Run the application!',
+    documentationUrl: 'https://docs.zephyr-cloud.io/bundlers/rsbuild',
+  };
+}
+
+export function formatScaffoldFailure(error: ScaffoldFailurePresentation): string {
+  const lastFailure = error.receipt.failures[error.receipt.failures.length - 1];
+  const stderr = lastFailure?.stderr?.trim();
+  return stderr ? `${error.message}\n\n${stderr}` : error.message;
+}

--- a/libs/create-zephyr-apps/src/scaffold.spec.ts
+++ b/libs/create-zephyr-apps/src/scaffold.spec.ts
@@ -8,6 +8,7 @@ import { parseCliArgs, resolveCliOptions, type ResolvedCliOptions } from './cli.
 import {
   defaultCommandRunner,
   detectPackageManager,
+  normalizeReceiptPath,
   ScaffoldFailure,
   scaffoldProject,
   type CommandRunner,
@@ -25,6 +26,15 @@ afterEach(async () => {
 });
 
 describe('scaffoldProject', () => {
+  it('normalizes machine-readable receipt paths to portable separators', () => {
+    expect(normalizeReceiptPath('src\\components\\Header.tsx')).toBe(
+      'src/components/Header.tsx'
+    );
+    expect(normalizeReceiptPath('C:\\work\\app\\dist\\index.js')).toBe(
+      'C:/work/app/dist/index.js'
+    );
+  });
+
   it('scaffolds the React/Rsbuild template from an exact revision without a TTY', async () => {
     const fixture = await createTemplateRepository();
     const output = path.join(fixture.root, 'output');
@@ -40,9 +50,11 @@ describe('scaffoldProject', () => {
     });
 
     expect(receipt.success).toBe(true);
+    expect(receipt.directory).toBe(normalizeReceiptPath(output));
     expect(receipt.templateRevision).toBe(fixture.revision);
     expect(receipt.createdFiles).toContain('package.json');
     expect(receipt.createdFiles).toContain('src/index.ts');
+    expect(receipt.commands.every(({ cwd }) => !cwd.includes('\\'))).toBe(true);
     expect(await fs.promises.readFile(path.join(output, 'src/index.ts'), 'utf8')).toBe(
       'export const fixture = true;\n'
     );

--- a/libs/create-zephyr-apps/src/scaffold.spec.ts
+++ b/libs/create-zephyr-apps/src/scaffold.spec.ts
@@ -326,6 +326,10 @@ async function createTemplateRepository(): Promise<{
   const template = path.join(repository, 'module-federation', 'react-rsbuild');
   await fs.promises.mkdir(path.join(template, 'src'), { recursive: true });
   await fs.promises.writeFile(
+    path.join(repository, '.gitattributes'),
+    '*.ts text eol=lf\n'
+  );
+  await fs.promises.writeFile(
     path.join(template, 'package.json'),
     JSON.stringify(
       {

--- a/libs/create-zephyr-apps/src/scaffold.spec.ts
+++ b/libs/create-zephyr-apps/src/scaffold.spec.ts
@@ -217,6 +217,48 @@ describe('scaffoldProject', () => {
     });
   });
 
+  it('reconciles conflicting package-manager metadata before an explicit install', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+    const observedPackageManagerFields: Array<string | undefined> = [];
+
+    const receipt = await scaffoldProject(
+      {
+        ...defaultOptions(output, fixture.revision),
+        packageManager: 'yarn',
+        install: true,
+      },
+      {
+        runCommand: async (command, args, options) => {
+          if (command !== 'yarn') {
+            return defaultCommandRunner(command, args, options);
+          }
+
+          const manifest = JSON.parse(
+            await fs.promises.readFile(path.join(output, 'package.json'), 'utf8')
+          ) as { packageManager?: string };
+          observedPackageManagerFields.push(manifest.packageManager);
+          return args[0] === '--version'
+            ? { exitCode: 0, stdout: '4.9.1\n', stderr: '' }
+            : { exitCode: 0, stdout: '', stderr: '' };
+        },
+        repositories: {
+          web: {
+            name: 'fixture',
+            url: fixture.repository,
+            revision: fixture.revision,
+          },
+        },
+      }
+    );
+
+    expect(observedPackageManagerFields).toEqual([undefined, 'yarn@4.9.1']);
+    expect(receipt.packageManager).toEqual({ name: 'yarn', version: '4.9.1' });
+    await expect(
+      fs.promises.readFile(path.join(output, 'package.json'), 'utf8')
+    ).resolves.toContain('"packageManager": "yarn@4.9.1"');
+  });
+
   it('initializes and commits Git only when requested', async () => {
     const fixture = await createTemplateRepository();
     const output = path.join(fixture.root, 'output');

--- a/libs/create-zephyr-apps/src/scaffold.spec.ts
+++ b/libs/create-zephyr-apps/src/scaffold.spec.ts
@@ -6,11 +6,13 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import { parseCliArgs, resolveCliOptions, type ResolvedCliOptions } from './cli.js';
 import {
+  collectResolvedPackageVersions,
   defaultCommandRunner,
   detectPackageManager,
   normalizeReceiptPath,
   ScaffoldFailure,
   scaffoldProject,
+  TEMPLATE_FETCH_TIMEOUT_MS,
   type CommandRunner,
 } from './scaffold.js';
 
@@ -119,6 +121,7 @@ describe('scaffoldProject', () => {
     ).rejects.toMatchObject({
       exitCode: 1,
       receipt: {
+        createdFiles: [],
         failures: [
           {
             stage: 'prepare',
@@ -171,6 +174,8 @@ describe('scaffoldProject', () => {
         stderr: 'install failed',
       }),
     ]);
+    expect(failure?.receipt.createdFiles).toContain('package.json');
+    expect(failure?.receipt.createdFiles).toContain('src/index.ts');
   });
 
   it('propagates the package-manager build exit code', async () => {
@@ -238,6 +243,134 @@ describe('scaffoldProject', () => {
     expect(stdout.trim()).toBe('Initial commit from Zephyr');
   });
 
+  it('includes install-generated lockfiles in the requested initial commit', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+    const runner = packageManagerRunner({
+      install: async () => {
+        await fs.promises.writeFile(
+          path.join(output, 'pnpm-lock.yaml'),
+          'lockfileVersion: 9\n'
+        );
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    await scaffoldProject(
+      {
+        ...defaultOptions(output, fixture.revision),
+        initializeGit: true,
+        install: true,
+      },
+      {
+        runCommand: runner,
+        repositories: {
+          web: {
+            name: 'fixture',
+            url: fixture.repository,
+            revision: fixture.revision,
+          },
+        },
+      }
+    );
+
+    const { stdout: trackedFiles } = await execFileAsync(
+      'git',
+      ['ls-tree', '--name-only', 'HEAD'],
+      { cwd: output }
+    );
+    const { stdout: status } = await execFileAsync('git', ['status', '--porcelain'], {
+      cwd: output,
+    });
+    expect(trackedFiles).toContain('pnpm-lock.yaml');
+    expect(status).toBe('');
+  });
+
+  it('does not let temporary cleanup replace a successful scaffold result', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+
+    const receipt = await scaffoldProject(defaultOptions(output, fixture.revision), {
+      repositories: {
+        web: {
+          name: 'fixture',
+          url: fixture.repository,
+          revision: fixture.revision,
+        },
+      },
+      async removeTemporaryDirectory(directory) {
+        temporaryDirectories.push(directory);
+        throw new Error('temporary directory is locked');
+      },
+    });
+
+    expect(receipt.success).toBe(true);
+  });
+
+  it('does not let temporary cleanup replace a command failure', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+
+    await expect(
+      scaffoldProject(
+        {
+          ...defaultOptions(output, fixture.revision),
+          install: true,
+        },
+        {
+          runCommand: packageManagerRunner({
+            install: { exitCode: 23, stdout: '', stderr: 'install failed' },
+          }),
+          repositories: {
+            web: {
+              name: 'fixture',
+              url: fixture.repository,
+              revision: fixture.revision,
+            },
+          },
+          async removeTemporaryDirectory(directory) {
+            temporaryDirectories.push(directory);
+            throw new Error('temporary directory is locked');
+          },
+        }
+      )
+    ).rejects.toMatchObject({
+      exitCode: 23,
+      receipt: {
+        failures: [
+          expect.objectContaining({
+            stage: 'install',
+            stderr: 'install failed',
+          }),
+        ],
+      },
+    });
+  });
+
+  it('applies the bounded timeout to the template fetch command', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+    let fetchTimeout: number | undefined;
+
+    await scaffoldProject(defaultOptions(output, fixture.revision), {
+      runCommand: async (command, args, options) => {
+        if (command === 'git' && args[0] === 'fetch') {
+          fetchTimeout = options.timeoutMs;
+        }
+        return defaultCommandRunner(command, args, options);
+      },
+      repositories: {
+        web: {
+          name: 'fixture',
+          url: fixture.repository,
+          revision: fixture.revision,
+        },
+      },
+    });
+
+    expect(fetchTimeout).toBe(TEMPLATE_FETCH_TIMEOUT_MS);
+  });
+
   it('records build artifacts and resolved workspace versions', async () => {
     const fixture = await createTemplateRepository();
     const output = path.join(fixture.root, 'output');
@@ -299,6 +432,67 @@ describe('detectPackageManager', () => {
         npm_config_user_agent: 'npm@11.0.0 node@24.0.0',
       })
     ).resolves.toBe('npm');
+
+    await expect(
+      detectPackageManager(output, root, {
+        npm_config_user_agent: 'yarn/1.22.22 npm/? node/v24.0.0',
+      })
+    ).resolves.toBe('yarn');
+  });
+});
+
+describe('defaultCommandRunner', () => {
+  it('terminates a command that exceeds its timeout', async () => {
+    const result = await defaultCommandRunner(
+      process.execPath,
+      ['-e', 'setInterval(() => undefined, 1_000)'],
+      { cwd: process.cwd(), timeoutMs: 100 }
+    );
+
+    expect(result.exitCode).toBe(124);
+    expect(result.stderr).toContain('Command timed out after 100ms.');
+  });
+});
+
+describe('collectResolvedPackageVersions', () => {
+  it('preserves distinct installed versions of one dependency', async () => {
+    const root = await makeTemporaryDirectory();
+    const packageA = path.join(root, 'packages/a');
+    const packageB = path.join(root, 'packages/b');
+
+    await Promise.all(
+      [
+        [packageA, 'workspace-a', '1.0.0', '2.0.0'],
+        [packageB, 'workspace-b', '1.0.0', '3.0.0'],
+      ].map(async ([directory, name, version, dependencyVersion]) => {
+        await fs.promises.mkdir(path.join(directory, 'node_modules/shared'), {
+          recursive: true,
+        });
+        await fs.promises.writeFile(
+          path.join(directory, 'package.json'),
+          JSON.stringify({
+            name,
+            version,
+            dependencies: { shared: '*' },
+          })
+        );
+        await fs.promises.writeFile(
+          path.join(directory, 'node_modules/shared/package.json'),
+          JSON.stringify({
+            name: 'shared',
+            version: dependencyVersion,
+          })
+        );
+      })
+    );
+
+    const versions = await collectResolvedPackageVersions(root);
+    expect(
+      versions.filter(({ name, source }) => name === 'shared' && source === 'installed')
+    ).toEqual([
+      { name: 'shared', version: '2.0.0', source: 'installed' },
+      { name: 'shared', version: '3.0.0', source: 'installed' },
+    ]);
   });
 });
 

--- a/libs/create-zephyr-apps/src/scaffold.spec.ts
+++ b/libs/create-zephyr-apps/src/scaffold.spec.ts
@@ -1,0 +1,380 @@
+import { afterEach, describe, expect, it } from '@rstest/core';
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { parseCliArgs, resolveCliOptions, type ResolvedCliOptions } from './cli.js';
+import {
+  defaultCommandRunner,
+  detectPackageManager,
+  ScaffoldFailure,
+  scaffoldProject,
+  type CommandRunner,
+} from './scaffold.js';
+
+const execFileAsync = promisify(execFile);
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.promises.rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe('scaffoldProject', () => {
+  it('scaffolds the React/Rsbuild template from an exact revision without a TTY', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+
+    const receipt = await scaffoldProject(defaultOptions(output, fixture.revision), {
+      repositories: {
+        web: {
+          name: 'fixture',
+          url: fixture.repository,
+          revision: fixture.revision,
+        },
+      },
+    });
+
+    expect(receipt.success).toBe(true);
+    expect(receipt.templateRevision).toBe(fixture.revision);
+    expect(receipt.createdFiles).toContain('package.json');
+    expect(receipt.createdFiles).toContain('src/index.ts');
+    expect(await fs.promises.readFile(path.join(output, 'src/index.ts'), 'utf8')).toBe(
+      'export const fixture = true;\n'
+    );
+  });
+
+  it('uses interactive answers with the same React/Rsbuild scaffolder', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'interactive-output');
+    const options = await resolveCliOptions(parseCliArgs([]), {
+      interactive: true,
+      prompts: {
+        async directory() {
+          return output;
+        },
+        async projectType() {
+          return 'web';
+        },
+        async template() {
+          return 'react-rsbuild';
+        },
+        async initializeGit() {
+          return false;
+        },
+      },
+    });
+
+    const receipt = await scaffoldProject(
+      {
+        ...options,
+        templateRevision: fixture.revision,
+      },
+      {
+        repositories: {
+          web: {
+            name: 'fixture',
+            url: fixture.repository,
+            revision: fixture.revision,
+          },
+        },
+      }
+    );
+
+    expect(receipt.success).toBe(true);
+    expect(receipt.template).toBe('react-rsbuild');
+    expect(receipt.createdFiles).toContain('src/index.ts');
+  });
+
+  it('fails safely before fetching when the output directory is non-empty', async () => {
+    const root = await makeTemporaryDirectory();
+    const output = path.join(root, 'output');
+    await fs.promises.mkdir(output);
+    await fs.promises.writeFile(path.join(output, 'keep.txt'), 'keep');
+    let commandCount = 0;
+
+    await expect(
+      scaffoldProject(defaultOptions(output, 'a'.repeat(40)), {
+        runCommand: async () => {
+          commandCount += 1;
+          return { exitCode: 0, stdout: '', stderr: '' };
+        },
+      })
+    ).rejects.toMatchObject({
+      exitCode: 1,
+      receipt: {
+        failures: [
+          {
+            stage: 'prepare',
+          },
+        ],
+      },
+    });
+
+    expect(commandCount).toBe(0);
+    expect(await fs.promises.readFile(path.join(output, 'keep.txt'), 'utf8')).toBe(
+      'keep'
+    );
+  });
+
+  it('propagates the package-manager install exit code and records the failure', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+    const runner = packageManagerRunner({
+      install: { exitCode: 23, stdout: '', stderr: 'install failed' },
+    });
+
+    let failure: ScaffoldFailure | undefined;
+    try {
+      await scaffoldProject(
+        {
+          ...defaultOptions(output, fixture.revision),
+          install: true,
+        },
+        {
+          runCommand: runner,
+          repositories: {
+            web: {
+              name: 'fixture',
+              url: fixture.repository,
+              revision: fixture.revision,
+            },
+          },
+        }
+      );
+    } catch (error) {
+      failure = error as ScaffoldFailure;
+    }
+
+    expect(failure).toBeInstanceOf(ScaffoldFailure);
+    expect(failure?.exitCode).toBe(23);
+    expect(failure?.receipt.failures).toEqual([
+      expect.objectContaining({
+        stage: 'install',
+        exitCode: 23,
+        stderr: 'install failed',
+      }),
+    ]);
+  });
+
+  it('propagates the package-manager build exit code', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+    const runner = packageManagerRunner({
+      build: { exitCode: 31, stdout: '', stderr: 'build failed' },
+    });
+
+    await expect(
+      scaffoldProject(
+        {
+          ...defaultOptions(output, fixture.revision),
+          install: true,
+          build: true,
+        },
+        {
+          runCommand: runner,
+          repositories: {
+            web: {
+              name: 'fixture',
+              url: fixture.repository,
+              revision: fixture.revision,
+            },
+          },
+        }
+      )
+    ).rejects.toMatchObject({
+      exitCode: 31,
+      receipt: {
+        failures: [
+          expect.objectContaining({
+            stage: 'build',
+            exitCode: 31,
+            stderr: 'build failed',
+          }),
+        ],
+      },
+    });
+  });
+
+  it('initializes and commits Git only when requested', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+
+    await scaffoldProject(
+      {
+        ...defaultOptions(output, fixture.revision),
+        initializeGit: true,
+      },
+      {
+        repositories: {
+          web: {
+            name: 'fixture',
+            url: fixture.repository,
+            revision: fixture.revision,
+          },
+        },
+      }
+    );
+
+    const { stdout } = await execFileAsync('git', ['log', '-1', '--format=%s'], {
+      cwd: output,
+    });
+    expect(stdout.trim()).toBe('Initial commit from Zephyr');
+  });
+
+  it('records build artifacts and resolved workspace versions', async () => {
+    const fixture = await createTemplateRepository();
+    const output = path.join(fixture.root, 'output');
+    const runner = packageManagerRunner({
+      build: async () => {
+        await fs.promises.mkdir(path.join(output, 'dist'));
+        await fs.promises.writeFile(path.join(output, 'dist/index.js'), 'built');
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    const receipt = await scaffoldProject(
+      {
+        ...defaultOptions(output, fixture.revision),
+        install: true,
+        build: true,
+      },
+      {
+        runCommand: runner,
+        repositories: {
+          web: {
+            name: 'fixture',
+            url: fixture.repository,
+            revision: fixture.revision,
+          },
+        },
+      }
+    );
+
+    expect(receipt.artifacts).toEqual(['dist/index.js']);
+    expect(receipt.packageManager).toEqual({ name: 'pnpm', version: '11.17.0' });
+    expect(receipt.resolvedPackageVersions).toContainEqual({
+      name: 'fixture-template',
+      version: '1.0.0',
+      source: 'workspace',
+    });
+  });
+});
+
+describe('detectPackageManager', () => {
+  it('prefers the template packageManager field, then the invocation user agent', async () => {
+    const root = await makeTemporaryDirectory();
+    const output = path.join(root, 'output');
+    await fs.promises.mkdir(output);
+    await fs.promises.writeFile(
+      path.join(output, 'package.json'),
+      JSON.stringify({ packageManager: 'yarn@4.0.0' })
+    );
+
+    await expect(
+      detectPackageManager(output, root, {
+        npm_config_user_agent: 'npm@11.0.0 node@24.0.0',
+      })
+    ).resolves.toBe('yarn');
+
+    await fs.promises.rm(path.join(output, 'package.json'));
+    await expect(
+      detectPackageManager(output, root, {
+        npm_config_user_agent: 'npm@11.0.0 node@24.0.0',
+      })
+    ).resolves.toBe('npm');
+  });
+});
+
+function defaultOptions(directory: string, templateRevision: string): ResolvedCliOptions {
+  return {
+    directory,
+    template: 'react-rsbuild',
+    projectType: 'web',
+    packageManager: 'pnpm',
+    initializeGit: false,
+    install: false,
+    build: false,
+    json: true,
+    templateRevision,
+  };
+}
+
+async function createTemplateRepository(): Promise<{
+  root: string;
+  repository: string;
+  revision: string;
+}> {
+  const root = await makeTemporaryDirectory();
+  const repository = path.join(root, 'repository');
+  const template = path.join(repository, 'module-federation', 'react-rsbuild');
+  await fs.promises.mkdir(path.join(template, 'src'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(template, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'fixture-template',
+        version: '1.0.0',
+        packageManager: 'pnpm@11.17.0',
+        scripts: { build: 'node build.mjs' },
+      },
+      null,
+      2
+    )
+  );
+  await fs.promises.writeFile(
+    path.join(template, 'src/index.ts'),
+    'export const fixture = true;\n'
+  );
+  await execFileAsync('git', ['init', '--quiet'], { cwd: repository });
+  await execFileAsync('git', ['add', '.'], { cwd: repository });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.name=Test',
+      '-c',
+      'user.email=test@example.com',
+      'commit',
+      '--quiet',
+      '-m',
+      'fixture',
+    ],
+    { cwd: repository }
+  );
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], {
+    cwd: repository,
+  });
+  return { root, repository, revision: stdout.trim() };
+}
+
+function packageManagerRunner(
+  overrides: {
+    install?: Awaited<ReturnType<CommandRunner>> | (() => ReturnType<CommandRunner>);
+    build?: Awaited<ReturnType<CommandRunner>> | (() => ReturnType<CommandRunner>);
+  } = {}
+): CommandRunner {
+  return async (command, args, options) => {
+    if (command !== 'pnpm') {
+      return defaultCommandRunner(command, args, options);
+    }
+    if (args[0] === '--version') {
+      return { exitCode: 0, stdout: '11.17.0\n', stderr: '' };
+    }
+    const override = args[0] === 'install' ? overrides.install : overrides.build;
+    if (typeof override === 'function') return override();
+    return override ?? { exitCode: 0, stdout: '', stderr: '' };
+  };
+}
+
+async function makeTemporaryDirectory(): Promise<string> {
+  const directory = await fs.promises.mkdtemp(
+    path.join(tmpdir(), 'create-zephyr-apps-test-')
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/libs/create-zephyr-apps/src/scaffold.ts
+++ b/libs/create-zephyr-apps/src/scaffold.ts
@@ -103,6 +103,11 @@ class CommandFailure extends Error {
   }
 }
 
+/** @internal */
+export function normalizeReceiptPath(value: string): string {
+  return value.replaceAll(path.win32.sep, path.posix.sep);
+}
+
 export async function defaultCommandRunner(
   command: string,
   args: string[],
@@ -158,7 +163,7 @@ export async function scaffoldProject(
   let packageManager = options.packageManager ?? 'pnpm';
   const receipt: ScaffoldReceipt = {
     success: false,
-    directory: outputDirectory,
+    directory: normalizeReceiptPath(outputDirectory),
     projectType: options.projectType,
     template: options.template ?? null,
     templateRepository: repository.url,
@@ -190,7 +195,7 @@ export async function scaffoldProject(
       stage,
       command,
       args,
-      cwd,
+      cwd: normalizeReceiptPath(cwd),
       exitCode: result.exitCode,
     });
     if (result.exitCode !== 0) {
@@ -467,7 +472,7 @@ async function listProjectFiles(root: string): Promise<string[]> {
       if (entry.isDirectory()) {
         await visit(absolutePath);
       } else {
-        files.push(path.relative(root, absolutePath));
+        files.push(normalizeReceiptPath(path.relative(root, absolutePath)));
       }
     }
   };

--- a/libs/create-zephyr-apps/src/scaffold.ts
+++ b/libs/create-zephyr-apps/src/scaffold.ts
@@ -26,6 +26,7 @@ export interface CommandResult {
 
 export interface CommandRunnerOptions {
   cwd: string;
+  timeoutMs?: number;
 }
 
 export type CommandRunner = (
@@ -77,6 +78,7 @@ export interface ScaffoldDependencies {
   runCommand?: CommandRunner;
   repositories?: Partial<Record<ResolvedCliOptions['projectType'], TemplateRepository>>;
   onProgress?: (stage: ScaffoldStage, message: string) => void;
+  removeTemporaryDirectory?: (directory: string) => Promise<void>;
 }
 
 export class ScaffoldFailure extends Error {
@@ -108,6 +110,9 @@ export function normalizeReceiptPath(value: string): string {
   return value.replaceAll(path.win32.sep, path.posix.sep);
 }
 
+export const TEMPLATE_FETCH_TIMEOUT_MS = 5 * 60 * 1_000;
+const COMMAND_TERMINATION_GRACE_MS = 5_000;
+
 export async function defaultCommandRunner(
   command: string,
   args: string[],
@@ -123,6 +128,22 @@ export async function defaultCommandRunner(
     let stdout = '';
     let stderr = '';
     let settled = false;
+    let timedOut = false;
+    let timeout: NodeJS.Timeout | undefined;
+    let forceKillTimeout: NodeJS.Timeout | undefined;
+
+    const settle = (result: CommandResult): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
+      resolve(result);
+    };
+
+    const timeoutStderr = (): string => {
+      const timeoutMessage = `Command timed out after ${options.timeoutMs}ms.`;
+      return `${stderr}${stderr ? '\n' : ''}${timeoutMessage}`;
+    };
 
     child.stdout?.setEncoding('utf8');
     child.stderr?.setEncoding('utf8');
@@ -133,20 +154,39 @@ export async function defaultCommandRunner(
       stderr += chunk;
     });
 
+    if (options.timeoutMs !== undefined) {
+      timeout = setTimeout(() => {
+        timedOut = true;
+        if (!child.kill('SIGTERM')) {
+          settle({ exitCode: 124, stdout, stderr: timeoutStderr() });
+          return;
+        }
+        forceKillTimeout = setTimeout(() => {
+          child.kill('SIGKILL');
+        }, COMMAND_TERMINATION_GRACE_MS);
+      }, options.timeoutMs);
+    }
+
     child.on('error', (error) => {
-      if (settled) return;
-      settled = true;
-      resolve({
-        exitCode: (error as NodeJS.ErrnoException).code === 'ENOENT' ? 127 : 1,
+      settle({
+        exitCode: timedOut
+          ? 124
+          : (error as NodeJS.ErrnoException).code === 'ENOENT'
+            ? 127
+            : 1,
         stdout,
-        stderr: `${stderr}${stderr ? '\n' : ''}${error.message}`,
+        stderr: timedOut
+          ? timeoutStderr()
+          : `${stderr}${stderr ? '\n' : ''}${error.message}`,
       });
     });
 
     child.on('close', (code) => {
-      if (settled) return;
-      settled = true;
-      resolve({ exitCode: code ?? 1, stdout, stderr });
+      settle({
+        exitCode: timedOut ? 124 : (code ?? 1),
+        stdout,
+        stderr: timedOut ? timeoutStderr() : stderr,
+      });
     });
   });
 }
@@ -178,6 +218,7 @@ export async function scaffoldProject(
   const runCommand = dependencies.runCommand ?? defaultCommandRunner;
   const progress = dependencies.onProgress ?? (() => undefined);
   let temporaryDirectory: string | undefined;
+  let outputMutationStarted = false;
   let currentStage: ScaffoldStage = 'prepare';
   const reportProgress = (stage: ScaffoldStage, message: string): void => {
     currentStage = stage;
@@ -188,9 +229,10 @@ export async function scaffoldProject(
     stage: ScaffoldStage,
     command: string,
     args: string[],
-    cwd: string
+    cwd: string,
+    commandOptions: Omit<CommandRunnerOptions, 'cwd'> = {}
   ): Promise<CommandResult> => {
-    const result = await runCommand(command, args, { cwd });
+    const result = await runCommand(command, args, { cwd, ...commandOptions });
     receipt.commands.push({
       stage,
       command,
@@ -229,7 +271,8 @@ export async function scaffoldProject(
       'fetch-template',
       'git',
       ['fetch', '--quiet', '--depth', '1', 'origin', options.templateRevision],
-      checkoutDirectory
+      checkoutDirectory,
+      { timeoutMs: TEMPLATE_FETCH_TIMEOUT_MS }
     );
     await execute(
       'fetch-template',
@@ -256,6 +299,7 @@ export async function scaffoldProject(
 
     reportProgress('copy-template', `Copying the template to ${outputDirectory}`);
     await fs.promises.mkdir(outputDirectory, { recursive: true });
+    outputMutationStarted = true;
     await fs.promises.cp(sourceDirectory, outputDirectory, {
       recursive: true,
       force: false,
@@ -264,6 +308,7 @@ export async function scaffoldProject(
         return path.basename(source) !== '.git';
       },
     });
+    await refreshReceiptFiles(outputDirectory, receipt);
     if (!options.packageManager) {
       packageManager = await detectPackageManager(
         outputDirectory,
@@ -274,24 +319,8 @@ export async function scaffoldProject(
     }
 
     if (options.initializeGit) {
-      reportProgress('git', 'Creating the initial Git commit');
+      reportProgress('git', 'Initializing the Git repository');
       await execute('git', 'git', ['init'], outputDirectory);
-      await execute('git', 'git', ['add', '.'], outputDirectory);
-      await execute(
-        'git',
-        'git',
-        [
-          '-c',
-          'user.email=zephyrbot@zephyr-cloud.io',
-          '-c',
-          'user.name=Zephyr Bot',
-          'commit',
-          '--no-gpg-sign',
-          '-m',
-          'Initial commit from Zephyr',
-        ],
-        outputDirectory
-      );
     }
 
     let beforeBuild = new Set(await listProjectFiles(outputDirectory));
@@ -311,7 +340,28 @@ export async function scaffoldProject(
         installCommand.args,
         outputDirectory
       );
+      await refreshReceiptFiles(outputDirectory, receipt);
       beforeBuild = new Set(await listProjectFiles(outputDirectory));
+    }
+
+    if (options.initializeGit) {
+      reportProgress('git', 'Creating the initial Git commit');
+      await execute('git', 'git', ['add', '.'], outputDirectory);
+      await execute(
+        'git',
+        'git',
+        [
+          '-c',
+          'user.email=zephyrbot@zephyr-cloud.io',
+          '-c',
+          'user.name=Zephyr Bot',
+          'commit',
+          '--no-gpg-sign',
+          '-m',
+          'Initial commit from Zephyr',
+        ],
+        outputDirectory
+      );
     }
 
     if (options.build) {
@@ -324,9 +374,7 @@ export async function scaffoldProject(
     }
 
     reportProgress('inspect', 'Collecting scaffold results');
-    const allFiles = await listProjectFiles(outputDirectory);
-    const artifacts = new Set(receipt.artifacts);
-    receipt.createdFiles = allFiles.filter((file) => !artifacts.has(file));
+    await refreshReceiptFiles(outputDirectory, receipt);
     receipt.resolvedPackageVersions =
       await collectResolvedPackageVersions(outputDirectory);
     receipt.success = true;
@@ -335,6 +383,9 @@ export async function scaffoldProject(
     const commandFailure = error instanceof CommandFailure ? error : undefined;
     const exitCode = commandFailure?.result.exitCode ?? 1;
     const message = error instanceof Error ? error.message : String(error);
+    if (outputMutationStarted) {
+      await refreshReceiptFiles(outputDirectory, receipt).catch(() => undefined);
+    }
     receipt.failures.push({
       stage: commandFailure?.stage ?? currentStage,
       message,
@@ -346,10 +397,18 @@ export async function scaffoldProject(
     throw new ScaffoldFailure(message, exitCode, receipt);
   } finally {
     if (temporaryDirectory) {
-      await fs.promises.rm(temporaryDirectory, {
-        recursive: true,
-        force: true,
-      });
+      const removeTemporaryDirectory =
+        dependencies.removeTemporaryDirectory ??
+        ((directory: string) =>
+          fs.promises.rm(directory, {
+            recursive: true,
+            force: true,
+          }));
+      try {
+        await removeTemporaryDirectory(temporaryDirectory);
+      } catch {
+        // Temporary cleanup must never replace a successful receipt or primary failure.
+      }
     }
   }
 }
@@ -365,7 +424,10 @@ export async function detectPackageManager(
   const outputLockfile = await detectLockfile(outputDirectory);
   if (outputLockfile) return outputLockfile;
 
-  const userAgent = environment['npm_config_user_agent']?.split(' ')[0]?.split('@')[0];
+  const userAgent = environment['npm_config_user_agent']
+    ?.trim()
+    .split(/\s+/u)[0]
+    ?.split(/[/@]/u)[0];
   if (isPackageManager(userAgent)) return userAgent;
 
   const packageManagerFromInvocation = await readPackageManagerField(invocationDirectory);
@@ -481,7 +543,17 @@ async function listProjectFiles(root: string): Promise<string[]> {
   return files.sort();
 }
 
-async function collectResolvedPackageVersions(
+async function refreshReceiptFiles(
+  outputDirectory: string,
+  receipt: ScaffoldReceipt
+): Promise<void> {
+  const allFiles = await listProjectFiles(outputDirectory);
+  const artifacts = new Set(receipt.artifacts);
+  receipt.createdFiles = allFiles.filter((file) => !artifacts.has(file));
+}
+
+/** @internal */
+export async function collectResolvedPackageVersions(
   root: string
 ): Promise<ResolvedPackageVersion[]> {
   const manifests = await findWorkspaceManifests(root);
@@ -502,7 +574,7 @@ async function collectResolvedPackageVersions(
     }
 
     if (manifest.name && manifest.version) {
-      versions.set(`workspace:${manifest.name}`, {
+      versions.set(`workspace:${manifest.name}@${manifest.version}`, {
         name: manifest.name,
         version: manifest.version,
         source: 'workspace',
@@ -526,11 +598,14 @@ async function collectResolvedPackageVersions(
           await fs.promises.readFile(installedManifest, 'utf8')
         ) as { name?: string; version?: string };
         if (dependencyManifest.name && dependencyManifest.version) {
-          versions.set(`installed:${dependencyManifest.name}`, {
-            name: dependencyManifest.name,
-            version: dependencyManifest.version,
-            source: 'installed',
-          });
+          versions.set(
+            `installed:${dependencyManifest.name}@${dependencyManifest.version}`,
+            {
+              name: dependencyManifest.name,
+              version: dependencyManifest.version,
+              source: 'installed',
+            }
+          );
         }
       } catch {
         // A malformed installed package is reported by the package manager/build.
@@ -540,7 +615,9 @@ async function collectResolvedPackageVersions(
 
   return [...versions.values()].sort(
     (left, right) =>
-      left.name.localeCompare(right.name) || left.source.localeCompare(right.source)
+      left.name.localeCompare(right.name) ||
+      left.source.localeCompare(right.source) ||
+      left.version.localeCompare(right.version)
   );
 }
 

--- a/libs/create-zephyr-apps/src/scaffold.ts
+++ b/libs/create-zephyr-apps/src/scaffold.ts
@@ -1,0 +1,596 @@
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { PackageManager, ResolvedCliOptions } from './cli.js';
+import {
+  getTemplate,
+  TemplateRepositories,
+  type TemplateRepository,
+} from './templates.js';
+
+export type ScaffoldStage =
+  | 'prepare'
+  | 'fetch-template'
+  | 'copy-template'
+  | 'git'
+  | 'install'
+  | 'build'
+  | 'inspect';
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface CommandRunnerOptions {
+  cwd: string;
+}
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  options: CommandRunnerOptions
+) => Promise<CommandResult>;
+
+export interface CommandReceipt {
+  stage: ScaffoldStage;
+  command: string;
+  args: string[];
+  cwd: string;
+  exitCode: number;
+}
+
+export interface ScaffoldFailureReceipt {
+  stage: ScaffoldStage;
+  message: string;
+  exitCode: number;
+  stderr?: string;
+}
+
+export interface ResolvedPackageVersion {
+  name: string;
+  version: string;
+  source: 'workspace' | 'installed';
+}
+
+export interface ScaffoldReceipt {
+  success: boolean;
+  directory: string;
+  projectType: ResolvedCliOptions['projectType'];
+  template: string | null;
+  templateRepository: string;
+  templateRevision: string;
+  packageManager: {
+    name: PackageManager;
+    version: string | null;
+  };
+  createdFiles: string[];
+  artifacts: string[];
+  resolvedPackageVersions: ResolvedPackageVersion[];
+  commands: CommandReceipt[];
+  failures: ScaffoldFailureReceipt[];
+}
+
+export interface ScaffoldDependencies {
+  runCommand?: CommandRunner;
+  repositories?: Partial<Record<ResolvedCliOptions['projectType'], TemplateRepository>>;
+  onProgress?: (stage: ScaffoldStage, message: string) => void;
+}
+
+export class ScaffoldFailure extends Error {
+  readonly exitCode: number;
+  readonly receipt: ScaffoldReceipt;
+
+  constructor(message: string, exitCode: number, receipt: ScaffoldReceipt) {
+    super(message);
+    this.name = 'ScaffoldFailure';
+    this.exitCode = exitCode;
+    this.receipt = receipt;
+  }
+}
+
+class CommandFailure extends Error {
+  readonly stage: ScaffoldStage;
+  readonly result: CommandResult;
+
+  constructor(stage: ScaffoldStage, command: string, result: CommandResult) {
+    super(`${command} exited with code ${result.exitCode}.`);
+    this.name = 'CommandFailure';
+    this.stage = stage;
+    this.result = result;
+  }
+}
+
+export async function defaultCommandRunner(
+  command: string,
+  args: string[],
+  options: CommandRunnerOptions
+): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: { ...process.env, NO_COLOR: '1' },
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      resolve({
+        exitCode: (error as NodeJS.ErrnoException).code === 'ENOENT' ? 127 : 1,
+        stdout,
+        stderr: `${stderr}${stderr ? '\n' : ''}${error.message}`,
+      });
+    });
+
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+export async function scaffoldProject(
+  options: ResolvedCliOptions,
+  dependencies: ScaffoldDependencies = {}
+): Promise<ScaffoldReceipt> {
+  const outputDirectory = path.resolve(options.directory);
+  const repository = {
+    ...TemplateRepositories[options.projectType],
+    ...dependencies.repositories?.[options.projectType],
+  };
+  let packageManager = options.packageManager ?? 'pnpm';
+  const receipt: ScaffoldReceipt = {
+    success: false,
+    directory: outputDirectory,
+    projectType: options.projectType,
+    template: options.template ?? null,
+    templateRepository: repository.url,
+    templateRevision: options.templateRevision,
+    packageManager: { name: packageManager, version: null },
+    createdFiles: [],
+    artifacts: [],
+    resolvedPackageVersions: [],
+    commands: [],
+    failures: [],
+  };
+  const runCommand = dependencies.runCommand ?? defaultCommandRunner;
+  const progress = dependencies.onProgress ?? (() => undefined);
+  let temporaryDirectory: string | undefined;
+  let currentStage: ScaffoldStage = 'prepare';
+  const reportProgress = (stage: ScaffoldStage, message: string): void => {
+    currentStage = stage;
+    progress(stage, message);
+  };
+
+  const execute = async (
+    stage: ScaffoldStage,
+    command: string,
+    args: string[],
+    cwd: string
+  ): Promise<CommandResult> => {
+    const result = await runCommand(command, args, { cwd });
+    receipt.commands.push({
+      stage,
+      command,
+      args,
+      cwd,
+      exitCode: result.exitCode,
+    });
+    if (result.exitCode !== 0) {
+      throw new CommandFailure(stage, command, result);
+    }
+    return result;
+  };
+
+  try {
+    reportProgress('prepare', 'Validating the project directory');
+    await assertEmptyOutputDirectory(outputDirectory);
+
+    temporaryDirectory = await fs.promises.mkdtemp(
+      path.join(tmpdir(), 'create-zephyr-apps-')
+    );
+    const checkoutDirectory = path.join(temporaryDirectory, repository.name);
+    await fs.promises.mkdir(checkoutDirectory, { recursive: true });
+
+    reportProgress(
+      'fetch-template',
+      `Fetching ${repository.name} at ${options.templateRevision}`
+    );
+    await execute('fetch-template', 'git', ['init', '--quiet'], checkoutDirectory);
+    await execute(
+      'fetch-template',
+      'git',
+      ['remote', 'add', 'origin', repository.url],
+      checkoutDirectory
+    );
+    await execute(
+      'fetch-template',
+      'git',
+      ['fetch', '--quiet', '--depth', '1', 'origin', options.templateRevision],
+      checkoutDirectory
+    );
+    await execute(
+      'fetch-template',
+      'git',
+      ['checkout', '--quiet', '--detach', 'FETCH_HEAD'],
+      checkoutDirectory
+    );
+    const revisionResult = await execute(
+      'fetch-template',
+      'git',
+      ['rev-parse', 'HEAD'],
+      checkoutDirectory
+    );
+    const resolvedRevision = revisionResult.stdout.trim();
+    if (resolvedRevision.toLowerCase() !== options.templateRevision.toLowerCase()) {
+      throw new Error(
+        `Fetched template revision ${resolvedRevision}, expected ${options.templateRevision}.`
+      );
+    }
+    receipt.templateRevision = resolvedRevision;
+
+    const sourceDirectory = resolveTemplateSource(options, checkoutDirectory);
+    await fs.promises.access(sourceDirectory, fs.constants.R_OK);
+
+    reportProgress('copy-template', `Copying the template to ${outputDirectory}`);
+    await fs.promises.mkdir(outputDirectory, { recursive: true });
+    await fs.promises.cp(sourceDirectory, outputDirectory, {
+      recursive: true,
+      force: false,
+      dereference: true,
+      filter(source) {
+        return path.basename(source) !== '.git';
+      },
+    });
+    if (!options.packageManager) {
+      packageManager = await detectPackageManager(
+        outputDirectory,
+        process.cwd(),
+        process.env
+      );
+      receipt.packageManager.name = packageManager;
+    }
+
+    if (options.initializeGit) {
+      reportProgress('git', 'Creating the initial Git commit');
+      await execute('git', 'git', ['init'], outputDirectory);
+      await execute('git', 'git', ['add', '.'], outputDirectory);
+      await execute(
+        'git',
+        'git',
+        [
+          '-c',
+          'user.email=zephyrbot@zephyr-cloud.io',
+          '-c',
+          'user.name=Zephyr Bot',
+          'commit',
+          '--no-gpg-sign',
+          '-m',
+          'Initial commit from Zephyr',
+        ],
+        outputDirectory
+      );
+    }
+
+    let beforeBuild = new Set(await listProjectFiles(outputDirectory));
+    if (options.install) {
+      reportProgress('install', `Installing dependencies with ${packageManager}`);
+      const versionResult = await execute(
+        'install',
+        packageManager,
+        ['--version'],
+        outputDirectory
+      );
+      receipt.packageManager.version = versionResult.stdout.trim() || null;
+      const installCommand = packageManagerCommands(packageManager).install;
+      await execute(
+        'install',
+        installCommand.command,
+        installCommand.args,
+        outputDirectory
+      );
+      beforeBuild = new Set(await listProjectFiles(outputDirectory));
+    }
+
+    if (options.build) {
+      reportProgress('build', `Building the project with ${packageManager}`);
+      const buildCommand = packageManagerCommands(packageManager).build;
+      await execute('build', buildCommand.command, buildCommand.args, outputDirectory);
+      receipt.artifacts = (await listProjectFiles(outputDirectory)).filter(
+        (file) => !beforeBuild.has(file)
+      );
+    }
+
+    reportProgress('inspect', 'Collecting scaffold results');
+    const allFiles = await listProjectFiles(outputDirectory);
+    const artifacts = new Set(receipt.artifacts);
+    receipt.createdFiles = allFiles.filter((file) => !artifacts.has(file));
+    receipt.resolvedPackageVersions =
+      await collectResolvedPackageVersions(outputDirectory);
+    receipt.success = true;
+    return receipt;
+  } catch (error) {
+    const commandFailure = error instanceof CommandFailure ? error : undefined;
+    const exitCode = commandFailure?.result.exitCode ?? 1;
+    const message = error instanceof Error ? error.message : String(error);
+    receipt.failures.push({
+      stage: commandFailure?.stage ?? currentStage,
+      message,
+      exitCode,
+      stderr: commandFailure
+        ? tail(commandFailure.result.stderr.trim(), 4_000)
+        : undefined,
+    });
+    throw new ScaffoldFailure(message, exitCode, receipt);
+  } finally {
+    if (temporaryDirectory) {
+      await fs.promises.rm(temporaryDirectory, {
+        recursive: true,
+        force: true,
+      });
+    }
+  }
+}
+
+export async function detectPackageManager(
+  outputDirectory: string,
+  invocationDirectory: string,
+  environment: NodeJS.ProcessEnv
+): Promise<PackageManager> {
+  const packageManagerFromOutput = await readPackageManagerField(outputDirectory);
+  if (packageManagerFromOutput) return packageManagerFromOutput;
+
+  const outputLockfile = await detectLockfile(outputDirectory);
+  if (outputLockfile) return outputLockfile;
+
+  const userAgent = environment['npm_config_user_agent']?.split(' ')[0]?.split('@')[0];
+  if (isPackageManager(userAgent)) return userAgent;
+
+  const packageManagerFromInvocation = await readPackageManagerField(invocationDirectory);
+  if (packageManagerFromInvocation) return packageManagerFromInvocation;
+
+  const invocationLockfile = await detectLockfile(invocationDirectory);
+  return invocationLockfile ?? 'pnpm';
+}
+
+function resolveTemplateSource(
+  options: ResolvedCliOptions,
+  checkoutDirectory: string
+): string {
+  if (options.projectType === 'react-native') {
+    return checkoutDirectory;
+  }
+
+  const template = options.template ? getTemplate(options.template) : undefined;
+  if (!template) {
+    throw new Error(`Unknown web template "${String(options.template)}".`);
+  }
+  return path.join(
+    checkoutDirectory,
+    template.directory,
+    template.sourceName ?? template.name
+  );
+}
+
+async function assertEmptyOutputDirectory(outputDirectory: string): Promise<void> {
+  try {
+    const stats = await fs.promises.stat(outputDirectory);
+    if (!stats.isDirectory()) {
+      throw new Error(`${outputDirectory} exists and is not a directory.`);
+    }
+    const files = await fs.promises.readdir(outputDirectory);
+    if (files.length > 0) {
+      throw new Error(
+        `Output directory ${outputDirectory} must be empty. Existing files were not changed.`
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+function packageManagerCommands(packageManager: PackageManager): {
+  install: { command: string; args: string[] };
+  build: { command: string; args: string[] };
+} {
+  return {
+    install: { command: packageManager, args: ['install'] },
+    build: { command: packageManager, args: ['run', 'build'] },
+  };
+}
+
+async function readPackageManagerField(
+  directory: string
+): Promise<PackageManager | undefined> {
+  try {
+    const manifest = JSON.parse(
+      await fs.promises.readFile(path.join(directory, 'package.json'), 'utf8')
+    ) as { packageManager?: string };
+    const name = manifest.packageManager?.split('@')[0];
+    return isPackageManager(name) ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function detectLockfile(directory: string): Promise<PackageManager | undefined> {
+  const lockfiles: Array<[string, PackageManager]> = [
+    ['pnpm-lock.yaml', 'pnpm'],
+    ['package-lock.json', 'npm'],
+    ['yarn.lock', 'yarn'],
+    ['bun.lock', 'bun'],
+    ['bun.lockb', 'bun'],
+  ];
+
+  for (const [lockfile, packageManager] of lockfiles) {
+    try {
+      await fs.promises.access(path.join(directory, lockfile));
+      return packageManager;
+    } catch {
+      // Keep looking.
+    }
+  }
+  return undefined;
+}
+
+function isPackageManager(value: string | undefined): value is PackageManager {
+  return value === 'pnpm' || value === 'npm' || value === 'yarn' || value === 'bun';
+}
+
+async function listProjectFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+
+  const visit = async (directory: string): Promise<void> => {
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === '.git' || entry.name === 'node_modules') continue;
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(absolutePath);
+      } else {
+        files.push(path.relative(root, absolutePath));
+      }
+    }
+  };
+
+  await visit(root);
+  return files.sort();
+}
+
+async function collectResolvedPackageVersions(
+  root: string
+): Promise<ResolvedPackageVersion[]> {
+  const manifests = await findWorkspaceManifests(root);
+  const versions = new Map<string, ResolvedPackageVersion>();
+
+  for (const manifestPath of manifests) {
+    let manifest: {
+      name?: string;
+      version?: string;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+    try {
+      manifest = JSON.parse(await fs.promises.readFile(manifestPath, 'utf8'));
+    } catch {
+      continue;
+    }
+
+    if (manifest.name && manifest.version) {
+      versions.set(`workspace:${manifest.name}`, {
+        name: manifest.name,
+        version: manifest.version,
+        source: 'workspace',
+      });
+    }
+
+    const dependencyNames = new Set([
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.devDependencies ?? {}),
+      ...Object.keys(manifest.optionalDependencies ?? {}),
+    ]);
+    for (const dependencyName of dependencyNames) {
+      const installedManifest = await findInstalledManifest(
+        path.dirname(manifestPath),
+        root,
+        dependencyName
+      );
+      if (!installedManifest) continue;
+      try {
+        const dependencyManifest = JSON.parse(
+          await fs.promises.readFile(installedManifest, 'utf8')
+        ) as { name?: string; version?: string };
+        if (dependencyManifest.name && dependencyManifest.version) {
+          versions.set(`installed:${dependencyManifest.name}`, {
+            name: dependencyManifest.name,
+            version: dependencyManifest.version,
+            source: 'installed',
+          });
+        }
+      } catch {
+        // A malformed installed package is reported by the package manager/build.
+      }
+    }
+  }
+
+  return [...versions.values()].sort(
+    (left, right) =>
+      left.name.localeCompare(right.name) || left.source.localeCompare(right.source)
+  );
+}
+
+async function findWorkspaceManifests(root: string): Promise<string[]> {
+  const manifests: string[] = [];
+  const excludedDirectories = new Set([
+    '.git',
+    'node_modules',
+    'dist',
+    'build',
+    'out',
+    '.output',
+  ]);
+
+  const visit = async (directory: string): Promise<void> => {
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!excludedDirectories.has(entry.name)) {
+          await visit(path.join(directory, entry.name));
+        }
+      } else if (entry.name === 'package.json') {
+        manifests.push(path.join(directory, entry.name));
+      }
+    }
+  };
+
+  await visit(root);
+  return manifests;
+}
+
+async function findInstalledManifest(
+  fromDirectory: string,
+  root: string,
+  packageName: string
+): Promise<string | undefined> {
+  let current = fromDirectory;
+
+  while (current.startsWith(root)) {
+    const candidate = path.join(current, 'node_modules', packageName, 'package.json');
+    try {
+      await fs.promises.access(candidate);
+      return candidate;
+    } catch {
+      // Search the next workspace ancestor.
+    }
+
+    if (current === root) break;
+    current = path.dirname(current);
+  }
+  return undefined;
+}
+
+function tail(value: string, maximumLength: number): string {
+  return value.length <= maximumLength
+    ? value
+    : value.slice(value.length - maximumLength);
+}

--- a/libs/create-zephyr-apps/src/scaffold.ts
+++ b/libs/create-zephyr-apps/src/scaffold.ts
@@ -326,6 +326,9 @@ export async function scaffoldProject(
     let beforeBuild = new Set(await listProjectFiles(outputDirectory));
     if (options.install) {
       reportProgress('install', `Installing dependencies with ${packageManager}`);
+      const packageManagerMetadataWasReconciled = options.packageManager
+        ? await removeConflictingPackageManagerMetadata(outputDirectory, packageManager)
+        : false;
       const versionResult = await execute(
         'install',
         packageManager,
@@ -333,6 +336,16 @@ export async function scaffoldProject(
         outputDirectory
       );
       receipt.packageManager.version = versionResult.stdout.trim() || null;
+      if (
+        packageManagerMetadataWasReconciled &&
+        receipt.packageManager.version !== null
+      ) {
+        await writePackageManagerMetadata(
+          outputDirectory,
+          packageManager,
+          receipt.packageManager.version
+        );
+      }
       const installCommand = packageManagerCommands(packageManager).install;
       await execute(
         'install',
@@ -483,6 +496,83 @@ function packageManagerCommands(packageManager: PackageManager): {
     install: { command: packageManager, args: ['install'] },
     build: { command: packageManager, args: ['run', 'build'] },
   };
+}
+
+interface MutablePackageManifest {
+  packageManager?: unknown;
+  [key: string]: unknown;
+}
+
+async function removeConflictingPackageManagerMetadata(
+  directory: string,
+  selectedPackageManager: PackageManager
+): Promise<boolean> {
+  const packageManifest = await readMutablePackageManifest(directory);
+  if (!packageManifest) return false;
+
+  const declaredPackageManager =
+    typeof packageManifest.manifest.packageManager === 'string'
+      ? packageManifest.manifest.packageManager.split('@')[0]
+      : undefined;
+  if (
+    !Object.hasOwn(packageManifest.manifest, 'packageManager') ||
+    declaredPackageManager === selectedPackageManager
+  ) {
+    return false;
+  }
+
+  delete packageManifest.manifest.packageManager;
+  await writeMutablePackageManifest(packageManifest);
+  return true;
+}
+
+async function writePackageManagerMetadata(
+  directory: string,
+  packageManager: PackageManager,
+  version: string
+): Promise<void> {
+  const packageManifest = await readMutablePackageManifest(directory);
+  if (!packageManifest) return;
+
+  packageManifest.manifest.packageManager = `${packageManager}@${version}`;
+  await writeMutablePackageManifest(packageManifest);
+}
+
+async function readMutablePackageManifest(directory: string): Promise<
+  | {
+      path: string;
+      source: string;
+      manifest: MutablePackageManifest;
+    }
+  | undefined
+> {
+  const manifestPath = path.join(directory, 'package.json');
+  try {
+    const source = await fs.promises.readFile(manifestPath, 'utf8');
+    return {
+      path: manifestPath,
+      source,
+      manifest: JSON.parse(source) as MutablePackageManifest,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function writeMutablePackageManifest(packageManifest: {
+  path: string;
+  source: string;
+  manifest: MutablePackageManifest;
+}): Promise<void> {
+  const indentation = packageManifest.source.match(/\n([ \t]+)"/u)?.[1] ?? '  ';
+  const trailingNewline = packageManifest.source.endsWith('\n') ? '\n' : '';
+  await fs.promises.writeFile(
+    packageManifest.path,
+    `${JSON.stringify(packageManifest.manifest, null, indentation)}${trailingNewline}`
+  );
 }
 
 async function readPackageManagerField(

--- a/libs/create-zephyr-apps/src/templates.ts
+++ b/libs/create-zephyr-apps/src/templates.ts
@@ -17,6 +17,14 @@ export type Template = {
   hint: string;
   directory: string;
   sourceName?: string;
+  bundlerDocumentation?:
+    | 'parcel'
+    | 'rolldown'
+    | 'rollup'
+    | 'rsbuild'
+    | 'rspack'
+    | 'vite'
+    | 'webpack';
 };
 
 export type ProjectType = (typeof ProjectTypes)[number]['value'];
@@ -46,37 +54,42 @@ export const TemplateRepositories: Record<ProjectType, TemplateRepository> = {
 
 export const DEFAULT_WEB_TEMPLATE = 'react-rsbuild';
 
-export const Templates: readonly Template[] = [
+const TemplateCatalog: Template[] = [
   // Bundlers
   {
     name: 'react-vite',
     label: 'React + Vite',
     hint: 'You will be building React app powered by Vite.',
     directory: 'bundlers',
+    bundlerDocumentation: 'vite',
   },
   {
     name: 'react-rspack',
     label: 'React + Rspack',
     hint: 'A simple React application built by Rspack.',
     directory: 'bundlers',
+    bundlerDocumentation: 'rspack',
   },
   {
     name: 'parcel-react',
     label: 'React + Parcel',
     hint: 'A React application using Parcel as the bundler.',
     directory: 'bundlers',
+    bundlerDocumentation: 'parcel',
   },
   {
     name: 'rolldown-react',
     label: 'React + Rolldown',
     hint: 'A React example using Rolldown.',
     directory: 'bundlers',
+    bundlerDocumentation: 'rolldown',
   },
   {
     name: 'rollup-react',
     label: 'React + Rollup',
     hint: 'A React application using Rollup as the bundler.',
     directory: 'bundlers',
+    bundlerDocumentation: 'rollup',
   },
   {
     name: 'tsdown',
@@ -96,6 +109,7 @@ export const Templates: readonly Template[] = [
     label: 'Angular + Rsbuild + Module Federation',
     hint: 'An Angular application with Module Federation using Rsbuild.',
     directory: 'module-federation',
+    bundlerDocumentation: 'rsbuild',
   },
   {
     name: 'angular-vite-mf',
@@ -103,12 +117,14 @@ export const Templates: readonly Template[] = [
     label: 'Angular + Vite + Module Federation',
     hint: 'An Angular application with Module Federation using Vite.',
     directory: 'module-federation',
+    bundlerDocumentation: 'vite',
   },
   {
     name: 'react-rsbuild',
     label: 'React + Rsbuild + Module Federation',
     hint: 'A React application with Module Federation using Rsbuild.',
     directory: 'module-federation',
+    bundlerDocumentation: 'rsbuild',
   },
   {
     name: 'react-vite-rspack-webpack',
@@ -121,12 +137,14 @@ export const Templates: readonly Template[] = [
     label: 'React + Webpack + Module Federation',
     hint: 'A React application with Module Federation using Webpack.',
     directory: 'module-federation',
+    bundlerDocumentation: 'webpack',
   },
   {
     name: 'tractor-sample',
     label: 'Tractor Store (Module Federation)',
     hint: 'A micro-frontend sample with Rspack and Module Federation.',
     directory: 'module-federation',
+    bundlerDocumentation: 'rspack',
   },
   // Frameworks
   {
@@ -134,6 +152,7 @@ export const Templates: readonly Template[] = [
     label: 'Angular + Vite',
     hint: 'You will be building an Angular app powered by Vite.',
     directory: 'frameworks',
+    bundlerDocumentation: 'vite',
   },
   {
     name: 'astro',
@@ -146,6 +165,7 @@ export const Templates: readonly Template[] = [
     label: 'Ember + Vite',
     hint: 'An Ember application using Vite as the bundler.',
     directory: 'frameworks',
+    bundlerDocumentation: 'vite',
   },
   {
     name: 'modernjs',
@@ -164,18 +184,21 @@ export const Templates: readonly Template[] = [
     label: 'Solid + Vite',
     hint: 'A Solid app using Vite as the bundler.',
     directory: 'frameworks',
+    bundlerDocumentation: 'vite',
   },
   {
     name: 'svelte-vite',
     label: 'Svelte + Vite',
     hint: 'A Svelte app using Vite as the bundler.',
     directory: 'frameworks',
+    bundlerDocumentation: 'vite',
   },
   {
     name: 'tanstack-start',
     label: 'TanStack Start',
     hint: 'A TanStack Start application with Vite.',
     directory: 'frameworks',
+    bundlerDocumentation: 'vite',
   },
   // Server
   {
@@ -202,14 +225,20 @@ export const Templates: readonly Template[] = [
     label: 'NX + React + Rspack + Module Federation',
     hint: 'A monorepo using NX, React, and Rspack with Module Federation.',
     directory: 'build-systems',
+    bundlerDocumentation: 'rspack',
   },
   {
     name: 'turborepo-rspack-mf',
     label: 'Turbo + Rspack + Module Federation',
     hint: 'A monorepo using Turborepo, React, and Rspack with Module Federation.',
     directory: 'build-systems',
+    bundlerDocumentation: 'rspack',
   },
-].sort((a, b) => a.name.localeCompare(b.name));
+];
+
+export const Templates: readonly Template[] = TemplateCatalog.sort((a, b) =>
+  a.name.localeCompare(b.name)
+);
 
 export function getTemplate(templateName: string): Template | undefined {
   return Templates.find((template) => template.name === templateName);

--- a/libs/create-zephyr-apps/src/templates.ts
+++ b/libs/create-zephyr-apps/src/templates.ts
@@ -9,17 +9,44 @@ export const ProjectTypes = [
     label: 'React Native',
     hint: 'This is a comprehensive example project provided by us. You will be building React Native powered by Re.Pack.',
   },
-];
+] as const;
 
 export type Template = {
   name: string;
   label: string;
   hint: string;
   directory: string;
+  sourceName?: string;
 };
 
-// TODO: Programmatically load templates from the examples repo after cloning it
-export const Templates: Template[] = [
+export type ProjectType = (typeof ProjectTypes)[number]['value'];
+
+export type TemplateRepository = {
+  name: string;
+  url: string;
+  revision: string;
+};
+
+/**
+ * Template revisions are intentionally pinned. Update them together with the catalog when
+ * publishing a create-zephyr-apps release.
+ */
+export const TemplateRepositories: Record<ProjectType, TemplateRepository> = {
+  web: {
+    name: 'zephyr-examples',
+    url: 'https://github.com/ZephyrCloudIO/zephyr-examples.git',
+    revision: '881c3a83d2f1888720c3da72e9b7a055aae1e3c7',
+  },
+  'react-native': {
+    name: 'zephyr-repack-example',
+    url: 'https://github.com/ZephyrCloudIO/zephyr-repack-example.git',
+    revision: 'ef50ebb43b43d2f1aa07ab1679fafa8b372662de',
+  },
+};
+
+export const DEFAULT_WEB_TEMPLATE = 'react-rsbuild';
+
+export const Templates: readonly Template[] = [
   // Bundlers
   {
     name: 'react-vite',
@@ -62,6 +89,19 @@ export const Templates: Template[] = [
     name: 'airbnb-clone',
     label: 'Airbnb clone',
     hint: 'You will be building an Airbnb clone with React, TypeScript, and Module Federation.',
+    directory: 'module-federation',
+  },
+  {
+    name: 'angular-rsbuild',
+    label: 'Angular + Rsbuild + Module Federation',
+    hint: 'An Angular application with Module Federation using Rsbuild.',
+    directory: 'module-federation',
+  },
+  {
+    name: 'angular-vite-mf',
+    sourceName: 'angular-vite',
+    label: 'Angular + Vite + Module Federation',
+    hint: 'An Angular application with Module Federation using Vite.',
     directory: 'module-federation',
   },
   {
@@ -170,3 +210,33 @@ export const Templates: Template[] = [
     directory: 'build-systems',
   },
 ].sort((a, b) => a.name.localeCompare(b.name));
+
+export function getTemplate(templateName: string): Template | undefined {
+  return Templates.find((template) => template.name === templateName);
+}
+
+export function validateTemplateCatalog(): void {
+  const names = new Set<string>();
+  const sourcePaths = new Set<string>();
+
+  for (const template of Templates) {
+    if (names.has(template.name)) {
+      throw new Error(`Duplicate template ID: ${template.name}`);
+    }
+    names.add(template.name);
+
+    const sourcePath = `${template.directory}/${template.sourceName ?? template.name}`;
+    if (sourcePaths.has(sourcePath)) {
+      throw new Error(`Duplicate template source path: ${sourcePath}`);
+    }
+    sourcePaths.add(sourcePath);
+  }
+
+  if (!names.has(DEFAULT_WEB_TEMPLATE)) {
+    throw new Error(
+      `Default template "${DEFAULT_WEB_TEMPLATE}" is missing from the template catalog.`
+    );
+  }
+}
+
+validateTemplateCatalog();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1826,6 +1826,9 @@ importers:
       '@rslib/core':
         specifier: catalog:rslib
         version: 0.23.2(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(typescript@5.9.3)
+      '@rstest/core':
+        specifier: catalog:rstest
+        version: 0.11.1(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0)(jsdom@29.1.1)
       '@types/node':
         specifier: catalog:typescript
         version: 24.13.3


### PR DESCRIPTION
## Summary

Make `create-zephyr-apps` deterministic and usable from agents, CI, and other non-TTY environments while preserving the existing interactive flow.

- add positional and `--directory` project paths plus a non-interactive parser
- pin both template repositories to exact release-compatible commits
- fix the default template ID to the existing `react-rsbuild` template
- add explicit package-manager, Git, install, build, JSON, and template-revision options
- reject unknown templates and non-empty output directories before fetching or writing
- record structured command, file, artifact, package-version, and failure receipts
- preserve install/build subprocess exit codes
- add parser, prompt-resolution, scaffolding, safety, Git, package-manager, artifact, and failure tests
- align the README examples with the parser and test the documented full command

## Why

The previous CLI required a TTY, cloned floating `main`, used a nonexistent interactive default (`mf-react-rsbuild`), always prompted for a Git commit, and could not provide machine-readable evidence. That forced automation to reconstruct templates and commands manually and made runs non-reproducible.

This change gives interactive users and automation one shared scaffolding implementation. Non-interactive defaults are deliberately conservative: `react-rsbuild`, pinned revision, no Git, no install, and no build unless requested.

## Behavior

```bash
create-zephyr-apps ./apps/example \
  --template react-rsbuild \
  --package-manager pnpm \
  --no-git \
  --install \
  --build \
  --json
```

`--build` implies `--install`. `--template-revision` accepts only a full 40-character commit SHA. Existing non-empty directories are rejected; this PR intentionally does not introduce a merge mode.

## Acceptance criteria

- [x] Positional and flag-based project directory behavior is documented and tested.
- [x] Non-interactive execution works without stdin/stdout TTYs.
- [x] Template IDs come from the pinned catalog and the default resolves to `react-rsbuild`.
- [x] Web and Re.Pack template repositories use exact commits compatible with this CLI release.
- [x] Existing non-empty directories fail before fetch/write and retain their contents.
- [x] Package-manager selection is explicit or deterministically detected.
- [x] Git initialization and the initial commit require a prompt confirmation or `--git`; `--no-git` is supported.
- [x] Optional install and build steps propagate their actual exit codes.
- [x] JSON reports created files, revision, package versions, commands, artifacts, and structured failures.
- [x] The documented end-to-end command is tested against the real parser.
- [x] CI tests prompt-resolved and non-interactive React/Rsbuild scaffolding through the same implementation.

## Validation

Run with the repository-pinned Node 24.15.0 and pnpm 11.17.0:

- `pnpm --filter create-zephyr-apps typecheck`
- `pnpm --filter create-zephyr-apps test` — 17 tests passed
- `pnpm --filter create-zephyr-apps build`
- `pnpm exec oxlint libs/create-zephyr-apps/src`
- commit hooks: repository-wide `oxfmt --check`, affected tests, and `oxlint`

Also smoke-tested the built non-TTY CLI against the pinned official `react-rsbuild` template. It fetched commit `881c3a83d2f1888720c3da72e9b7a055aae1e3c7`, copied the expected consumer/provider workspace, and emitted a successful JSON receipt. The smoke test did not install dependencies, build, authenticate, or deploy.

Closes #517