### PR TITLE
feat(zephyr-cli): add project doctor diagnostics

### DIFF
--- a/libs/zephyr-cli/README.md
+++ b/libs/zephyr-cli/README.md
@@ -79,12 +79,86 @@ rebuilding the TAP host. This command deliberately requires `--target tap-app`:
 ze-cli watch ./dist --target tap-app --metadata ./dist/zephyr-publication.json
 ```
 
+### Doctor Command
+
+Inspect a project or monorepo without installing dependencies, evaluating config
+files, editing files, building, authenticating, or deploying:
+
+```bash
+ze-cli doctor [directory] --format text
+ze-cli doctor [directory] --format json
+```
+
+The directory defaults to the current directory and must contain `package.json`.
+Doctor statically checks:
+
+- Supported bundler packages and config files.
+- Zephyr and Module Federation plugin declaration, installation, config use, and
+  plugin order.
+- Declared, locked, and installed Zephyr, Module Federation, TypeScript,
+  Rsbuild/Rspack, and other supported bundler versions.
+- Rsbuild `output.assetPrefix`, explicit `source.entry`, exposes, object-form
+  remotes, and `zephyr:dependencies` alias correspondence.
+- Web watch scripts versus TAP-only `ze-cli watch --target tap-app --metadata`.
+- `.mf/typesGenerate.log`, `node_modules/.federation` temporary artifacts,
+  `@mf-types.zip`, and safe DTS diagnostic commands.
+
+JSON uses schema version `1.0.0`. Consumers should branch on `status`,
+`exitCode`, and finding `code`; they must not match human-readable messages.
+Evidence paths are project-relative. Doctor never reads `.env` or emits config
+source, authentication state, environment values, or file contents.
+TypeScript report types, schema version, finding codes, and exit-code constants
+are exported from `zephyr-cli/doctor/schema`.
+
+#### Doctor exit codes
+
+| Code | Meaning                                      |
+| ---- | -------------------------------------------- |
+| `0`  | Healthy; no warning or error findings        |
+| `1`  | Valid project with warning or error findings |
+| `2`  | Invalid project path or root `package.json`  |
+| `3`  | Doctor could not complete the read-only scan |
+
+#### Stable finding codes
+
+Every finding contains `code`, `severity`, `message`, structured `evidence`, and
+`remediation`.
+
+| Code     | Check                                                 |
+| -------- | ----------------------------------------------------- |
+| `ZD0001` | Project directory not found                           |
+| `ZD0002` | Root `package.json` missing                           |
+| `ZD0003` | Package manifest cannot be parsed                     |
+| `ZD0004` | Read-only doctor scan failed                          |
+| `ZD0101` | Supported bundler not detected                        |
+| `ZD0102` | Rsbuild declared without an Rsbuild config            |
+| `ZD0201` | Zephyr Rsbuild plugin not declared                    |
+| `ZD0202` | Zephyr Rsbuild plugin not installed                   |
+| `ZD0203` | `withZephyr()` missing from Rsbuild config            |
+| `ZD0204` | Zephyr plugin appears before Module Federation        |
+| `ZD0210` | Declared Module Federation plugin missing from config |
+| `ZD0301` | Lockfile missing                                      |
+| `ZD0302` | Relevant package not installed                        |
+| `ZD0303` | Locked and installed package versions differ          |
+| `ZD0304` | Lockfile version extraction unsupported               |
+| `ZD0401` | Rsbuild `assetPrefix` missing                         |
+| `ZD0402` | Rsbuild `assetPrefix` is not `"auto"`                 |
+| `ZD0403` | Explicit Rsbuild `source.entry` missing               |
+| `ZD0410` | Module Federation expose key invalid                  |
+| `ZD0411` | Module Federation remotes are not object-form         |
+| `ZD0412` | Remote aliases and `zephyr:dependencies` keys differ  |
+| `ZD0501` | Web project uses TAP-only `ze-cli watch`              |
+| `ZD0502` | TAP watch target missing                              |
+| `ZD0503` | TAP watch metadata sidecar missing                    |
+| `ZD0601` | Module Federation DTS diagnostic failure found        |
+
 ## Options
 
 - `--ssr` - Mark this snapshot as server-side rendered
 - `--target, -t <target>` - Build target: `web`, `ios`, `android`, or `tap-app` (default: `web`)
 - `--metadata <path>` - JSON Module Federation sidecar. Required with `--target tap-app`.
 - `--debounce <milliseconds>` - Delay a `watch` publication until output changes settle (default: `250`)
+- `--format <json|text>` - Doctor output format (default: `text`)
 - `--verbose, -v` - Enable verbose output
 - `--help, -h` - Show help message
 

--- a/libs/zephyr-cli/package.json
+++ b/libs/zephyr-cli/package.json
@@ -43,6 +43,16 @@
         "default": "./dist/index.js"
       }
     },
+    "./doctor/schema": {
+      "import": {
+        "types": "./dist/doctor/schema.d.mts",
+        "default": "./dist/doctor/schema.mjs"
+      },
+      "require": {
+        "types": "./dist/doctor/schema.d.ts",
+        "default": "./dist/doctor/schema.js"
+      }
+    },
     "./package.json": "./package.json",
     "./*": "./*"
   },

--- a/libs/zephyr-cli/src/cli.spec.ts
+++ b/libs/zephyr-cli/src/cli.spec.ts
@@ -77,3 +77,30 @@ describe('parseArgs build target', () => {
     );
   });
 });
+
+describe('parseArgs doctor', () => {
+  it('defaults to the current directory and text output', () => {
+    expect(parseArgs(['doctor'])).toMatchObject({
+      command: 'doctor',
+      directory: '.',
+      format: 'text',
+    });
+  });
+
+  it('accepts an optional directory and JSON output', () => {
+    expect(parseArgs(['doctor', './apps/host', '--format', 'json'])).toMatchObject({
+      command: 'doctor',
+      directory: './apps/host',
+      format: 'json',
+    });
+  });
+
+  it('rejects unsupported doctor formats and flags', () => {
+    expect(() => parseArgs(['doctor', '--format', 'yaml'])).toThrow(
+      '--format must be either json or text'
+    );
+    expect(() => parseArgs(['doctor', '--write'])).toThrow(
+      'Unknown doctor option: --write'
+    );
+  });
+});

--- a/libs/zephyr-cli/src/cli.ts
+++ b/libs/zephyr-cli/src/cli.ts
@@ -1,9 +1,10 @@
 import { isZephyrBuildTarget, type ZephyrBuildTarget } from 'zephyr-edge-contract';
 
 export interface CliOptions {
-  command: 'run' | 'deploy' | 'watch';
+  command: 'run' | 'deploy' | 'watch' | 'doctor';
   commandLine?: string; // For 'run' command
-  directory?: string; // For 'deploy' and 'watch' commands
+  directory?: string; // For 'deploy', 'watch', and 'doctor' commands
+  format?: 'json' | 'text'; // For 'doctor'
   target?: ZephyrBuildTarget;
   verbose?: boolean;
   ssr?: boolean;
@@ -20,6 +21,7 @@ export interface CliOptions {
  * - Ze-cli [options] <command> [args...] - run command (default)
  * - Ze-cli deploy <directory> [options] - deploy command
  * - Ze-cli watch <directory> [options] - watch and publish command
+ * - Ze-cli doctor [directory] [--format json|text] - inspect without mutation
  *
  * Examples:
  *
@@ -29,6 +31,7 @@ export interface CliOptions {
  * - Ze-cli deploy ./dist
  * - Ze-cli deploy ./dist --target tap-app --metadata ./dist/zephyr-publication.json
  * - Ze-cli watch ./dist --target tap-app
+ * - Ze-cli doctor . --format json
  * - Ze-cli deploy ./dist --ssr
  */
 export function parseArgs(args: string[]): CliOptions {
@@ -94,7 +97,26 @@ export function parseArgs(args: string[]): CliOptions {
   const firstArg = args[commandStartIndex];
 
   // Check if it's a directory-based subcommand.
-  if (firstArg === 'deploy' || firstArg === 'watch') {
+  if (firstArg === 'doctor') {
+    options.command = 'doctor';
+    const possibleDirectory = args[commandStartIndex + 1];
+    const hasDirectory = Boolean(possibleDirectory && !possibleDirectory.startsWith('-'));
+    options.directory = hasDirectory ? possibleDirectory : '.';
+    options.format = 'text';
+
+    for (let i = commandStartIndex + (hasDirectory ? 2 : 1); i < args.length; i++) {
+      const arg = args[i];
+      if (arg === '--format') {
+        const value = args[++i];
+        if (value !== 'json' && value !== 'text') {
+          throw new Error('--format must be either json or text.');
+        }
+        options.format = value;
+      } else {
+        throw new Error(`Unknown doctor option: ${String(arg)}`);
+      }
+    }
+  } else if (firstArg === 'deploy' || firstArg === 'watch') {
     options.command = firstArg;
     const directory = args[commandStartIndex + 1];
 
@@ -150,6 +172,7 @@ function printHelp(): void {
   console.log(`
 Usage: ze-cli [options] <command> [args...]
        ze-cli deploy <directory> [options]
+       ze-cli doctor [directory] [--format json|text]
 
 Run a build command and automatically upload assets to Zephyr, or deploy
 pre-built assets from a directory.
@@ -158,6 +181,7 @@ Commands:
   <command> [args...]      Run a build command and upload (default)
   deploy <directory>       Upload pre-built assets from a directory
   watch <directory>        Watch pre-built output and publish each settled change
+  doctor [directory]       Inspect project readiness without installing or building
 
 Options:
   --ssr                    Mark this snapshot as server-side rendered
@@ -165,6 +189,7 @@ Options:
   --metadata <path>        JSON sidecar for Module Federation publication metadata
   --debounce <milliseconds>  Delay output-watch publications after changes (default: 250)
   --verbose                Enable verbose output
+  --format <json|text>     Doctor output format (default: text)
   --help, -h               Show this help message
 
 Examples:
@@ -183,12 +208,18 @@ Examples:
   ze-cli deploy ./dist --target tap-app --metadata ./dist/zephyr-publication.json
   ze-cli watch ./dist --target tap-app
 
+  # Inspect without mutation
+  ze-cli doctor .
+  ze-cli doctor ./apps/host --format json
+
 How it works:
   - For run commands, ze-cli executes your build command and automatically
     detects the output directory to upload assets.
   - For deploy commands, ze-cli uploads assets from the specified directory.
   - For watch commands, ze-cli publishes each settled output change as a new immutable
     snapshot. The Zephyr control plane authorizes and advances any development tag.
+  - The doctor command only reads project, package, config, lockfile, and diagnostic
+    artifact metadata. It never installs, edits, builds, authenticates, or deploys.
   - All stdout/stderr from build commands are passed through.
   - ze-cli logs are written to stderr only.
 

--- a/libs/zephyr-cli/src/commands/doctor.ts
+++ b/libs/zephyr-cli/src/commands/doctor.ts
@@ -1,0 +1,17 @@
+import { analyzeProject } from '../doctor/analyze';
+import { formatDoctorReport } from '../doctor/format';
+import type { DoctorExitCode } from '../doctor/schema';
+
+export interface DoctorCommandOptions {
+  directory: string;
+  format: 'json' | 'text';
+  cwd: string;
+}
+
+export async function doctorCommand(
+  options: DoctorCommandOptions
+): Promise<DoctorExitCode> {
+  const report = await analyzeProject(options.directory, { cwd: options.cwd });
+  console.log(formatDoctorReport(report, options.format));
+  return report.exitCode;
+}

--- a/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/apps/host/package.fixture.json
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/apps/host/package.fixture.json
@@ -1,0 +1,12 @@
+{
+  "name": "host",
+  "private": true,
+  "devDependencies": {
+    "@module-federation/rsbuild-plugin": "2.8.0",
+    "@rsbuild/core": "2.1.5",
+    "zephyr-rsbuild-plugin": "1.2.0"
+  },
+  "zephyr:dependencies": {
+    "catalogHeader": "zephyr:header.example.example@production"
+  }
+}

--- a/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/apps/host/rsbuild.config.ts
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/apps/host/rsbuild.config.ts
@@ -1,0 +1,16 @@
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+import { defineConfig } from '@rsbuild/core';
+import { withZephyr } from 'zephyr-rsbuild-plugin';
+
+export default defineConfig({
+  output: {
+    assetPrefix: '/static/',
+  },
+  plugins: [
+    withZephyr(),
+    pluginModuleFederation({
+      name: 'host',
+      remotes: ['header@http://localhost:3001/remoteEntry.js'],
+    }),
+  ],
+});

--- a/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/apps/remote/package.fixture.json
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/apps/remote/package.fixture.json
@@ -1,0 +1,9 @@
+{
+  "name": "remote",
+  "private": true,
+  "devDependencies": {
+    "@module-federation/rsbuild-plugin": "2.8.0",
+    "@rsbuild/core": "2.1.5",
+    "zephyr-rsbuild-plugin": "1.2.0"
+  }
+}

--- a/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/apps/remote/rsbuild.config.ts
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/apps/remote/rsbuild.config.ts
@@ -1,0 +1,15 @@
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+import { defineConfig } from '@rsbuild/core';
+import { withZephyr } from 'zephyr-rsbuild-plugin';
+
+export default defineConfig({
+  plugins: [
+    pluginModuleFederation({
+      name: 'remote',
+      exposes: {
+        button: './src/Button.tsx',
+      },
+    }),
+    withZephyr(),
+  ],
+});

--- a/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/package.fixture.json
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/package.fixture.json
@@ -1,0 +1,11 @@
+{
+  "name": "broken-rsbuild-workspace",
+  "private": true,
+  "packageManager": "pnpm@11.17.0",
+  "scripts": {
+    "watch": "ze-cli watch ./dist"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/pnpm-lock.yaml
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/pnpm-lock.yaml
@@ -1,0 +1,30 @@
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+  apps/host:
+    devDependencies:
+      '@module-federation/rsbuild-plugin':
+        specifier: 2.8.0
+        version: 2.8.0
+      '@rsbuild/core':
+        specifier: 2.1.5
+        version: 2.1.5
+      zephyr-rsbuild-plugin:
+        specifier: 1.2.0
+        version: 1.2.0
+  apps/remote:
+    devDependencies:
+      '@module-federation/rsbuild-plugin':
+        specifier: 2.8.0
+        version: 2.8.0
+      '@rsbuild/core':
+        specifier: 2.1.5
+        version: 2.1.5
+      zephyr-rsbuild-plugin:
+        specifier: 1.2.0
+        version: 1.2.0

--- a/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/pnpm-workspace.yaml
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/broken-rsbuild/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - apps/*

--- a/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/apps/host/package.fixture.json
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/apps/host/package.fixture.json
@@ -1,0 +1,15 @@
+{
+  "name": "host",
+  "private": true,
+  "scripts": {
+    "build": "rsbuild build"
+  },
+  "devDependencies": {
+    "@module-federation/rsbuild-plugin": "2.8.0",
+    "@rsbuild/core": "2.1.5",
+    "zephyr-rsbuild-plugin": "1.2.0"
+  },
+  "zephyr:dependencies": {
+    "remote": "zephyr:remote.example.example@production"
+  }
+}

--- a/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/apps/host/rsbuild.config.ts
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/apps/host/rsbuild.config.ts
@@ -1,0 +1,23 @@
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+import { defineConfig } from '@rsbuild/core';
+import { withZephyr } from 'zephyr-rsbuild-plugin';
+
+export default defineConfig({
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  output: {
+    assetPrefix: 'auto',
+  },
+  plugins: [
+    pluginModuleFederation({
+      name: 'host',
+      remotes: {
+        remote: 'remote@http://localhost:3001/mf-manifest.json',
+      },
+    }),
+    withZephyr(),
+  ],
+});

--- a/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/apps/remote/package.fixture.json
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/apps/remote/package.fixture.json
@@ -1,0 +1,12 @@
+{
+  "name": "remote",
+  "private": true,
+  "scripts": {
+    "build": "rsbuild build"
+  },
+  "devDependencies": {
+    "@module-federation/rsbuild-plugin": "2.8.0",
+    "@rsbuild/core": "2.1.5",
+    "zephyr-rsbuild-plugin": "1.2.0"
+  }
+}

--- a/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/apps/remote/rsbuild.config.ts
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/apps/remote/rsbuild.config.ts
@@ -1,0 +1,24 @@
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+import { defineConfig } from '@rsbuild/core';
+import { withZephyr } from 'zephyr-rsbuild-plugin';
+
+export default defineConfig({
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  output: {
+    assetPrefix: 'auto',
+  },
+  plugins: [
+    pluginModuleFederation({
+      name: 'remote',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './button': './src/Button.tsx',
+      },
+    }),
+    withZephyr(),
+  ],
+});

--- a/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/package.fixture.json
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/package.fixture.json
@@ -1,0 +1,12 @@
+{
+  "name": "healthy-rsbuild-workspace",
+  "private": true,
+  "packageManager": "pnpm@11.17.0",
+  "scripts": {
+    "build": "pnpm --filter remote build && pnpm --filter host build",
+    "watch": "rsbuild build --watch"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/pnpm-lock.yaml
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/pnpm-lock.yaml
@@ -1,0 +1,30 @@
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+  apps/host:
+    devDependencies:
+      '@module-federation/rsbuild-plugin':
+        specifier: 2.8.0
+        version: 2.8.0
+      '@rsbuild/core':
+        specifier: 2.1.5
+        version: 2.1.5
+      zephyr-rsbuild-plugin:
+        specifier: 1.2.0
+        version: 1.2.0
+  apps/remote:
+    devDependencies:
+      '@module-federation/rsbuild-plugin':
+        specifier: 2.8.0
+        version: 2.8.0
+      '@rsbuild/core':
+        specifier: 2.1.5
+        version: 2.1.5
+      zephyr-rsbuild-plugin:
+        specifier: 1.2.0
+        version: 1.2.0

--- a/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/pnpm-workspace.yaml
+++ b/libs/zephyr-cli/src/doctor/__fixtures__/healthy-rsbuild/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - apps/*

--- a/libs/zephyr-cli/src/doctor/analyze.ts
+++ b/libs/zephyr-cli/src/doctor/analyze.ts
@@ -1,0 +1,1255 @@
+import * as fs from 'node:fs';
+import path from 'node:path';
+import {
+  DOCTOR_SCHEMA_VERSION,
+  DoctorExitCode,
+  DoctorFindingCode,
+  type DoctorBundlerState,
+  type DoctorConfigState,
+  type DoctorDtsState,
+  type DoctorFinding,
+  type DoctorPackageState,
+  type DoctorReport,
+  type DoctorWatchState,
+  type SupportedBundler,
+} from './schema';
+
+const MAX_TEXT_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_SCAN_DIRECTORIES = 10_000;
+const CONFIG_FILE_PATTERN =
+  /^(rsbuild|rspack|webpack|vite|rollup|rslib)\.config\.(?:js|mjs|cjs|ts|mts|cts)$/u;
+const EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.turbo',
+  '.output',
+  'build',
+  'coverage',
+  'dist',
+  'out',
+  'node_modules',
+]);
+
+type PackageManager = DoctorReport['packageManager'];
+
+interface PackageManifest {
+  absolutePath: string;
+  relativePath: string;
+  directory: string;
+  data: PackageJson;
+}
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+  packageManager?: string;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  'zephyr:dependencies'?: Record<string, string>;
+  'zephyr:target'?: string;
+}
+
+interface ConfigFile {
+  absolutePath: string;
+  relativePath: string;
+  bundler: SupportedBundler;
+  manifest: PackageManifest;
+}
+
+interface LockState {
+  path: string | null;
+  packageManager: PackageManager;
+  format: Exclude<PackageManager, 'unknown'> | null;
+  versions: Map<string, Set<string>>;
+  supported: boolean;
+}
+
+interface PropertyContainer {
+  kind: 'object' | 'array';
+  body: string;
+  start: number;
+}
+
+export interface DoctorOptions {
+  cwd?: string;
+}
+
+export async function analyzeProject(
+  directory = '.',
+  options: DoctorOptions = {}
+): Promise<DoctorReport> {
+  const projectDirectory = path.resolve(options.cwd ?? process.cwd(), directory);
+  const report = createBaseReport(projectDirectory);
+
+  try {
+    let rootStats: fs.Stats;
+    try {
+      rootStats = await fs.promises.stat(projectDirectory);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return invalidProjectReport(
+          report,
+          DoctorFindingCode.ProjectNotFound,
+          'The requested project directory does not exist.',
+          'Pass an existing project directory containing package.json.'
+        );
+      }
+      throw error;
+    }
+
+    if (!rootStats.isDirectory()) {
+      return invalidProjectReport(
+        report,
+        DoctorFindingCode.ProjectNotFound,
+        'The requested project path is not a directory.',
+        'Pass a project directory containing package.json.'
+      );
+    }
+
+    const rootPackagePath = path.join(projectDirectory, 'package.json');
+    if (!(await pathExists(rootPackagePath))) {
+      return invalidProjectReport(
+        report,
+        DoctorFindingCode.PackageJsonMissing,
+        'No package.json was found in the requested project directory.',
+        'Run doctor from the project or workspace root.'
+      );
+    }
+
+    const rootManifestResult = await readPackageManifest(
+      rootPackagePath,
+      projectDirectory
+    );
+    if (!rootManifestResult.manifest) {
+      return invalidProjectReport(
+        report,
+        DoctorFindingCode.PackageJsonInvalid,
+        'The root package.json could not be parsed.',
+        'Fix the JSON syntax in package.json before running doctor again.',
+        rootManifestResult.detail
+      );
+    }
+
+    const findings: DoctorFinding[] = [];
+    const manifests = await discoverPackageManifests(
+      projectDirectory,
+      rootManifestResult.manifest,
+      findings
+    );
+    const configFiles = await discoverConfigFiles(projectDirectory, manifests);
+    const lockState = await inspectLockfile(
+      projectDirectory,
+      rootManifestResult.manifest.data
+    );
+
+    report.packageManager = lockState.packageManager;
+    report.lockfile = lockState.path;
+    report.bundlers = detectBundlers(manifests, configFiles);
+    report.configs = await inspectConfigs(projectDirectory, configFiles, findings);
+    report.packages = await inspectPackages(
+      projectDirectory,
+      manifests,
+      lockState,
+      findings
+    );
+    inspectBundlerReadiness(report.bundlers, report.configs, manifests, findings);
+    inspectLockfileReadiness(lockState, findings);
+    report.watch = inspectWatchMode(manifests, report.bundlers, findings);
+    report.dts = await inspectDtsEvidence(
+      projectDirectory,
+      manifests,
+      report.packageManager,
+      findings
+    );
+
+    return finalizeReport(report, findings);
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    report.findings = [
+      {
+        code: DoctorFindingCode.ToolFailure,
+        severity: 'error',
+        message: 'Zephyr Doctor could not complete the read-only project scan.',
+        evidence: [
+          {
+            path: '.',
+            detail: errorCode ? `filesystem error: ${errorCode}` : 'unexpected error',
+          },
+        ],
+        remediation:
+          'Verify the directory is readable and retry. Use --format json when reporting the failure.',
+      },
+    ];
+    report.summary = { errors: 1, warnings: 0, info: 0 };
+    report.status = 'tool_failure';
+    report.exitCode = DoctorExitCode.ToolFailure;
+    return report;
+  }
+}
+
+function createBaseReport(projectDirectory: string): DoctorReport {
+  return {
+    schemaVersion: DOCTOR_SCHEMA_VERSION,
+    command: 'doctor',
+    status: 'healthy',
+    exitCode: DoctorExitCode.Healthy,
+    projectDirectory,
+    packageManager: 'unknown',
+    lockfile: null,
+    bundlers: [],
+    configs: [],
+    packages: [],
+    watch: {
+      mode: 'unknown',
+      scriptNames: [],
+      recommendedCommand: null,
+    },
+    dts: {
+      logs: [],
+      temporaryArtifacts: [],
+      typeArchives: [],
+      diagnosticCommands: [],
+    },
+    summary: { errors: 0, warnings: 0, info: 0 },
+    findings: [],
+  };
+}
+
+function invalidProjectReport(
+  report: DoctorReport,
+  code:
+    | typeof DoctorFindingCode.ProjectNotFound
+    | typeof DoctorFindingCode.PackageJsonMissing
+    | typeof DoctorFindingCode.PackageJsonInvalid,
+  message: string,
+  remediation: string,
+  detail?: string
+): DoctorReport {
+  report.status = 'invalid_project';
+  report.exitCode = DoctorExitCode.InvalidProject;
+  report.findings = [
+    {
+      code,
+      severity: 'error',
+      message,
+      evidence: [{ path: 'package.json', detail }],
+      remediation,
+    },
+  ];
+  report.summary = { errors: 1, warnings: 0, info: 0 };
+  return report;
+}
+
+function finalizeReport(report: DoctorReport, findings: DoctorFinding[]): DoctorReport {
+  report.findings = findings.sort(
+    (left, right) =>
+      severityRank(left.severity) - severityRank(right.severity) ||
+      left.code.localeCompare(right.code) ||
+      (left.evidence[0]?.path ?? '').localeCompare(right.evidence[0]?.path ?? '')
+  );
+  report.summary = {
+    errors: findings.filter(({ severity }) => severity === 'error').length,
+    warnings: findings.filter(({ severity }) => severity === 'warning').length,
+    info: findings.filter(({ severity }) => severity === 'info').length,
+  };
+  if (report.summary.errors > 0 || report.summary.warnings > 0) {
+    report.status = 'findings';
+    report.exitCode = DoctorExitCode.Findings;
+  }
+  return report;
+}
+
+function severityRank(severity: DoctorFinding['severity']): number {
+  return severity === 'error' ? 0 : severity === 'warning' ? 1 : 2;
+}
+
+async function discoverPackageManifests(
+  root: string,
+  rootManifest: PackageManifest,
+  findings: DoctorFinding[]
+): Promise<PackageManifest[]> {
+  const manifests = [rootManifest];
+  let visitedDirectories = 0;
+
+  const visit = async (directory: string): Promise<void> => {
+    visitedDirectories += 1;
+    if (visitedDirectories > MAX_SCAN_DIRECTORIES) {
+      throw new Error(`Project scan exceeded ${MAX_SCAN_DIRECTORIES} directories.`);
+    }
+
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || EXCLUDED_DIRECTORIES.has(entry.name)) continue;
+      const childDirectory = path.join(directory, entry.name);
+      const childPackagePath = path.join(childDirectory, 'package.json');
+      if (await pathExists(childPackagePath)) {
+        const result = await readPackageManifest(childPackagePath, root);
+        if (result.manifest) {
+          manifests.push(result.manifest);
+        } else {
+          findings.push({
+            code: DoctorFindingCode.PackageJsonInvalid,
+            severity: 'warning',
+            message: 'A workspace package.json could not be parsed.',
+            evidence: [
+              {
+                path: relativePath(root, childPackagePath),
+                detail: result.detail,
+              },
+            ],
+            remediation:
+              'Fix the workspace package.json syntax so package and config checks include it.',
+          });
+        }
+      }
+      await visit(childDirectory);
+    }
+  };
+
+  await visit(root);
+  return uniqueBy(manifests, ({ relativePath: manifestPath }) => manifestPath);
+}
+
+async function readPackageManifest(
+  absolutePath: string,
+  root: string
+): Promise<{ manifest?: PackageManifest; detail?: string }> {
+  const content = await readBoundedTextFile(absolutePath);
+  try {
+    const data = JSON.parse(content) as PackageJson | undefined;
+    if (!data) {
+      return { detail: 'empty JSON document' };
+    }
+    return {
+      manifest: {
+        absolutePath,
+        relativePath: relativePath(root, absolutePath),
+        directory: path.dirname(absolutePath),
+        data,
+      },
+    };
+  } catch {
+    return { detail: 'invalid JSON syntax' };
+  }
+}
+
+async function discoverConfigFiles(
+  root: string,
+  manifests: PackageManifest[]
+): Promise<ConfigFile[]> {
+  const configFiles: ConfigFile[] = [];
+  for (const manifest of manifests) {
+    const entries = await fs.promises.readdir(manifest.directory, {
+      withFileTypes: true,
+    });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const match = CONFIG_FILE_PATTERN.exec(entry.name);
+      if (!match) continue;
+      configFiles.push({
+        absolutePath: path.join(manifest.directory, entry.name),
+        relativePath: relativePath(root, path.join(manifest.directory, entry.name)),
+        bundler: match[1] as SupportedBundler,
+        manifest,
+      });
+    }
+  }
+  return configFiles.sort((left, right) =>
+    left.relativePath.localeCompare(right.relativePath)
+  );
+}
+
+function detectBundlers(
+  manifests: PackageManifest[],
+  configs: ConfigFile[]
+): DoctorBundlerState[] {
+  const bundlers = new Map<SupportedBundler, Set<string>>();
+  const packageToBundler: Record<string, SupportedBundler> = {
+    '@rsbuild/core': 'rsbuild',
+    '@rspack/core': 'rspack',
+    webpack: 'webpack',
+    vite: 'vite',
+    rollup: 'rollup',
+    '@rslib/core': 'rslib',
+  };
+
+  for (const manifest of manifests) {
+    for (const packageName of declaredPackageNames(manifest.data)) {
+      const bundler = packageToBundler[packageName];
+      if (bundler && !bundlers.has(bundler)) bundlers.set(bundler, new Set());
+    }
+  }
+  for (const config of configs) {
+    const paths = bundlers.get(config.bundler) ?? new Set<string>();
+    paths.add(config.relativePath);
+    bundlers.set(config.bundler, paths);
+  }
+
+  return [...bundlers.entries()]
+    .map(([name, configFiles]) => ({
+      name,
+      configFiles: [...configFiles].sort(),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function inspectConfigs(
+  root: string,
+  configFiles: ConfigFile[],
+  findings: DoctorFinding[]
+): Promise<DoctorConfigState[]> {
+  const states: DoctorConfigState[] = [];
+
+  for (const config of configFiles) {
+    const source = await readBoundedTextFile(config.absolutePath);
+    const zephyrCall = /\bwithZephyr\s*\(/u.exec(source);
+    const moduleFederationCall = /\bpluginModuleFederation\s*\(/u.exec(source);
+    const assetPrefixMatch = /\bassetPrefix\s*:\s*(['"`])auto\1/u.exec(source);
+    const hasAssetPrefix = /\bassetPrefix\s*:/u.test(source);
+    const sourceEntry = /\bsource\s*:\s*\{[\s\S]*?\bentry\s*:/u.test(source);
+    const exposes = extractPropertyContainer(source, 'exposes');
+    const remotes = extractPropertyContainer(source, 'remotes');
+    const exposeKeys =
+      exposes?.kind === 'object' ? extractTopLevelObjectKeys(exposes.body) : [];
+    const remoteKeys =
+      remotes?.kind === 'object' ? extractTopLevelObjectKeys(remotes.body) : [];
+    const declaredNames = new Set(declaredPackageNames(config.manifest.data));
+
+    if (config.bundler === 'rsbuild') {
+      if (!declaredNames.has('zephyr-rsbuild-plugin')) {
+        findings.push({
+          code: DoctorFindingCode.ZephyrPluginNotDeclared,
+          severity: 'error',
+          message: 'The Rsbuild package does not declare zephyr-rsbuild-plugin.',
+          evidence: [{ path: config.manifest.relativePath }],
+          remediation:
+            'Add zephyr-rsbuild-plugin with the workspace package manager, then reinstall.',
+        });
+      }
+      if (!zephyrCall) {
+        findings.push({
+          code: DoctorFindingCode.ZephyrPluginConfigMissing,
+          severity: 'error',
+          message: 'The Rsbuild config does not call withZephyr().',
+          evidence: [{ path: config.relativePath }],
+          remediation:
+            'Import withZephyr from zephyr-rsbuild-plugin and place withZephyr() after Module Federation.',
+        });
+      }
+      if (
+        declaredNames.has('@module-federation/rsbuild-plugin') &&
+        !moduleFederationCall
+      ) {
+        findings.push({
+          code: DoctorFindingCode.ModuleFederationPluginConfigMissing,
+          severity: 'error',
+          message:
+            'The package declares the Module Federation Rsbuild plugin but the config does not call it.',
+          evidence: [{ path: config.relativePath }],
+          remediation:
+            'Add pluginModuleFederation(...) to the Rsbuild plugins array before withZephyr().',
+        });
+      }
+      if (
+        zephyrCall &&
+        moduleFederationCall &&
+        zephyrCall.index < moduleFederationCall.index
+      ) {
+        findings.push({
+          code: DoctorFindingCode.ZephyrPluginOrder,
+          severity: 'error',
+          message: 'withZephyr() appears before pluginModuleFederation().',
+          evidence: [
+            {
+              path: config.relativePath,
+              line: lineNumber(source, zephyrCall.index),
+            },
+          ],
+          remediation:
+            'Move withZephyr() after pluginModuleFederation() in the plugins array.',
+        });
+      }
+      if (!hasAssetPrefix) {
+        findings.push({
+          code: DoctorFindingCode.AssetPrefixMissing,
+          severity: 'warning',
+          message: 'The Rsbuild config does not set output.assetPrefix.',
+          evidence: [{ path: config.relativePath }],
+          remediation: 'Set output.assetPrefix to "auto" for Zephyr-hosted assets.',
+        });
+      } else if (!assetPrefixMatch) {
+        findings.push({
+          code: DoctorFindingCode.AssetPrefixInvalid,
+          severity: 'error',
+          message: 'The Rsbuild assetPrefix is not set to "auto".',
+          evidence: [{ path: config.relativePath }],
+          remediation: 'Set output.assetPrefix to "auto".',
+        });
+      }
+      if (!sourceEntry) {
+        findings.push({
+          code: DoctorFindingCode.SourceEntryMissing,
+          severity: 'warning',
+          message: 'The Rsbuild config does not declare an explicit source.entry.',
+          evidence: [{ path: config.relativePath }],
+          remediation:
+            'Declare source.entry explicitly so build and federation entry behavior is reproducible.',
+        });
+      }
+    }
+
+    if (exposes?.kind === 'object') {
+      for (const exposeKey of exposeKeys.filter((key) => !key.startsWith('./'))) {
+        findings.push({
+          code: DoctorFindingCode.ExposeKeyInvalid,
+          severity: 'error',
+          message: 'A Module Federation expose key does not start with "./".',
+          evidence: [
+            {
+              path: config.relativePath,
+              detail: `expose key: ${boundedDetail(exposeKey)}`,
+            },
+          ],
+          remediation: 'Prefix exposed module keys with "./", for example "./button".',
+        });
+      }
+    }
+    if (remotes?.kind === 'array') {
+      findings.push({
+        code: DoctorFindingCode.RemotesMustBeObject,
+        severity: 'error',
+        message: 'Module Federation remotes must use object form.',
+        evidence: [{ path: config.relativePath }],
+        remediation:
+          'Use an object whose keys are stable remote aliases and values are remote definitions.',
+      });
+    }
+
+    const remoteDependencyKeys = Object.keys(
+      config.manifest.data['zephyr:dependencies'] ?? {}
+    );
+    if (remoteDependencyKeys.length > 0) {
+      const missingRemotes = remoteDependencyKeys.filter(
+        (key) => !remoteKeys.includes(key)
+      );
+      const missingDependencies = remoteKeys.filter(
+        (key) => !remoteDependencyKeys.includes(key)
+      );
+      if (missingRemotes.length > 0 || missingDependencies.length > 0) {
+        findings.push({
+          code: DoctorFindingCode.RemoteDependencyAliasMismatch,
+          severity: 'error',
+          message:
+            'Module Federation remote aliases and zephyr:dependencies keys do not match.',
+          evidence: [
+            {
+              path: config.relativePath,
+              detail: boundedDetail(
+                [
+                  missingRemotes.length
+                    ? `missing remotes: ${missingRemotes.join(', ')}`
+                    : '',
+                  missingDependencies.length
+                    ? `missing dependencies: ${missingDependencies.join(', ')}`
+                    : '',
+                ]
+                  .filter(Boolean)
+                  .join('; ')
+              ),
+            },
+            { path: config.manifest.relativePath },
+          ],
+          remediation:
+            'Use the same alias keys in Module Federation remotes and package.json zephyr:dependencies.',
+        });
+      }
+    }
+
+    states.push({
+      path: config.relativePath,
+      bundler: config.bundler,
+      zephyrPlugin: Boolean(zephyrCall),
+      moduleFederationPlugin: Boolean(moduleFederationCall),
+      assetPrefix: assetPrefixMatch ? 'auto' : hasAssetPrefix ? 'other' : 'missing',
+      sourceEntry,
+      exposes: exposeKeys.sort(),
+      remotes: remoteKeys.sort(),
+    });
+  }
+
+  return states;
+}
+
+function inspectBundlerReadiness(
+  bundlers: DoctorBundlerState[],
+  configs: DoctorConfigState[],
+  manifests: PackageManifest[],
+  findings: DoctorFinding[]
+): void {
+  if (bundlers.length === 0) {
+    findings.push({
+      code: DoctorFindingCode.BundlerNotDetected,
+      severity: 'warning',
+      message: 'No supported bundler was detected.',
+      evidence: [{ path: 'package.json' }],
+      remediation:
+        'Declare a supported bundler and add its standard config file before publishing.',
+    });
+  }
+
+  if (
+    bundlers.some(({ name }) => name === 'rsbuild') &&
+    !configs.some(({ bundler }) => bundler === 'rsbuild')
+  ) {
+    const rsbuildManifest =
+      manifests.find((manifest) =>
+        declaredPackageNames(manifest.data).includes('@rsbuild/core')
+      ) ?? manifests[0];
+    findings.push({
+      code: DoctorFindingCode.RsbuildConfigMissing,
+      severity: 'error',
+      message: 'Rsbuild is declared but no rsbuild.config file was found.',
+      evidence: [{ path: rsbuildManifest?.relativePath ?? 'package.json' }],
+      remediation: 'Add rsbuild.config.ts using defineConfig.',
+    });
+  }
+}
+
+async function inspectLockfile(
+  root: string,
+  rootPackage: PackageJson
+): Promise<LockState> {
+  const candidates: Array<{
+    file: string;
+    manager: Exclude<PackageManager, 'unknown'>;
+  }> = [
+    { file: 'pnpm-lock.yaml', manager: 'pnpm' },
+    { file: 'package-lock.json', manager: 'npm' },
+    { file: 'yarn.lock', manager: 'yarn' },
+    { file: 'bun.lock', manager: 'bun' },
+    { file: 'bun.lockb', manager: 'bun' },
+  ];
+  const declaredManager = packageManagerName(rootPackage.packageManager);
+
+  for (const candidate of candidates) {
+    const absolutePath = path.join(root, candidate.file);
+    if (!(await pathExists(absolutePath))) continue;
+    return {
+      path: candidate.file,
+      packageManager: declaredManager ?? candidate.manager,
+      format: candidate.manager,
+      versions: new Map(),
+      supported: candidate.manager !== 'bun',
+    };
+  }
+
+  return {
+    path: null,
+    packageManager: declaredManager ?? 'unknown',
+    format: null,
+    versions: new Map(),
+    supported: true,
+  };
+}
+
+function inspectLockfileReadiness(lockState: LockState, findings: DoctorFinding[]): void {
+  if (!lockState.path) {
+    findings.push({
+      code: DoctorFindingCode.LockfileMissing,
+      severity: 'warning',
+      message: 'No supported package-manager lockfile was found.',
+      evidence: [{ path: 'package.json' }],
+      remediation:
+        'Install with the selected package manager and commit its lockfile for reproducible builds.',
+    });
+  } else if (!lockState.supported) {
+    findings.push({
+      code: DoctorFindingCode.LockfileUnsupported,
+      severity: 'warning',
+      message: 'This lockfile format cannot yet be inspected for resolved versions.',
+      evidence: [{ path: lockState.path }],
+      remediation:
+        'Confirm installed versions with the package manager until this lockfile format is supported.',
+    });
+  }
+}
+
+async function inspectPackages(
+  root: string,
+  manifests: PackageManifest[],
+  lockState: LockState,
+  findings: DoctorFinding[]
+): Promise<DoctorPackageState[]> {
+  const declared = new Map<string, Array<{ manifest: PackageManifest; range: string }>>();
+
+  for (const manifest of manifests) {
+    for (const [name, range] of declaredPackages(manifest.data)) {
+      if (!isRelevantPackage(name)) continue;
+      const entries = declared.get(name) ?? [];
+      entries.push({ manifest, range });
+      declared.set(name, entries);
+    }
+  }
+
+  if (lockState.path && lockState.supported) {
+    lockState.versions = await readLockVersions(
+      path.join(root, lockState.path),
+      lockState.format ?? lockState.packageManager,
+      [...declared.keys()]
+    );
+  }
+
+  const states: DoctorPackageState[] = [];
+  for (const [name, declarations] of [...declared.entries()].sort(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    const installed = new Map<string, string>();
+    for (const declaration of declarations) {
+      const installedManifest = await findInstalledPackageManifest(
+        declaration.manifest.directory,
+        root,
+        name
+      );
+      if (!installedManifest) continue;
+      const installedResult = await readPackageManifest(installedManifest, root);
+      const version = installedResult.manifest?.data.version;
+      if (version) {
+        installed.set(relativePath(root, installedManifest), version);
+      }
+    }
+
+    const locked = [...(lockState.versions.get(name) ?? new Set())].sort();
+    const installedEntries = [...installed.entries()]
+      .map(([installedPath, version]) => ({ path: installedPath, version }))
+      .sort((left, right) => left.path.localeCompare(right.path));
+
+    states.push({
+      name,
+      declared: declarations
+        .map(({ manifest, range }) => ({
+          path: manifest.relativePath,
+          range: boundedDetail(range),
+        }))
+        .sort((left, right) => left.path.localeCompare(right.path)),
+      locked,
+      installed: installedEntries,
+    });
+
+    if (installedEntries.length === 0) {
+      findings.push({
+        code:
+          name === 'zephyr-rsbuild-plugin'
+            ? DoctorFindingCode.ZephyrPluginNotInstalled
+            : DoctorFindingCode.PackageNotInstalled,
+        severity: 'warning',
+        message: `${name} is declared but no installed package.json was found.`,
+        evidence: declarations.map(({ manifest, range }) => ({
+          path: manifest.relativePath,
+          detail: `declared: ${boundedDetail(range)}`,
+        })),
+        remediation: 'Run the workspace package-manager install and retry doctor.',
+      });
+    }
+
+    if (
+      locked.length > 0 &&
+      installedEntries.some(({ version }) => !locked.includes(version))
+    ) {
+      findings.push({
+        code: DoctorFindingCode.PackageVersionMismatch,
+        severity: 'error',
+        message: `${name} has different locked and installed versions.`,
+        evidence: [
+          ...(lockState.path
+            ? [
+                {
+                  path: lockState.path,
+                  detail: `locked: ${boundedDetail(locked.join(', '))}`,
+                },
+              ]
+            : []),
+          ...installedEntries.map(({ path: installedPath, version }) => ({
+            path: installedPath,
+            detail: `installed: ${boundedDetail(version)}`,
+          })),
+        ],
+        remediation:
+          'Reinstall from the committed lockfile and do not debug against a divergent node_modules tree.',
+      });
+    }
+  }
+  return states;
+}
+
+async function readLockVersions(
+  lockfilePath: string,
+  packageManager: PackageManager,
+  packageNames: string[]
+): Promise<Map<string, Set<string>>> {
+  const versions = new Map<string, Set<string>>();
+  const content = await readBoundedTextFile(lockfilePath);
+
+  if (packageManager === 'npm') {
+    const parsed = JSON.parse(content) as {
+      packages?: Record<string, { version?: string }>;
+    };
+    for (const packageName of packageNames) {
+      const version = parsed.packages?.[`node_modules/${packageName}`]?.version;
+      if (version) versions.set(packageName, new Set([version]));
+    }
+    return versions;
+  }
+
+  const lines = content.split(/\r?\n/u);
+  for (const packageName of packageNames) {
+    const found = new Set<string>();
+    for (let index = 0; index < lines.length; index++) {
+      const line = lines[index] ?? '';
+      const key = unquoteYamlKey(line.trim().replace(/:$/u, ''));
+
+      if (packageManager === 'pnpm' && key === packageName) {
+        const indent = leadingWhitespace(line);
+        for (let next = index + 1; next < lines.length; next++) {
+          const candidate = lines[next] ?? '';
+          if (candidate.trim() && leadingWhitespace(candidate) <= indent) break;
+          const versionMatch = /^\s*version:\s*(['"]?)([^'"\s]+)\1\s*$/u.exec(candidate);
+          if (versionMatch?.[2]) found.add(normalizeLockVersion(versionMatch[2]));
+        }
+      } else if (
+        packageManager === 'yarn' &&
+        leadingWhitespace(line) === 0 &&
+        line.includes(`${packageName}@`) &&
+        line.trim().endsWith(':')
+      ) {
+        for (let next = index + 1; next < lines.length; next++) {
+          const candidate = lines[next] ?? '';
+          if (candidate.trim() && leadingWhitespace(candidate) === 0) break;
+          const versionMatch = /^\s*version\s+(['"]?)([^'"\s]+)\1\s*$/u.exec(candidate);
+          if (versionMatch?.[2]) found.add(normalizeLockVersion(versionMatch[2]));
+        }
+      }
+    }
+    if (found.size > 0) versions.set(packageName, found);
+  }
+  return versions;
+}
+
+function inspectWatchMode(
+  manifests: PackageManifest[],
+  bundlers: DoctorBundlerState[],
+  findings: DoctorFinding[]
+): DoctorWatchState {
+  const scriptNames: DoctorWatchState['scriptNames'] = [];
+  const scripts: Array<{
+    manifest: PackageManifest;
+    name: string;
+    command: string;
+  }> = [];
+  let tapProject = false;
+
+  for (const manifest of manifests) {
+    const manifestScripts = Object.entries(manifest.data.scripts ?? {});
+    const matchedNames = manifestScripts
+      .filter(([, command]) => /\b(?:watch|dev)\b/u.test(command))
+      .map(([name]) => name)
+      .sort();
+    if (matchedNames.length > 0) {
+      scriptNames.push({ path: manifest.relativePath, names: matchedNames });
+    }
+    for (const [name, command] of manifestScripts) {
+      scripts.push({ manifest, name, command });
+      if (command.includes('--target tap-app')) tapProject = true;
+    }
+    if (
+      declaredPackageNames(manifest.data).includes('zephyr-tap-runtime') ||
+      manifest.data['zephyr:target'] === 'tap-app'
+    ) {
+      tapProject = true;
+    }
+  }
+
+  const zeCliWatchScripts = scripts.filter(({ command }) =>
+    /\bze-cli\s+watch\b/u.test(command)
+  );
+  if (!tapProject) {
+    for (const script of zeCliWatchScripts) {
+      findings.push({
+        code: DoctorFindingCode.WebWatchUsesTapCommand,
+        severity: 'error',
+        message: 'A web project uses the TAP-only ze-cli watch command.',
+        evidence: [
+          {
+            path: script.manifest.relativePath,
+            detail: `script: ${boundedDetail(script.name)}`,
+          },
+        ],
+        remediation:
+          'Use "rsbuild build --watch" for web projects. ze-cli watch is reserved for TAP packages.',
+      });
+    }
+    return {
+      mode: bundlers.some(({ name }) => name === 'rsbuild') ? 'web' : 'unknown',
+      scriptNames,
+      recommendedCommand: bundlers.some(({ name }) => name === 'rsbuild')
+        ? 'rsbuild build --watch'
+        : null,
+    };
+  }
+
+  for (const script of zeCliWatchScripts) {
+    if (!script.command.includes('--target tap-app')) {
+      findings.push({
+        code: DoctorFindingCode.TapWatchTargetMissing,
+        severity: 'error',
+        message: 'A TAP watch script is missing --target tap-app.',
+        evidence: [
+          {
+            path: script.manifest.relativePath,
+            detail: `script: ${boundedDetail(script.name)}`,
+          },
+        ],
+        remediation: 'Add --target tap-app to the ze-cli watch command.',
+      });
+    }
+    if (!script.command.includes('--metadata')) {
+      findings.push({
+        code: DoctorFindingCode.TapWatchMetadataMissing,
+        severity: 'error',
+        message: 'A TAP watch script is missing the publication metadata sidecar.',
+        evidence: [
+          {
+            path: script.manifest.relativePath,
+            detail: `script: ${boundedDetail(script.name)}`,
+          },
+        ],
+        remediation: 'Pass --metadata <sidecar.json> to ze-cli watch.',
+      });
+    }
+  }
+
+  return {
+    mode: 'tap-app',
+    scriptNames,
+    recommendedCommand:
+      'ze-cli watch ./dist --target tap-app --metadata ./dist/zephyr-publication.json',
+  };
+}
+
+async function inspectDtsEvidence(
+  root: string,
+  manifests: PackageManifest[],
+  packageManager: PackageManager,
+  findings: DoctorFinding[]
+): Promise<DoctorDtsState> {
+  const logs = new Set<string>();
+  const temporaryArtifacts = new Set<string>();
+  const typeArchives = new Set<string>();
+
+  for (const manifest of manifests) {
+    const logPath = path.join(manifest.directory, '.mf', 'typesGenerate.log');
+    if (await pathExists(logPath)) logs.add(relativePath(root, logPath));
+
+    const archivePath = path.join(manifest.directory, 'dist', '@mf-types.zip');
+    if (await pathExists(archivePath)) typeArchives.add(relativePath(root, archivePath));
+
+    const federationDirectory = path.join(
+      manifest.directory,
+      'node_modules',
+      '.federation'
+    );
+    for (const artifact of await listDiagnosticArtifacts(federationDirectory)) {
+      temporaryArtifacts.add(relativePath(root, artifact));
+    }
+  }
+
+  for (const log of logs) {
+    const absoluteLog = path.join(root, log);
+    const source = await readBoundedTextFile(absoluteLog);
+    const diagnosticCodes = [
+      ...new Set(source.match(/\b(?:TYPE-\d+|TS6059)\b/gu) ?? []),
+    ].sort();
+    if (diagnosticCodes.length > 0) {
+      findings.push({
+        code: DoctorFindingCode.DtsDiagnosticFailure,
+        severity: 'error',
+        message: 'Module Federation DTS diagnostics contain a known failure code.',
+        evidence: [
+          {
+            path: log,
+            detail: `codes: ${diagnosticCodes.join(', ')}`,
+          },
+        ],
+        remediation:
+          'Run the reported DTS reproduction command, preserve the temporary tsconfig, and inspect .mf/typesGenerate.log before disabling DTS.',
+      });
+    }
+  }
+
+  const packageCommand = packageManager === 'unknown' ? 'pnpm' : packageManager;
+  return {
+    logs: [...logs].sort(),
+    temporaryArtifacts: [...temporaryArtifacts].sort(),
+    typeArchives: [...typeArchives].sort(),
+    diagnosticCommands: [
+      `FEDERATION_DEBUG=true ${packageCommand} run build`,
+      `${packageCommand} exec rsbuild inspect`,
+    ],
+  };
+}
+
+async function listDiagnosticArtifacts(directory: string): Promise<string[]> {
+  if (!(await pathExists(directory))) return [];
+  const artifacts: string[] = [];
+  const visit = async (current: string): Promise<void> => {
+    const entries = await fs.promises.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolutePath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await visit(absolutePath);
+      } else if (
+        /\.(?:json|jsonc|log|ts)$/u.test(entry.name) ||
+        entry.name.includes('tsconfig')
+      ) {
+        artifacts.push(absolutePath);
+      }
+    }
+  };
+  await visit(directory);
+  return artifacts;
+}
+
+function declaredPackages(packageJson: PackageJson): Array<[string, string]> {
+  return Object.entries({
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+    ...packageJson.optionalDependencies,
+    ...packageJson.peerDependencies,
+  });
+}
+
+function declaredPackageNames(packageJson: PackageJson): string[] {
+  return declaredPackages(packageJson).map(([name]) => name);
+}
+
+function isRelevantPackage(name: string): boolean {
+  return (
+    name === 'typescript' ||
+    name === 'webpack' ||
+    name === 'vite' ||
+    name === 'rollup' ||
+    name.startsWith('zephyr-') ||
+    name.startsWith('@zephyr-cloud/') ||
+    name.startsWith('@zephyrcloudio/') ||
+    name.startsWith('@module-federation/') ||
+    name.startsWith('@rsbuild/') ||
+    name.startsWith('@rspack/') ||
+    name.startsWith('@rslib/')
+  );
+}
+
+async function findInstalledPackageManifest(
+  fromDirectory: string,
+  root: string,
+  packageName: string
+): Promise<string | undefined> {
+  let current = fromDirectory;
+  while (current === root || current.startsWith(`${root}${path.sep}`)) {
+    const candidate = path.join(current, 'node_modules', packageName, 'package.json');
+    if (await pathExists(candidate)) return candidate;
+    if (current === root) break;
+    current = path.dirname(current);
+  }
+  return undefined;
+}
+
+function packageManagerName(value: string | undefined): PackageManager | undefined {
+  const name = value?.split('@')[0];
+  return name === 'pnpm' || name === 'npm' || name === 'yarn' || name === 'bun'
+    ? name
+    : undefined;
+}
+
+function extractPropertyContainer(
+  source: string,
+  propertyName: string
+): PropertyContainer | undefined {
+  const propertyMatch = new RegExp(`\\b${propertyName}\\s*:`, 'u').exec(source);
+  if (!propertyMatch) return undefined;
+
+  let cursor = propertyMatch.index + propertyMatch[0].length;
+  while (/\s/u.test(source[cursor] ?? '')) cursor += 1;
+  const opener = source[cursor];
+  if (opener !== '{' && opener !== '[') return undefined;
+  const closer = opener === '{' ? '}' : ']';
+  const end = findMatchingDelimiter(source, cursor, opener, closer);
+  if (end === -1) return undefined;
+  return {
+    kind: opener === '{' ? 'object' : 'array',
+    body: source.slice(cursor + 1, end),
+    start: cursor,
+  };
+}
+
+function findMatchingDelimiter(
+  source: string,
+  start: number,
+  opener: string,
+  closer: string
+): number {
+  let depth = 0;
+  let quote: string | undefined;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = start; index < source.length; index++) {
+    const character = source[index] ?? '';
+    const next = source[index + 1] ?? '';
+    if (lineComment) {
+      if (character === '\n') lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (character === '*' && next === '/') {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (character === '/' && next === '/') {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === '/' && next === '*') {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character;
+      continue;
+    }
+    if (character === opener) depth += 1;
+    if (character === closer) {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function extractTopLevelObjectKeys(body: string): string[] {
+  const depths = nestingDepths(body);
+  const keys = new Set<string>();
+  const pattern = /(?:^|,|\n)\s*(?:['"]([^'"]+)['"]|([A-Za-z_$][\w$.-]*))\s*:/gu;
+  for (const match of body.matchAll(pattern)) {
+    if (depths[match.index ?? 0] === 0) {
+      const key = match[1] ?? match[2];
+      if (key) keys.add(key);
+    }
+  }
+  return [...keys];
+}
+
+function nestingDepths(source: string): number[] {
+  const depths = Array.from({ length: source.length }, () => 0);
+  let depth = 0;
+  let quote: string | undefined;
+  let escaped = false;
+
+  for (let index = 0; index < source.length; index++) {
+    depths[index] = depth;
+    const character = source[index] ?? '';
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (character === '\\') escaped = true;
+      else if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character;
+    } else if (character === '{' || character === '[' || character === '(') {
+      depth += 1;
+    } else if (character === '}' || character === ']' || character === ')') {
+      depth = Math.max(0, depth - 1);
+    }
+  }
+  return depths;
+}
+
+function lineNumber(source: string, index: number): number {
+  return source.slice(0, index).split('\n').length;
+}
+
+async function readBoundedTextFile(absolutePath: string): Promise<string> {
+  const stats = await fs.promises.stat(absolutePath);
+  if (stats.size > MAX_TEXT_FILE_BYTES) {
+    throw new Error(`Refusing to inspect a file larger than ${MAX_TEXT_FILE_BYTES}.`);
+  }
+  return fs.promises.readFile(absolutePath, 'utf8');
+}
+
+async function pathExists(absolutePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(absolutePath, fs.constants.F_OK);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function relativePath(root: string, absolutePath: string): string {
+  const relative = path.relative(root, absolutePath) || '.';
+  return relative.split(path.sep).join('/');
+}
+
+function leadingWhitespace(value: string): number {
+  return /^\s*/u.exec(value)?.[0].length ?? 0;
+}
+
+function unquoteYamlKey(value: string): string {
+  if (
+    (value.startsWith("'") && value.endsWith("'")) ||
+    (value.startsWith('"') && value.endsWith('"'))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function normalizeLockVersion(value: string): string {
+  return value.replace(/^npm:/u, '').split('(')[0] ?? value;
+}
+
+function boundedDetail(value: string): string {
+  const redacted = value
+    .replace(/([a-z][a-z\d+.-]*:\/\/)[^/@\s]+@/giu, '$1[redacted]@')
+    .replace(/([?&](?:token|key|secret|password)=)[^&\s]+/giu, '$1[redacted]')
+    .replace(/\b(?:token|secret|password|authorization)\s*[:=]\s*\S+/giu, '[redacted]')
+    .replace(/\bbearer\s+\S+/giu, 'Bearer [redacted]');
+  return redacted.length <= 240 ? redacted : `${redacted.slice(0, 237)}...`;
+}
+
+function uniqueBy<T>(values: T[], key: (value: T) => string): T[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const identity = key(value);
+    if (seen.has(identity)) return false;
+    seen.add(identity);
+    return true;
+  });
+}

--- a/libs/zephyr-cli/src/doctor/analyze.ts
+++ b/libs/zephyr-cli/src/doctor/analyze.ts
@@ -15,6 +15,7 @@ import {
 } from './schema';
 
 const MAX_TEXT_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_LOCKFILE_BYTES = 64 * 1024 * 1024;
 const MAX_SCAN_DIRECTORIES = 10_000;
 const CONFIG_FILE_PATTERN =
   /^(rsbuild|rspack|webpack|vite|rollup|rslib)\.config\.(?:js|mjs|cjs|ts|mts|cts)$/u;
@@ -42,6 +43,7 @@ interface PackageJson {
   name?: string;
   version?: string;
   packageManager?: string;
+  workspaces?: string[] | { packages?: string[] };
   scripts?: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
@@ -68,6 +70,11 @@ interface LockState {
 
 interface PropertyContainer {
   kind: 'object' | 'array';
+  body: string;
+  start: number;
+}
+
+interface ArrayEntry {
   body: string;
   start: number;
 }
@@ -271,6 +278,15 @@ async function discoverPackageManifests(
   findings: DoctorFinding[]
 ): Promise<PackageManifest[]> {
   const manifests = [rootManifest];
+  const workspacePatterns = await readWorkspacePatterns(root, rootManifest.data);
+  if (workspacePatterns.length === 0) return manifests;
+
+  const includedPatterns = workspacePatterns.filter(
+    (pattern) => !pattern.startsWith('!')
+  );
+  const excludedPatterns = workspacePatterns
+    .filter((pattern) => pattern.startsWith('!'))
+    .map((pattern) => pattern.slice(1));
   let visitedDirectories = 0;
 
   const visit = async (directory: string): Promise<void> => {
@@ -283,8 +299,19 @@ async function discoverPackageManifests(
     for (const entry of entries) {
       if (!entry.isDirectory() || EXCLUDED_DIRECTORIES.has(entry.name)) continue;
       const childDirectory = path.join(directory, entry.name);
+      const childRelativePath = relativePath(root, childDirectory);
+      if (!shouldVisitWorkspaceDirectory(childRelativePath, includedPatterns)) {
+        continue;
+      }
       const childPackagePath = path.join(childDirectory, 'package.json');
-      if (await pathExists(childPackagePath)) {
+      const isWorkspace =
+        includedPatterns.some((pattern) =>
+          path.matchesGlob(childRelativePath, normalizeWorkspacePattern(pattern))
+        ) &&
+        !excludedPatterns.some((pattern) =>
+          path.matchesGlob(childRelativePath, normalizeWorkspacePattern(pattern))
+        );
+      if (isWorkspace && (await pathExists(childPackagePath))) {
         const result = await readPackageManifest(childPackagePath, root);
         if (result.manifest) {
           manifests.push(result.manifest);
@@ -312,22 +339,105 @@ async function discoverPackageManifests(
   return uniqueBy(manifests, ({ relativePath: manifestPath }) => manifestPath);
 }
 
+async function readWorkspacePatterns(
+  root: string,
+  rootPackage: PackageJson
+): Promise<string[]> {
+  const manifestWorkspaces = Array.isArray(rootPackage.workspaces)
+    ? rootPackage.workspaces
+    : (rootPackage.workspaces?.packages ?? []);
+  const pnpmWorkspacePath = path.join(root, 'pnpm-workspace.yaml');
+  const pnpmWorkspaces = (await pathExists(pnpmWorkspacePath))
+    ? parsePnpmWorkspacePatterns(await readBoundedTextFile(pnpmWorkspacePath))
+    : [];
+  return [
+    ...new Set(
+      [...manifestWorkspaces, ...pnpmWorkspaces]
+        .map(normalizeWorkspacePattern)
+        .filter(Boolean)
+    ),
+  ];
+}
+
+function parsePnpmWorkspacePatterns(source: string): string[] {
+  const patterns: string[] = [];
+  let inPackages = false;
+  for (const line of source.split(/\r?\n/u)) {
+    if (/^packages\s*:\s*(?:#.*)?$/u.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (/^\S/u.test(line) && !line.startsWith('#')) {
+      inPackages = false;
+    }
+    if (!inPackages) continue;
+    const match = /^\s+-\s+(.+?)\s*$/u.exec(line);
+    if (!match?.[1]) continue;
+    const value = stripYamlComment(match[1]).trim();
+    if (!value) continue;
+    patterns.push(unquoteYamlKey(value));
+  }
+  return patterns;
+}
+
+function stripYamlComment(value: string): string {
+  let quote: string | undefined;
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index];
+    if (quote) {
+      if (character === quote && value[index - 1] !== '\\') quote = undefined;
+    } else if (character === "'" || character === '"') {
+      quote = character;
+    } else if (character === '#') {
+      return value.slice(0, index);
+    }
+  }
+  return value;
+}
+
+function normalizeWorkspacePattern(pattern: string): string {
+  return pattern
+    .trim()
+    .replace(/\\/gu, '/')
+    .replace(/^\.\/+/u, '')
+    .replace(/\/+$/u, '');
+}
+
+function shouldVisitWorkspaceDirectory(
+  relativeDirectory: string,
+  patterns: string[]
+): boolean {
+  return patterns.some((pattern) => {
+    const normalized = normalizeWorkspacePattern(pattern);
+    const wildcardIndex = normalized.search(/[*?[\]{}()]/u);
+    const literalPrefix =
+      wildcardIndex === -1 ? normalized : normalized.slice(0, wildcardIndex);
+    const directoryPrefix = literalPrefix.replace(/\/+$/u, '');
+    return (
+      !directoryPrefix ||
+      relativeDirectory === directoryPrefix ||
+      directoryPrefix.startsWith(`${relativeDirectory}/`) ||
+      relativeDirectory.startsWith(`${directoryPrefix}/`)
+    );
+  });
+}
+
 async function readPackageManifest(
   absolutePath: string,
   root: string
 ): Promise<{ manifest?: PackageManifest; detail?: string }> {
   const content = await readBoundedTextFile(absolutePath);
   try {
-    const data = JSON.parse(content) as PackageJson | undefined;
-    if (!data) {
-      return { detail: 'empty JSON document' };
+    const data = JSON.parse(content) as unknown;
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+      return { detail: 'JSON root must be an object' };
     }
     return {
       manifest: {
         absolutePath,
         relativePath: relativePath(root, absolutePath),
         directory: path.dirname(absolutePath),
-        data,
+        data: data as PackageJson,
       },
     };
   } catch {
@@ -404,13 +514,17 @@ async function inspectConfigs(
 
   for (const config of configFiles) {
     const source = await readBoundedTextFile(config.absolutePath);
-    const zephyrCall = /\bwithZephyr\s*\(/u.exec(source);
-    const moduleFederationCall = /\bpluginModuleFederation\s*\(/u.exec(source);
-    const assetPrefixMatch = /\bassetPrefix\s*:\s*(['"`])auto\1/u.exec(source);
-    const hasAssetPrefix = /\bassetPrefix\s*:/u.test(source);
-    const sourceEntry = /\bsource\s*:\s*\{[\s\S]*?\bentry\s*:/u.test(source);
-    const exposes = extractPropertyContainer(source, 'exposes');
-    const remotes = extractPropertyContainer(source, 'remotes');
+    const analyzableSource = stripComments(source);
+    const zephyrCall = /\bwithZephyr\s*\(/u.exec(analyzableSource);
+    const moduleFederationCall = /\bpluginModuleFederation\s*\(/u.exec(analyzableSource);
+    const assetPrefixMatch = /\bassetPrefix\s*:\s*(['"`])auto\1/u.exec(analyzableSource);
+    const hasAssetPrefix = /\bassetPrefix\s*:/u.test(analyzableSource);
+    const sourceEntry = /\bsource\s*:\s*\{[\s\S]*?\bentry\s*:/u.test(analyzableSource);
+    const exposes = extractPropertyContainer(analyzableSource, 'exposes');
+    const remotes = extractPropertyContainer(analyzableSource, 'remotes');
+    const plugins = extractPropertyContainer(analyzableSource, 'plugins');
+    const pluginOrder =
+      plugins?.kind === 'array' ? findPluginOrder(analyzableSource, plugins) : undefined;
     const exposeKeys =
       exposes?.kind === 'object' ? extractTopLevelObjectKeys(exposes.body) : [];
     const remoteKeys =
@@ -453,18 +567,19 @@ async function inspectConfigs(
         });
       }
       if (
-        zephyrCall &&
-        moduleFederationCall &&
-        zephyrCall.index < moduleFederationCall.index
+        pluginOrder?.zephyr !== undefined &&
+        pluginOrder.moduleFederation !== undefined &&
+        pluginOrder.zephyr < pluginOrder.moduleFederation
       ) {
         findings.push({
           code: DoctorFindingCode.ZephyrPluginOrder,
           severity: 'error',
-          message: 'withZephyr() appears before pluginModuleFederation().',
+          message:
+            'withZephyr() appears before pluginModuleFederation() in the plugins array.',
           evidence: [
             {
               path: config.relativePath,
-              line: lineNumber(source, zephyrCall.index),
+              line: lineNumber(source, (plugins?.start ?? 0) + 1 + pluginOrder.zephyr),
             },
           ],
           remediation:
@@ -530,7 +645,7 @@ async function inspectConfigs(
     const remoteDependencyKeys = Object.keys(
       config.manifest.data['zephyr:dependencies'] ?? {}
     );
-    if (remoteDependencyKeys.length > 0) {
+    if (remoteDependencyKeys.length > 0 || remoteKeys.length > 0) {
       const missingRemotes = remoteDependencyKeys.filter(
         (key) => !remoteKeys.includes(key)
       );
@@ -706,17 +821,26 @@ async function inspectPackages(
     left.localeCompare(right)
   )) {
     const installed = new Map<string, string>();
+    const missingDeclarations: Array<{
+      manifest: PackageManifest;
+      range: string;
+    }> = [];
     for (const declaration of declarations) {
       const installedManifest = await findInstalledPackageManifest(
         declaration.manifest.directory,
         root,
         name
       );
-      if (!installedManifest) continue;
+      if (!installedManifest) {
+        missingDeclarations.push(declaration);
+        continue;
+      }
       const installedResult = await readPackageManifest(installedManifest, root);
       const version = installedResult.manifest?.data.version;
       if (version) {
         installed.set(relativePath(root, installedManifest), version);
+      } else {
+        missingDeclarations.push(declaration);
       }
     }
 
@@ -737,15 +861,15 @@ async function inspectPackages(
       installed: installedEntries,
     });
 
-    if (installedEntries.length === 0) {
+    if (missingDeclarations.length > 0) {
       findings.push({
         code:
           name === 'zephyr-rsbuild-plugin'
             ? DoctorFindingCode.ZephyrPluginNotInstalled
             : DoctorFindingCode.PackageNotInstalled,
         severity: 'warning',
-        message: `${name} is declared but no installed package.json was found.`,
-        evidence: declarations.map(({ manifest, range }) => ({
+        message: `${name} is declared but no installed package.json was found for one or more workspaces.`,
+        evidence: missingDeclarations.map(({ manifest, range }) => ({
           path: manifest.relativePath,
           detail: `declared: ${boundedDetail(range)}`,
         })),
@@ -789,7 +913,7 @@ async function readLockVersions(
   packageNames: string[]
 ): Promise<Map<string, Set<string>>> {
   const versions = new Map<string, Set<string>>();
-  const content = await readBoundedTextFile(lockfilePath);
+  const content = await readBoundedTextFile(lockfilePath, MAX_LOCKFILE_BYTES);
 
   if (packageManager === 'npm') {
     const parsed = JSON.parse(content) as {
@@ -815,7 +939,10 @@ async function readLockVersions(
           const candidate = lines[next] ?? '';
           if (candidate.trim() && leadingWhitespace(candidate) <= indent) break;
           const versionMatch = /^\s*version:\s*(['"]?)([^'"\s]+)\1\s*$/u.exec(candidate);
-          if (versionMatch?.[2]) found.add(normalizeLockVersion(versionMatch[2]));
+          const version = versionMatch?.[2]
+            ? normalizeLockVersion(versionMatch[2])
+            : undefined;
+          if (version) found.add(version);
         }
       } else if (
         packageManager === 'yarn' &&
@@ -826,8 +953,13 @@ async function readLockVersions(
         for (let next = index + 1; next < lines.length; next++) {
           const candidate = lines[next] ?? '';
           if (candidate.trim() && leadingWhitespace(candidate) === 0) break;
-          const versionMatch = /^\s*version\s+(['"]?)([^'"\s]+)\1\s*$/u.exec(candidate);
-          if (versionMatch?.[2]) found.add(normalizeLockVersion(versionMatch[2]));
+          const versionMatch = /^\s*version(?::\s*|\s+)(['"]?)([^'"\s]+)\1\s*$/u.exec(
+            candidate
+          );
+          const version = versionMatch?.[2]
+            ? normalizeLockVersion(versionMatch[2])
+            : undefined;
+          if (version) found.add(version);
         }
       }
     }
@@ -896,6 +1028,22 @@ function inspectWatchMode(
         ? 'rsbuild build --watch'
         : null,
     };
+  }
+
+  if (zeCliWatchScripts.length === 0) {
+    findings.push({
+      code: DoctorFindingCode.TapWatchTargetMissing,
+      severity: 'error',
+      message: 'The TAP project does not define a ze-cli watch command.',
+      evidence: [
+        {
+          path: manifests[0]?.relativePath ?? 'package.json',
+          detail: 'missing: ze-cli watch --target tap-app',
+        },
+      ],
+      remediation:
+        'Add a watch script using ze-cli watch with --target tap-app and --metadata <sidecar.json>.',
+    });
   }
 
   for (const script of zeCliWatchScripts) {
@@ -1092,6 +1240,65 @@ function extractPropertyContainer(
   };
 }
 
+function findPluginOrder(
+  source: string,
+  plugins: PropertyContainer
+): { zephyr?: number; moduleFederation?: number } {
+  const pluginVariables = new Map<string, 'zephyr' | 'moduleFederation'>();
+  const declarationPattern =
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:await\s+)?(withZephyr|pluginModuleFederation)\s*\(/gu;
+  for (const match of source.matchAll(declarationPattern)) {
+    const variableName = match[1];
+    const factoryName = match[2];
+    if (variableName && factoryName) {
+      pluginVariables.set(
+        variableName,
+        factoryName === 'withZephyr' ? 'zephyr' : 'moduleFederation'
+      );
+    }
+  }
+
+  const order: { zephyr?: number; moduleFederation?: number } = {};
+  for (const entry of extractTopLevelArrayEntries(plugins.body)) {
+    const directFactory = /\b(withZephyr|pluginModuleFederation)\s*\(/u.exec(
+      entry.body
+    )?.[1];
+    let kind: 'zephyr' | 'moduleFederation' | undefined =
+      directFactory === 'withZephyr'
+        ? 'zephyr'
+        : directFactory === 'pluginModuleFederation'
+          ? 'moduleFederation'
+          : undefined;
+    if (!kind) {
+      const identifier = /^\s*([A-Za-z_$][\w$]*)\s*$/u.exec(entry.body)?.[1];
+      if (identifier) kind = pluginVariables.get(identifier);
+    }
+    if (kind && order[kind] === undefined) order[kind] = entry.start;
+  }
+  return order;
+}
+
+function extractTopLevelArrayEntries(body: string): ArrayEntry[] {
+  const entries: ArrayEntry[] = [];
+  const depths = nestingDepths(body);
+  let start = 0;
+  for (let index = 0; index <= body.length; index++) {
+    if (index < body.length && (body[index] !== ',' || depths[index] !== 0)) {
+      continue;
+    }
+    const entryBody = body.slice(start, index);
+    const leading = leadingWhitespace(entryBody);
+    if (entryBody.trim()) {
+      entries.push({
+        body: entryBody,
+        start: start + leading,
+      });
+    }
+    start = index + 1;
+  }
+  return entries;
+}
+
 function findMatchingDelimiter(
   source: string,
   start: number,
@@ -1194,10 +1401,69 @@ function lineNumber(source: string, index: number): number {
   return source.slice(0, index).split('\n').length;
 }
 
-async function readBoundedTextFile(absolutePath: string): Promise<string> {
+function stripComments(source: string): string {
+  const characters = source.split('');
+  let quote: string | undefined;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index] ?? '';
+    const next = source[index + 1] ?? '';
+    if (lineComment) {
+      if (character === '\n') {
+        lineComment = false;
+      } else {
+        characters[index] = ' ';
+      }
+      continue;
+    }
+    if (blockComment) {
+      if (character === '*' && next === '/') {
+        characters[index] = ' ';
+        characters[index + 1] = ' ';
+        blockComment = false;
+        index += 1;
+      } else if (character !== '\n') {
+        characters[index] = ' ';
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character;
+    } else if (character === '/' && next === '/') {
+      characters[index] = ' ';
+      characters[index + 1] = ' ';
+      lineComment = true;
+      index += 1;
+    } else if (character === '/' && next === '*') {
+      characters[index] = ' ';
+      characters[index + 1] = ' ';
+      blockComment = true;
+      index += 1;
+    }
+  }
+  return characters.join('');
+}
+
+async function readBoundedTextFile(
+  absolutePath: string,
+  maximumBytes = MAX_TEXT_FILE_BYTES
+): Promise<string> {
   const stats = await fs.promises.stat(absolutePath);
-  if (stats.size > MAX_TEXT_FILE_BYTES) {
-    throw new Error(`Refusing to inspect a file larger than ${MAX_TEXT_FILE_BYTES}.`);
+  if (stats.size > maximumBytes) {
+    throw new Error(`Refusing to inspect a file larger than ${maximumBytes}.`);
   }
   return fs.promises.readFile(absolutePath, 'utf8');
 }
@@ -1231,7 +1497,8 @@ function unquoteYamlKey(value: string): string {
   return value;
 }
 
-function normalizeLockVersion(value: string): string {
+function normalizeLockVersion(value: string): string | undefined {
+  if (/^(?:file|link|portal|workspace):/u.test(value)) return undefined;
   return value.replace(/^npm:/u, '').split('(')[0] ?? value;
 }
 

--- a/libs/zephyr-cli/src/doctor/doctor.spec.ts
+++ b/libs/zephyr-cli/src/doctor/doctor.spec.ts
@@ -168,6 +168,300 @@ describe('Zephyr Doctor Rsbuild fixtures', () => {
   });
 });
 
+describe('Zephyr Doctor review regressions', () => {
+  it('compares federation remotes when zephyr dependencies are absent', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'host',
+      devDependencies: {
+        '@module-federation/rsbuild-plugin': '2.8.0',
+        '@rsbuild/core': '2.1.5',
+        'zephyr-rsbuild-plugin': '1.2.0',
+      },
+    });
+    await fs.promises.writeFile(
+      path.join(project, 'rsbuild.config.ts'),
+      `
+        export default {
+          plugins: [
+            pluginModuleFederation({ remotes: { remote: 'remote@https://example.test/mf.js' } }),
+            withZephyr(),
+          ],
+          output: { assetPrefix: 'auto' },
+          source: { entry: { index: './src.ts' } },
+        };
+      `
+    );
+
+    const report = await analyzeProject(project);
+
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        code: DoctorFindingCode.RemoteDependencyAliasMismatch,
+      })
+    );
+  });
+
+  it('ignores pnpm workspace links when comparing package versions', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'workspace-link-consumer',
+      packageManager: 'pnpm@11.17.0',
+      dependencies: {
+        '@zephyr-cloud/workspace-package': 'workspace:*',
+      },
+    });
+    await fs.promises.writeFile(
+      path.join(project, 'pnpm-lock.yaml'),
+      `
+        lockfileVersion: '9.0'
+        importers:
+          .:
+            dependencies:
+              '@zephyr-cloud/workspace-package':
+                specifier: workspace:*
+                version: link:../workspace-package
+      `
+    );
+    await writeInstalledPackages(project, {
+      '@zephyr-cloud/workspace-package': '1.2.0',
+    });
+
+    const report = await analyzeProject(project);
+    const packageState = report.packages.find(
+      ({ name }) => name === '@zephyr-cloud/workspace-package'
+    );
+
+    expect(packageState?.locked).toEqual([]);
+    expect(report.findings.map(({ code }) => code)).not.toContain(
+      DoctorFindingCode.PackageVersionMismatch
+    );
+  });
+
+  it('parses Yarn Berry version fields for mismatch detection', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'yarn-project',
+      packageManager: 'yarn@4.9.2',
+      devDependencies: {
+        typescript: '^5.0.0',
+      },
+    });
+    await fs.promises.writeFile(
+      path.join(project, 'yarn.lock'),
+      [
+        '__metadata:',
+        '  version: 8',
+        '',
+        '"typescript@npm:^5.0.0":',
+        '  version: 5.9.3',
+        '  resolution: "typescript@npm:5.9.3"',
+        '',
+      ].join('\n')
+    );
+    await writeInstalledPackages(project, { typescript: '5.9.2' });
+
+    const report = await analyzeProject(project);
+
+    expect(report.packages.find(({ name }) => name === 'typescript')?.locked).toEqual([
+      '5.9.3',
+    ]);
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        code: DoctorFindingCode.PackageVersionMismatch,
+      })
+    );
+  });
+
+  it('uses a lockfile-specific size bound above two MiB', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'large-lockfile-project',
+      packageManager: 'pnpm@11.17.0',
+      devDependencies: {
+        typescript: '5.9.3',
+      },
+    });
+    const lockfile = `
+      lockfileVersion: '9.0'
+      importers:
+        .:
+          devDependencies:
+            typescript:
+              specifier: 5.9.3
+              version: 5.9.3
+    `;
+    await fs.promises.writeFile(
+      path.join(project, 'pnpm-lock.yaml'),
+      `${lockfile}\n#${'padding'.repeat(350_000)}\n`
+    );
+    await writeInstalledPackages(project, { typescript: '5.9.3' });
+
+    const report = await analyzeProject(project);
+
+    expect(report.status).not.toBe('tool_failure');
+    expect(report.packages.find(({ name }) => name === 'typescript')?.locked).toEqual([
+      '5.9.3',
+    ]);
+  });
+
+  it('ignores commented-out configuration examples', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'commented-config',
+      devDependencies: {
+        '@module-federation/rsbuild-plugin': '2.8.0',
+        '@rsbuild/core': '2.1.5',
+        'zephyr-rsbuild-plugin': '1.2.0',
+      },
+    });
+    await fs.promises.writeFile(
+      path.join(project, 'rsbuild.config.ts'),
+      `
+        export default {
+          // plugins: [pluginModuleFederation({}), withZephyr()],
+          // output: { assetPrefix: 'auto' },
+          /* source: { entry: { index: './src.ts' } } */
+        };
+      `
+    );
+
+    const report = await analyzeProject(project);
+    const codes = report.findings.map(({ code }) => code);
+
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        DoctorFindingCode.ZephyrPluginConfigMissing,
+        DoctorFindingCode.ModuleFederationPluginConfigMissing,
+        DoctorFindingCode.AssetPrefixMissing,
+        DoctorFindingCode.SourceEntryMissing,
+      ])
+    );
+  });
+
+  it('discovers only package manifests selected by workspace patterns', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'workspace-root',
+      private: true,
+      workspaces: ['packages/*'],
+    });
+    await fs.promises.mkdir(path.join(project, 'packages/member'), {
+      recursive: true,
+    });
+    await writeJson(path.join(project, 'packages/member/package.json'), {
+      name: 'member',
+      devDependencies: { vite: '7.0.0' },
+    });
+    await fs.promises.mkdir(path.join(project, 'fixtures/ignored'), {
+      recursive: true,
+    });
+    await writeJson(path.join(project, 'fixtures/ignored/package.json'), {
+      name: 'ignored',
+      devDependencies: { webpack: '5.0.0' },
+    });
+
+    const report = await analyzeProject(project);
+
+    expect(report.bundlers.map(({ name }) => name)).toEqual(['vite']);
+    expect(report.packages.map(({ name }) => name)).not.toContain('webpack');
+  });
+
+  it('derives Zephyr plugin order from plugins array entries', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'plugin-order',
+      devDependencies: {
+        '@module-federation/rsbuild-plugin': '2.8.0',
+        '@rsbuild/core': '2.1.5',
+        'zephyr-rsbuild-plugin': '1.2.0',
+      },
+    });
+    const configPath = path.join(project, 'rsbuild.config.ts');
+    await fs.promises.writeFile(
+      configPath,
+      `
+        const zephyr = withZephyr();
+        const federation = pluginModuleFederation({});
+        export default {
+          plugins: [federation, zephyr],
+          output: { assetPrefix: 'auto' },
+          source: { entry: { index: './src.ts' } },
+        };
+      `
+    );
+
+    const validReport = await analyzeProject(project);
+    expect(validReport.findings.map(({ code }) => code)).not.toContain(
+      DoctorFindingCode.ZephyrPluginOrder
+    );
+
+    await fs.promises.writeFile(
+      configPath,
+      `
+        const federation = pluginModuleFederation({});
+        const zephyr = withZephyr();
+        export default {
+          plugins: [zephyr, federation],
+          output: { assetPrefix: 'auto' },
+          source: { entry: { index: './src.ts' } },
+        };
+      `
+    );
+    const invalidReport = await analyzeProject(project);
+    expect(invalidReport.findings).toContainEqual(
+      expect.objectContaining({
+        code: DoctorFindingCode.ZephyrPluginOrder,
+      })
+    );
+  });
+
+  it('rejects package manifests whose JSON root is not an object', async () => {
+    const project = await makeTemporaryDirectory();
+    for (const document of ['[]', 'true', '"package"']) {
+      await fs.promises.writeFile(path.join(project, 'package.json'), document);
+
+      const report = await analyzeProject(project);
+
+      expect(report.status).toBe('invalid_project');
+      expect(report.exitCode).toBe(DoctorExitCode.InvalidProject);
+      expect(report.findings[0]?.code).toBe(DoctorFindingCode.PackageJsonInvalid);
+    }
+  });
+
+  it('reports missing installations for each declaring workspace', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'workspace-root',
+      private: true,
+      workspaces: ['packages/*'],
+    });
+    for (const workspace of ['installed', 'missing']) {
+      await fs.promises.mkdir(path.join(project, 'packages', workspace), {
+        recursive: true,
+      });
+      await writeJson(path.join(project, 'packages', workspace, 'package.json'), {
+        name: workspace,
+        devDependencies: { typescript: '5.9.3' },
+      });
+    }
+    await writeInstalledPackages(path.join(project, 'packages/installed'), {
+      typescript: '5.9.3',
+    });
+
+    const report = await analyzeProject(project);
+    const finding = report.findings.find(
+      ({ code }) => code === DoctorFindingCode.PackageNotInstalled
+    );
+
+    expect(finding?.evidence).toEqual([
+      expect.objectContaining({
+        path: 'packages/missing/package.json',
+      }),
+    ]);
+  });
+});
+
 describe('Zephyr Doctor exit classes', () => {
   it('distinguishes TAP watch requirements from web watch mode', async () => {
     const project = await makeTemporaryDirectory();
@@ -206,6 +500,29 @@ describe('Zephyr Doctor exit classes', () => {
     expect(report.status).toBe('invalid_project');
     expect(report.exitCode).toBe(DoctorExitCode.InvalidProject);
     expect(report.findings[0]?.code).toBe(DoctorFindingCode.PackageJsonMissing);
+  });
+
+  it('flags a TAP project without a ze-cli watch command', async () => {
+    const project = await makeTemporaryDirectory();
+    await writeJson(path.join(project, 'package.json'), {
+      name: 'tap-package',
+      private: true,
+      scripts: {
+        watch: 'rsbuild build --watch',
+      },
+      devDependencies: {
+        'zephyr-tap-runtime': '1.2.0',
+      },
+    });
+
+    const report = await analyzeProject(project);
+
+    expect(report.watch.mode).toBe('tap-app');
+    expect(report.findings).toContainEqual(
+      expect.objectContaining({
+        code: DoctorFindingCode.TapWatchTargetMissing,
+      })
+    );
   });
 
   it('returns a structured tool failure for an unreadable scan input', async () => {
@@ -262,6 +579,10 @@ async function writeInstalledPackages(
       JSON.stringify({ name, version })
     );
   }
+}
+
+async function writeJson(absolutePath: string, value: unknown): Promise<void> {
+  await fs.promises.writeFile(absolutePath, JSON.stringify(value, null, 2));
 }
 
 async function captureTree(root: string): Promise<Record<string, string>> {

--- a/libs/zephyr-cli/src/doctor/doctor.spec.ts
+++ b/libs/zephyr-cli/src/doctor/doctor.spec.ts
@@ -1,0 +1,291 @@
+import { afterEach, describe, expect, it } from '@rstest/core';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { analyzeProject } from './analyze';
+import { formatDoctorReport } from './format';
+import { DOCTOR_SCHEMA_VERSION, DoctorExitCode, DoctorFindingCode } from './schema';
+
+const fixtureRoot = path.join(import.meta.dirname, '__fixtures__');
+const temporaryDirectories: string[] = [];
+const installedVersions = {
+  '@module-federation/rsbuild-plugin': '2.8.0',
+  '@rsbuild/core': '2.1.5',
+  typescript: '5.9.3',
+  'zephyr-rsbuild-plugin': '1.2.0',
+};
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.promises.rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe('Zephyr Doctor Rsbuild fixtures', () => {
+  it('returns a stable healthy report for a configured host/remote workspace', async () => {
+    const project = await copyFixture('healthy-rsbuild');
+    await writeInstalledPackages(project, installedVersions);
+
+    const report = await analyzeProject(project);
+
+    expect(report).toMatchObject({
+      schemaVersion: DOCTOR_SCHEMA_VERSION,
+      command: 'doctor',
+      status: 'healthy',
+      exitCode: DoctorExitCode.Healthy,
+      packageManager: 'pnpm',
+      lockfile: 'pnpm-lock.yaml',
+      summary: { errors: 0, warnings: 0, info: 0 },
+      watch: {
+        mode: 'web',
+        recommendedCommand: 'rsbuild build --watch',
+      },
+    });
+    expect(report.findings).toEqual([]);
+    expect(report.bundlers).toContainEqual({
+      name: 'rsbuild',
+      configFiles: ['apps/host/rsbuild.config.ts', 'apps/remote/rsbuild.config.ts'],
+    });
+    expect(report.configs).toContainEqual(
+      expect.objectContaining({
+        path: 'apps/host/rsbuild.config.ts',
+        assetPrefix: 'auto',
+        sourceEntry: true,
+        remotes: ['remote'],
+      })
+    );
+    expect(report.packages).toContainEqual(
+      expect.objectContaining({
+        name: '@rsbuild/core',
+        locked: ['2.1.5'],
+        installed: [
+          {
+            path: 'node_modules/@rsbuild/core/package.json',
+            version: '2.1.5',
+          },
+        ],
+      })
+    );
+    expect(report.dts.diagnosticCommands).toEqual([
+      'FEDERATION_DEBUG=true pnpm run build',
+      'pnpm exec rsbuild inspect',
+    ]);
+  });
+
+  it('reports broken config, package state, watch mode, and DTS by stable code', async () => {
+    const project = await copyFixture('broken-rsbuild');
+    await writeInstalledPackages(project, {
+      ...installedVersions,
+      '@rsbuild/core': '2.0.0',
+    });
+    await fs.promises.mkdir(path.join(project, 'apps/remote/.mf'), {
+      recursive: true,
+    });
+    await fs.promises.writeFile(
+      path.join(project, 'apps/remote/.mf/typesGenerate.log'),
+      'TYPE-001 failed while checking TS6059\n'
+    );
+    await fs.promises.mkdir(path.join(project, 'apps/remote/node_modules/.federation'), {
+      recursive: true,
+    });
+    await fs.promises.writeFile(
+      path.join(project, 'apps/remote/node_modules/.federation/tsconfig.generated.json'),
+      '{}'
+    );
+    await fs.promises.writeFile(
+      path.join(project, '.env'),
+      'ZEPHYR_TOKEN=SECRET_VALUE\n'
+    );
+    const rootPackagePath = path.join(project, 'package.json');
+    const rootPackage = JSON.parse(
+      await fs.promises.readFile(rootPackagePath, 'utf8')
+    ) as { devDependencies: Record<string, string> };
+    rootPackage.devDependencies['@zephyr-cloud/private'] =
+      'https://user:SECRET_VALUE@example.com/private.tgz';
+    await fs.promises.writeFile(rootPackagePath, JSON.stringify(rootPackage, null, 2));
+    const before = await captureTree(project);
+
+    const report = await analyzeProject(project);
+    const json = formatDoctorReport(report, 'json');
+    const codes = new Set(report.findings.map(({ code }) => code));
+
+    expect(report.status).toBe('findings');
+    expect(report.exitCode).toBe(DoctorExitCode.Findings);
+    for (const finding of report.findings) {
+      expect(finding.code).toMatch(/^ZD\d{4}$/u);
+      expect(['info', 'warning', 'error']).toContain(finding.severity);
+      expect(finding.message.length).toBeGreaterThan(0);
+      expect(finding.evidence.length).toBeGreaterThan(0);
+      expect(finding.remediation.length).toBeGreaterThan(0);
+    }
+    expect([...codes]).toEqual(
+      expect.arrayContaining([
+        DoctorFindingCode.ZephyrPluginOrder,
+        DoctorFindingCode.PackageVersionMismatch,
+        DoctorFindingCode.AssetPrefixInvalid,
+        DoctorFindingCode.AssetPrefixMissing,
+        DoctorFindingCode.SourceEntryMissing,
+        DoctorFindingCode.ExposeKeyInvalid,
+        DoctorFindingCode.RemotesMustBeObject,
+        DoctorFindingCode.RemoteDependencyAliasMismatch,
+        DoctorFindingCode.WebWatchUsesTapCommand,
+        DoctorFindingCode.DtsDiagnosticFailure,
+      ])
+    );
+    expect(report.dts).toMatchObject({
+      logs: ['apps/remote/.mf/typesGenerate.log'],
+      temporaryArtifacts: [
+        'apps/remote/node_modules/.federation/tsconfig.generated.json',
+      ],
+    });
+    expect(JSON.parse(json)).toMatchObject({
+      schemaVersion: DOCTOR_SCHEMA_VERSION,
+      findings: expect.arrayContaining([
+        expect.objectContaining({
+          code: DoctorFindingCode.DtsDiagnosticFailure,
+          severity: 'error',
+          evidence: expect.any(Array),
+          remediation: expect.any(String),
+        }),
+      ]),
+    });
+    expect(json).not.toContain('SECRET_VALUE');
+    expect(await captureTree(project)).toEqual(before);
+  });
+
+  it('renders stable codes and remediation in text output', async () => {
+    const project = await copyFixture('broken-rsbuild');
+    await writeInstalledPackages(project, installedVersions);
+    const report = await analyzeProject(project);
+    const text = formatDoctorReport(report, 'text');
+
+    expect(text).toContain(`Zephyr Doctor (schema ${DOCTOR_SCHEMA_VERSION})`);
+    expect(text).toContain(DoctorFindingCode.AssetPrefixInvalid);
+    expect(text).toContain('Remediation:');
+  });
+});
+
+describe('Zephyr Doctor exit classes', () => {
+  it('distinguishes TAP watch requirements from web watch mode', async () => {
+    const project = await makeTemporaryDirectory();
+    await fs.promises.writeFile(
+      path.join(project, 'package.json'),
+      JSON.stringify({
+        name: 'tap-package',
+        private: true,
+        scripts: {
+          watch: 'ze-cli watch ./dist',
+        },
+        devDependencies: {
+          'zephyr-tap-runtime': '1.2.0',
+        },
+      })
+    );
+
+    const report = await analyzeProject(project);
+    const codes = report.findings.map(({ code }) => code);
+
+    expect(report.watch.mode).toBe('tap-app');
+    expect(report.watch.recommendedCommand).toContain('--target tap-app');
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        DoctorFindingCode.TapWatchTargetMissing,
+        DoctorFindingCode.TapWatchMetadataMissing,
+      ])
+    );
+    expect(codes).not.toContain(DoctorFindingCode.WebWatchUsesTapCommand);
+  });
+
+  it('distinguishes an invalid project from diagnostic findings', async () => {
+    const project = await makeTemporaryDirectory();
+    const report = await analyzeProject(project);
+
+    expect(report.status).toBe('invalid_project');
+    expect(report.exitCode).toBe(DoctorExitCode.InvalidProject);
+    expect(report.findings[0]?.code).toBe(DoctorFindingCode.PackageJsonMissing);
+  });
+
+  it('returns a structured tool failure for an unreadable scan input', async () => {
+    const project = await makeTemporaryDirectory();
+    await fs.promises.writeFile(
+      path.join(project, 'package.json'),
+      Buffer.alloc(2 * 1024 * 1024 + 1)
+    );
+
+    const report = await analyzeProject(project);
+
+    expect(report.status).toBe('tool_failure');
+    expect(report.exitCode).toBe(DoctorExitCode.ToolFailure);
+    expect(report.findings).toEqual([
+      expect.objectContaining({
+        code: DoctorFindingCode.ToolFailure,
+        severity: 'error',
+      }),
+    ]);
+  });
+});
+
+async function copyFixture(name: string): Promise<string> {
+  const temporaryDirectory = await makeTemporaryDirectory();
+  const project = path.join(temporaryDirectory, name);
+  await fs.promises.cp(path.join(fixtureRoot, name), project, {
+    recursive: true,
+  });
+  await materializePackageManifests(project);
+  return project;
+}
+
+async function materializePackageManifests(directory: string): Promise<void> {
+  const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await materializePackageManifests(absolutePath);
+    } else if (entry.name === 'package.fixture.json') {
+      await fs.promises.rename(absolutePath, path.join(directory, 'package.json'));
+    }
+  }
+}
+
+async function writeInstalledPackages(
+  project: string,
+  versions: Record<string, string>
+): Promise<void> {
+  for (const [name, version] of Object.entries(versions)) {
+    const packageDirectory = path.join(project, 'node_modules', name);
+    await fs.promises.mkdir(packageDirectory, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(packageDirectory, 'package.json'),
+      JSON.stringify({ name, version })
+    );
+  }
+}
+
+async function captureTree(root: string): Promise<Record<string, string>> {
+  const snapshot: Record<string, string> = {};
+  const visit = async (directory: string): Promise<void> => {
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(absolutePath);
+      } else {
+        const content = await fs.promises.readFile(absolutePath);
+        snapshot[path.relative(root, absolutePath)] = createHash('sha256')
+          .update(content)
+          .digest('hex');
+      }
+    }
+  };
+  await visit(root);
+  return snapshot;
+}
+
+async function makeTemporaryDirectory(): Promise<string> {
+  const directory = await fs.promises.mkdtemp(path.join(tmpdir(), 'ze-cli-doctor-test-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/libs/zephyr-cli/src/doctor/format.ts
+++ b/libs/zephyr-cli/src/doctor/format.ts
@@ -1,0 +1,48 @@
+import type { DoctorReport } from './schema';
+
+export function formatDoctorReport(
+  report: DoctorReport,
+  format: 'json' | 'text'
+): string {
+  return format === 'json' ? JSON.stringify(report, null, 2) : formatDoctorText(report);
+}
+
+function formatDoctorText(report: DoctorReport): string {
+  const lines = [
+    `Zephyr Doctor (schema ${report.schemaVersion})`,
+    `Project: ${report.projectDirectory}`,
+    `Status: ${report.status}`,
+    `Exit code: ${report.exitCode}`,
+    `Package manager: ${report.packageManager}`,
+    `Lockfile: ${report.lockfile ?? 'not found'}`,
+    `Bundlers: ${report.bundlers.map(({ name }) => name).join(', ') || 'not detected'}`,
+    `Findings: ${report.summary.errors} error(s), ${report.summary.warnings} warning(s), ${report.summary.info} info`,
+  ];
+
+  if (report.findings.length === 0) {
+    lines.push('', 'No actionable findings.');
+  } else {
+    lines.push('', 'Findings:');
+    for (const finding of report.findings) {
+      lines.push(
+        `[${finding.severity.toUpperCase()}] ${finding.code} ${finding.message}`
+      );
+      for (const evidence of finding.evidence) {
+        lines.push(
+          `  Evidence: ${evidence.path}${evidence.line ? `:${evidence.line}` : ''}${evidence.detail ? ` — ${evidence.detail}` : ''}`
+        );
+      }
+      lines.push(`  Remediation: ${finding.remediation}`);
+    }
+  }
+
+  lines.push(
+    '',
+    `Watch mode: ${report.watch.mode}`,
+    `Recommended watch command: ${report.watch.recommendedCommand ?? 'not available'}`,
+    `DTS logs: ${report.dts.logs.join(', ') || 'none found'}`,
+    `DTS temporary artifacts: ${report.dts.temporaryArtifacts.join(', ') || 'none found'}`,
+    `DTS diagnostic commands: ${report.dts.diagnosticCommands.join(' | ')}`
+  );
+  return lines.join('\n');
+}

--- a/libs/zephyr-cli/src/doctor/schema.ts
+++ b/libs/zephyr-cli/src/doctor/schema.ts
@@ -1,0 +1,138 @@
+export const DOCTOR_SCHEMA_VERSION = '1.0.0';
+
+export const DoctorExitCode = {
+  Healthy: 0,
+  Findings: 1,
+  InvalidProject: 2,
+  ToolFailure: 3,
+} as const;
+
+export type DoctorExitCode = (typeof DoctorExitCode)[keyof typeof DoctorExitCode];
+
+export const DoctorFindingCode = {
+  ProjectNotFound: 'ZD0001',
+  PackageJsonMissing: 'ZD0002',
+  PackageJsonInvalid: 'ZD0003',
+  ToolFailure: 'ZD0004',
+  BundlerNotDetected: 'ZD0101',
+  RsbuildConfigMissing: 'ZD0102',
+  ZephyrPluginNotDeclared: 'ZD0201',
+  ZephyrPluginNotInstalled: 'ZD0202',
+  ZephyrPluginConfigMissing: 'ZD0203',
+  ZephyrPluginOrder: 'ZD0204',
+  ModuleFederationPluginConfigMissing: 'ZD0210',
+  LockfileMissing: 'ZD0301',
+  PackageNotInstalled: 'ZD0302',
+  PackageVersionMismatch: 'ZD0303',
+  LockfileUnsupported: 'ZD0304',
+  AssetPrefixMissing: 'ZD0401',
+  AssetPrefixInvalid: 'ZD0402',
+  SourceEntryMissing: 'ZD0403',
+  ExposeKeyInvalid: 'ZD0410',
+  RemotesMustBeObject: 'ZD0411',
+  RemoteDependencyAliasMismatch: 'ZD0412',
+  WebWatchUsesTapCommand: 'ZD0501',
+  TapWatchTargetMissing: 'ZD0502',
+  TapWatchMetadataMissing: 'ZD0503',
+  DtsDiagnosticFailure: 'ZD0601',
+} as const;
+
+export type DoctorFindingCode =
+  (typeof DoctorFindingCode)[keyof typeof DoctorFindingCode];
+
+export type DoctorSeverity = 'info' | 'warning' | 'error';
+export type DoctorStatus = 'healthy' | 'findings' | 'invalid_project' | 'tool_failure';
+
+export interface DoctorEvidence {
+  /** Project-relative path; never an absolute path. */
+  path: string;
+  line?: number;
+  /** A bounded, redacted fact such as a package version or config key. */
+  detail?: string;
+}
+
+export interface DoctorFinding {
+  code: DoctorFindingCode;
+  severity: DoctorSeverity;
+  message: string;
+  evidence: DoctorEvidence[];
+  remediation: string;
+}
+
+export interface DoctorDeclaredVersion {
+  path: string;
+  range: string;
+}
+
+export interface DoctorInstalledVersion {
+  path: string;
+  version: string;
+}
+
+export interface DoctorPackageState {
+  name: string;
+  declared: DoctorDeclaredVersion[];
+  locked: string[];
+  installed: DoctorInstalledVersion[];
+}
+
+export type SupportedBundler =
+  | 'rsbuild'
+  | 'rspack'
+  | 'webpack'
+  | 'vite'
+  | 'rollup'
+  | 'rslib';
+
+export interface DoctorBundlerState {
+  name: SupportedBundler;
+  configFiles: string[];
+}
+
+export interface DoctorConfigState {
+  path: string;
+  bundler: SupportedBundler;
+  zephyrPlugin: boolean;
+  moduleFederationPlugin: boolean;
+  assetPrefix: 'auto' | 'missing' | 'other';
+  sourceEntry: boolean;
+  exposes: string[];
+  remotes: string[];
+}
+
+export interface DoctorWatchState {
+  mode: 'web' | 'tap-app' | 'unknown';
+  scriptNames: Array<{
+    path: string;
+    names: string[];
+  }>;
+  recommendedCommand: string | null;
+}
+
+export interface DoctorDtsState {
+  logs: string[];
+  temporaryArtifacts: string[];
+  typeArchives: string[];
+  diagnosticCommands: string[];
+}
+
+export interface DoctorReport {
+  schemaVersion: typeof DOCTOR_SCHEMA_VERSION;
+  command: 'doctor';
+  status: DoctorStatus;
+  exitCode: DoctorExitCode;
+  projectDirectory: string;
+  packageManager: 'pnpm' | 'npm' | 'yarn' | 'bun' | 'unknown';
+  lockfile: string | null;
+  bundlers: DoctorBundlerState[];
+  configs: DoctorConfigState[];
+  packages: DoctorPackageState[];
+  watch: DoctorWatchState;
+  dts: DoctorDtsState;
+  summary: {
+    errors: number;
+    warnings: number;
+    info: number;
+  };
+  findings: DoctorFinding[];
+}

--- a/libs/zephyr-cli/src/index.ts
+++ b/libs/zephyr-cli/src/index.ts
@@ -4,6 +4,7 @@ import { cwd } from 'node:process';
 import { ZeErrors, ZephyrError } from 'zephyr-agent';
 import { parseArgs } from './cli';
 import { deployCommand } from './commands/deploy';
+import { doctorCommand } from './commands/doctor';
 import { runCommand } from './commands/run';
 import { watchCommand } from './commands/watch';
 
@@ -17,7 +18,14 @@ async function main(): Promise<void> {
     const workingDir = cwd();
 
     // Dispatch to the appropriate command
-    if (options.command === 'deploy' || options.command === 'watch') {
+    if (options.command === 'doctor') {
+      const exitCode = await doctorCommand({
+        directory: options.directory ?? '.',
+        format: options.format ?? 'text',
+        cwd: workingDir,
+      });
+      process.exitCode = exitCode;
+    } else if (options.command === 'deploy' || options.command === 'watch') {
       if (!options.directory) {
         throw new ZephyrError(ZeErrors.ERR_UNKNOWN, {
           message: 'Directory is required for deploy command',

--- a/libs/zephyr-cli/tsconfig.json
+++ b/libs/zephyr-cli/tsconfig.json
@@ -23,7 +23,7 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/__fixtures__/**"],
   "references": [
     {
       "path": "../zephyr-agent/tsconfig.json"


### PR DESCRIPTION
## Summary

Add a read-only, structured project diagnostic command:

```bash
ze-cli doctor [directory] --format text
ze-cli doctor [directory] --format json
```

The command statically inspects the requested project and reports bundler integration, Zephyr and Module Federation plugin state/order, declared/locked/installed package versions, Rsbuild federation settings, watch-mode correctness, and Module Federation DTS evidence. It never installs, edits, evaluates config files, builds, authenticates, or deploys.

## Structured contract

- versioned report schema: `1.0.0`
- stable `ZDxxxx` finding codes
- every finding contains severity, message, project-relative evidence, and remediation
- exit codes:
  - `0`: healthy
  - `1`: valid project with warning/error findings
  - `2`: invalid project
  - `3`: doctor scan failure
- TypeScript report types, schema/finding constants, and exit-code constants exported from `zephyr-cli/doctor/schema`
- bounded/redacted evidence; config source, environment values, `.env`, authentication state, and secrets are not emitted

## Checks

- detects Rsbuild, Rspack, Webpack, Vite, Rollup, and Rslib packages/config files
- verifies `zephyr-rsbuild-plugin`, `withZephyr()`, Module Federation config use, and plugin order
- reports declared, lockfile, and installed versions for Zephyr, Module Federation, TypeScript, and supported bundler packages
- checks Rsbuild `assetPrefix: "auto"`, explicit `source.entry`, expose keys, object-form remotes, and remote-dependency alias correspondence
- distinguishes `rsbuild build --watch` for web projects from TAP-only `ze-cli watch --target tap-app --metadata`
- locates `.mf/typesGenerate.log`, `.federation` temporary configs, `@mf-types.zip`, and emits safe diagnostic commands including `FEDERATION_DEBUG` and `rsbuild inspect`

## Acceptance criteria

- [x] Doctor is read-only and does not install, edit, build, authenticate, or deploy.
- [x] Supported bundlers, Zephyr plugin state/order, and relevant config files are detected.
- [x] Declared, locked, and installed relevant package versions are reported.
- [x] Rsbuild asset prefix, source entry, exposes, remotes, and remote dependency aliases are checked.
- [x] Web and TAP watch requirements are distinguished.
- [x] Module Federation DTS logs, temporary artifacts, archives, and diagnostic commands are reported.
- [x] Every finding has a stable code, severity, message, evidence, and remediation.
- [x] JSON uses a versioned schema and redacts/avoids secrets.
- [x] Exit codes distinguish healthy, findings, invalid project, and tool failure.
- [x] Healthy and intentionally broken Rsbuild host/remote monorepo fixtures are covered.
- [x] TAP can consume schema version, status, exit code, and finding codes without matching prose.

## Validation

Run with the repository-pinned Node 24.15.0 and pnpm 11.17.0:

- `pnpm turbo run typecheck --filter=zephyr-cli`
- `pnpm turbo run test --filter=zephyr-cli` — 41 tests passed
- `pnpm turbo run build --filter=zephyr-cli`
- `pnpm exec oxlint libs/zephyr-cli/src`
- `pnpm pack --dry-run` — doctor command and public schema artifacts included
- commit hooks — repository format check, affected tests, and lint passed

A built-CLI smoke test ran `doctor --format json` against the repository's existing `examples/mf-react-rsbuild`. It returned pure schema `1.0.0` JSON and the expected findings exit code without executing the project.

## Intentional limitations

- Config inspection is static and supports conventional object-form Rsbuild/Module Federation syntax. Doctor intentionally does not import or execute dynamic config code.
- Resolved lockfile extraction supports pnpm, npm, and Yarn. Bun projects receive stable `ZD0304` until Bun lock parsing is added.
- The requested directory is the scan boundary. Run doctor at the monorepo root when parent workspace manifests and lockfiles should be included.

This branch is based directly on `origin/main` at `2f2d8b6b713e1c33eb33618f0579de9712f97e2d`; it does not contain or depend on PR #514.

Closes #516