### PR TITLE
ci: update preview action and migrate to CI token

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -44,8 +44,7 @@ jobs:
       - name: run example builds
         env:
           ZE_IS_PREVIEW: true
-          ZE_API: ${{ vars.ZE_API_DEV }}
-          ZE_API_GATE: ${{ vars.ZE_API_GATE_DEV }}
+          # ZE_API and ZE_API_GATE intentionally use the production defaults.
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
         # Deployments are side effects, so affected application builds must never be
         # satisfied from cache. A cache hit would skip upload and leave no e2e state.
@@ -53,7 +52,7 @@ jobs:
         # directory used by the authenticated Zephyr deployment store.
         run: >-
           pnpm exec turbo run build
-          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/*' || '--affected' }}
+          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/**' || '--affected' }}
           --force --env-mode=loose --output-logs=errors-only
       - name: run deployment e2e tests
         # Keep deployment records in-process. Persisted Zephyr state can include
@@ -95,12 +94,11 @@ jobs:
       - name: run example builds
         env:
           ZE_IS_PREVIEW: true
-          ZE_API: ${{ vars.ZE_API_DEV }}
-          ZE_API_GATE: ${{ vars.ZE_API_GATE_DEV }}
+          # ZE_API and ZE_API_GATE intentionally use the production defaults.
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
         run: >-
           pnpm exec turbo run build
-          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/*' || '--affected' }}
+          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/**' || '--affected' }}
           --force --env-mode=loose --output-logs=new-only
       - name: run deployment e2e tests
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -41,7 +41,7 @@ jobs:
           ZE_IS_PREVIEW: true
           ZE_API: ${{ vars.ZE_API_DEV }}
           ZE_API_GATE: ${{ vars.ZE_API_GATE_DEV }}
-          ZE_SECRET_TOKEN: ${{ secrets.ZE_SECRET_TOKEN }}
+          ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
         # Deployments are side effects, so affected application builds must never be
         # satisfied from cache. A cache hit would skip upload and leave no e2e state.
         # Loose mode preserves GitHub's detached-HEAD metadata and the OS home
@@ -88,7 +88,7 @@ jobs:
           ZE_IS_PREVIEW: true
           ZE_API: ${{ vars.ZE_API_DEV }}
           ZE_API_GATE: ${{ vars.ZE_API_GATE_DEV }}
-          ZE_SECRET_TOKEN: ${{ secrets.ZE_SECRET_TOKEN }}
+          ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
         run: pnpm exec turbo run build --affected --force --env-mode=loose --output-logs=new-only
       - name: run deployment e2e tests
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -53,8 +53,8 @@ jobs:
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only
       - name: Zephyr Preview Environments
         if: github.event_name == 'pull_request'
-        # Pinned to the verified 2026-07-08 release commit.
-        uses: ZephyrCloudIO/zephyr-preview-environment-action@a1b8399f877374d0cfc7f9badff1374c55cf070a
+        # Pinned to the v1.0.0 release commit.
+        uses: ZephyrCloudIO/zephyr-preview-environment-action@05822254ff8661c4e68f9dd12b83db7815ca2cf8 # v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -48,10 +48,8 @@ jobs:
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
         # Deployments are side effects, so affected application builds must never be
         # satisfied from cache. A cache hit would skip upload and leave no e2e state.
-        # Builds run concurrently in both modes. Each deployment record is a separate
-        # per-application key in the local store, so concurrent builds do not contend;
-        # cross-build record loss came from unscoped 401 token cleanup, now fixed in
-        # the agent.
+        # Linux runs every example concurrently; only the Windows job needs a
+        # concurrency cap (see build-windows).
         # Loose mode preserves GitHub's detached-HEAD metadata and the OS home
         # directory used by the authenticated Zephyr deployment store.
         run: >-
@@ -100,9 +98,15 @@ jobs:
           ZE_IS_PREVIEW: true
           # ZE_API and ZE_API_GATE intentionally use the production defaults.
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
+        # Forced runs serialize because building every example concurrently exhausts
+        # Windows session resources: bundler tasks abort with 0xC0000142
+        # (STATUS_DLL_INIT_FAILED) and concurrent `git` spawns fail, which the agent
+        # reports as "Not a git repository". Serializing costs ~45s here (3m00s versus
+        # Linux's 2m16s at full concurrency), so the cap is close to free. A cap above 1
+        # is untested; do not raise it without a green forced Windows run.
         run: >-
           pnpm exec turbo run build
-          ${{ env.ZE_FORCE_ALL_EXAMPLES == 'true' && '--filter=./examples/**' || '--affected' }}
+          ${{ env.ZE_FORCE_ALL_EXAMPLES == 'true' && '--filter=./examples/** --concurrency=1' || '--affected' }}
           --force --env-mode=loose --output-logs=new-only
       - name: run deployment e2e tests
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -48,11 +48,14 @@ jobs:
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
         # Deployments are side effects, so affected application builds must never be
         # satisfied from cache. A cache hit would skip upload and leave no e2e state.
+        # Force-all runs serialize deployments because each build writes to the same
+        # local deployment-record store consumed by the following E2E step.
         # Loose mode preserves GitHub's detached-HEAD metadata and the OS home
         # directory used by the authenticated Zephyr deployment store.
         run: >-
           pnpm exec turbo run build
           ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/**' || '--affected' }}
+          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--concurrency=1' || '' }}
           --force --env-mode=loose --output-logs=errors-only
       - name: run deployment e2e tests
         # Keep deployment records in-process. Persisted Zephyr state can include
@@ -99,6 +102,7 @@ jobs:
         run: >-
           pnpm exec turbo run build
           ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/**' || '--affected' }}
+          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--concurrency=1' || '' }}
           --force --env-mode=loose --output-logs=new-only
       - name: run deployment e2e tests
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,17 +1,21 @@
 name: CI
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - main
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Label-triggered runs must not cancel or replace the required checks for the
+  # same commit. Their jobs use separate check names below for the same reason.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.action == 'labeled' && format('label-{0}', github.event.label.name) || 'ci' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   ZE_FAIL_BUILD: true
+  ZE_FORCE_ALL_EXAMPLES: ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') }}
   TURBO_TELEMETRY_DISABLED: 1
   # Compare PRs with their base and main pushes with the previous main revision.
   # The fallback supports manual runs.
@@ -22,7 +26,8 @@ permissions:
 
 jobs:
   build:
-    name: End-to-end test of examples (ubuntu-latest)
+    name: ${{ github.event.action == 'labeled' && 'Force example previews (ubuntu-latest)' || 'End-to-end test of examples (ubuntu-latest)' }}
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci:force-example-builds'
     runs-on: depot-ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -36,7 +41,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-key-suffix: e2e
-      - name: run build affected
+      - name: run example builds
         env:
           ZE_IS_PREVIEW: true
           ZE_API: ${{ vars.ZE_API_DEV }}
@@ -46,7 +51,10 @@ jobs:
         # satisfied from cache. A cache hit would skip upload and leave no e2e state.
         # Loose mode preserves GitHub's detached-HEAD metadata and the OS home
         # directory used by the authenticated Zephyr deployment store.
-        run: pnpm exec turbo run build --affected --force --env-mode=loose --output-logs=errors-only
+        run: >-
+          pnpm exec turbo run build
+          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/*' || '--affected' }}
+          --force --env-mode=loose --output-logs=errors-only
       - name: run deployment e2e tests
         # Keep deployment records in-process. Persisted Zephyr state can include
         # credentials and must never be uploaded as a workflow artifact.
@@ -59,7 +67,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   build-windows:
-    name: End-to-end test of examples (windows-latest)
+    name: ${{ github.event.action == 'labeled' && 'Force example previews (windows-latest)' || 'End-to-end test of examples (windows-latest)' }}
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci:force-example-builds'
     # Modern.js/Rspack currently aborts with 0xC0000409 on Depot's Windows
     # Server 2025 image (`depot-windows-latest`). Pin the supported 2022 image.
     runs-on: depot-windows-2022
@@ -83,17 +92,22 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-key-suffix: e2e
-      - name: run build affected
+      - name: run example builds
         env:
           ZE_IS_PREVIEW: true
           ZE_API: ${{ vars.ZE_API_DEV }}
           ZE_API_GATE: ${{ vars.ZE_API_GATE_DEV }}
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
-        run: pnpm exec turbo run build --affected --force --env-mode=loose --output-logs=new-only
+        run: >-
+          pnpm exec turbo run build
+          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/*' || '--affected' }}
+          --force --env-mode=loose --output-logs=new-only
       - name: run deployment e2e tests
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only
 
   lint:
+    name: ${{ github.event.action == 'labeled' && 'Force example previews (lint skipped)' || 'lint' }}
+    if: github.event.action != 'labeled'
     runs-on: depot-ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -111,6 +125,8 @@ jobs:
         run: pnpm typecheck
 
   test:
+    name: ${{ github.event.action == 'labeled' && format('Force example previews (test skipped, {0})', matrix.os) || format('test ({0})', matrix.os) }}
+    if: github.event.action != 'labeled'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -48,14 +48,15 @@ jobs:
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
         # Deployments are side effects, so affected application builds must never be
         # satisfied from cache. A cache hit would skip upload and leave no e2e state.
-        # Force-all runs serialize deployments because each build writes to the same
-        # local deployment-record store consumed by the following E2E step.
+        # Builds run concurrently in both modes. Each deployment record is a separate
+        # per-application key in the local store, so concurrent builds do not contend;
+        # cross-build record loss came from unscoped 401 token cleanup, now fixed in
+        # the agent.
         # Loose mode preserves GitHub's detached-HEAD metadata and the OS home
         # directory used by the authenticated Zephyr deployment store.
         run: >-
           pnpm exec turbo run build
-          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/**' || '--affected' }}
-          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--concurrency=1' || '' }}
+          ${{ env.ZE_FORCE_ALL_EXAMPLES == 'true' && '--filter=./examples/**' || '--affected' }}
           --force --env-mode=loose --output-logs=errors-only
       - name: run deployment e2e tests
         # Keep deployment records in-process. Persisted Zephyr state can include
@@ -101,8 +102,7 @@ jobs:
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
         run: >-
           pnpm exec turbo run build
-          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--filter=./examples/**' || '--affected' }}
-          ${{ contains(github.event.pull_request.labels.*.name, 'ci:force-example-builds') && '--concurrency=1' || '' }}
+          ${{ env.ZE_FORCE_ALL_EXAMPLES == 'true' && '--filter=./examples/**' || '--affected' }}
           --force --env-mode=loose --output-logs=new-only
       - name: run deployment e2e tests
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ plugin repository does not own product applications or duplicate their plan.
 - `pnpm test:coverage` - Runs the repository-wide Rstest coverage suite
 - `pnpm test:examples` - Runs example unit tests and the production deployment E2E suite
 
+PR CI builds and deploys affected examples by default. Apply the
+`ci:force-example-builds` label to build and deploy every example with a build
+script and refresh the Zephyr preview links. Remove the label to return future
+PR updates to affected-only builds.
+
 ### Linting & Formatting
 
 - `pnpm lint` - Checks code for linting errors

--- a/docs/ci-token-identity.md
+++ b/docs/ci-token-identity.md
@@ -28,7 +28,8 @@ available from JWT claims or the `/job` response, they must match `CI_JOB_ID`, `
 
 GitHub Actions reads the local webhook payload from `GITHUB_EVENT_PATH`. It prefers the matching commit author email,
 then commit committer email, then `head_commit`, then `pusher.email`. It always sends the stable GitHub actor ID from
-`GITHUB_ACTOR_ID` when available and includes GitHub's noreply email shape as an email candidate. This requires no
+`GITHUB_ACTOR_ID` when available, keeps it paired with `GITHUB_ACTOR` on reruns, and includes GitHub's noreply email
+shape as an email candidate. This requires no
 workflow YAML changes beyond setting `ZE_CI_TOKEN`. Reliable multi-email attribution requires the user's GitHub account
 to be linked in cloud-io as a `GitProviderIdentity`; email candidates are only a fallback.
 

--- a/docs/ci-token-identity.md
+++ b/docs/ci-token-identity.md
@@ -51,7 +51,8 @@ must infer the CI actor and exchange the credential for a short-lived access tok
 Large monorepo builds run many plugin processes against the same `~/.zephyr` directory. CI access-token resolution uses
 an identity-scoped, cross-process single-flight cache so those processes do not all exchange and write the same token:
 
-1. Hash the CI token together with the normalized provider identity. The raw CI token is never written to disk.
+1. Hash the CI token together with the API gateway and normalized provider identity. The raw CI token is never written to
+   disk.
 2. Acquire the matching lock under `~/.zephyr/locks` using `proper-lockfile` with retries and stale-lock recovery.
 3. Re-read `ze-ci-auth-token:<scope>` from `~/.zephyr/storage` after acquiring the lock.
 4. Reuse the access token only when the record has the expected version and scope and its JWT remains valid beyond the
@@ -59,13 +60,13 @@ an identity-scoped, cross-process single-flight cache so those processes do not 
 5. On a miss, perform the exchange while holding the lock, persist the derived access token with its JWT lifetime as the
    storage TTL, and release the lock. Waiting processes then observe the persisted token instead of exchanging again.
 
-Different CI credentials or actors use different cache keys and locks. Browser/server access tokens continue to use the
-`ze-auth-token` record and a separate `auth-token` lock. All credential-bearing storage and lock targets are owner-only on
-POSIX systems.
+Different API gateways, CI credentials, or actors use different cache keys and locks. Browser/server access tokens
+continue to use the `ze-auth-token` record and a separate `auth-token` lock. All credential-bearing storage and lock
+targets are owner-only on POSIX systems.
 
 Authentication cleanup is scoped to authentication records. It must not call `nodePersist.clear()`, because the shared
 store also contains application configuration and deployment results produced by concurrent builds. CI exchange requests
 also skip generic 401 cleanup while holding the cache lock to avoid recursively acquiring the same lock; a rejected
 exchange removes its scoped cache record before surfacing the terminal CI-token error. Other 401 responses use
 compare-and-delete semantics so a delayed response for an older credential cannot remove a newer token written by another
-process.
+process. A process retains the scoped keys it has used so a later 401 for that newer token can still invalidate it.

--- a/docs/ci-token-identity.md
+++ b/docs/ci-token-identity.md
@@ -64,9 +64,22 @@ Different API gateways, CI credentials, or actors use different cache keys and l
 continue to use the `ze-auth-token` record and a separate `auth-token` lock. All credential-bearing storage and lock
 targets are owner-only on POSIX systems.
 
+Token coordination is an optimization, not an invariant. Without a lock, processes repeat an exchange or race a
+single-key write, which is the behavior that predates the lock. Every token lock therefore runs with
+`whenUnavailable: 'proceed'`: an exhausted retry budget or an unusable `~/.zephyr/locks` directory logs under
+`ze_log.misc` and continues unlocked instead of failing the build. Callers guarding multi-step state, such as the atomic
+partial-asset store, keep the default `whenUnavailable: 'throw'` and pass a shorter retry budget. Both share
+`withStorageLock` so there is one implementation of the private lock anchor, stale-lock recovery, and release path.
+
 Authentication cleanup is scoped to authentication records. It must not call `nodePersist.clear()`, because the shared
-store also contains application configuration and deployment results produced by concurrent builds. CI exchange requests
-also skip generic 401 cleanup while holding the cache lock to avoid recursively acquiring the same lock; a rejected
-exchange removes its scoped cache record before surfacing the terminal CI-token error. Other 401 responses use
+store also contains application configuration and deployment results produced by concurrent builds. Authenticated
+requests declare the credential they used through `HttpRequestOptions.credentialToken`, so a 401 invalidates only that
+credential rather than whatever the `Authorization` header happened to contain. CI exchange requests additionally skip
+generic 401 cleanup while holding the cache lock to avoid recursively acquiring the same lock; a rejected exchange
+removes its scoped cache record before surfacing the terminal CI-token error. Other 401 responses use
 compare-and-delete semantics so a delayed response for an older credential cannot remove a newer token written by another
 process. A process retains the scoped keys it has used so a later 401 for that newer token can still invalidate it.
+
+A single JWT-expiry implementation lives in `lib/auth/token-expiry.ts` and is shared by the login flow, application
+configuration reuse, and the CI access-token cache. `login.ts` re-exports `isTokenStillValid` so credential storage can
+use it without importing the interactive login flow, which itself depends on token storage.

--- a/docs/ci-token-identity.md
+++ b/docs/ci-token-identity.md
@@ -40,3 +40,31 @@ When `ZE_CI_TOKEN` is present, token exchange failures are terminal. The plugin 
 login in CI. A rejected exchange usually means the workflow actor's Git provider identity is not linked to a Zephyr user.
 The error should tell the user to link that Git provider account in Zephyr Cloud and rerun the workflow, while also
 checking that the CI token secret belongs to the right Zephyr workspace.
+
+## Access-token caching and concurrency
+
+`ZE_SECRET_TOKEN` and `ZE_CI_TOKEN` have different lifecycles. `ZE_SECRET_TOKEN` is already a bearer credential, so the
+agent reads it directly from the environment and never persists it. `ZE_CI_TOKEN` is an exchange credential: the agent
+must infer the CI actor and exchange the credential for a short-lived access token before calling Zephyr APIs.
+
+Large monorepo builds run many plugin processes against the same `~/.zephyr` directory. CI access-token resolution uses
+an identity-scoped, cross-process single-flight cache so those processes do not all exchange and write the same token:
+
+1. Hash the CI token together with the normalized provider identity. The raw CI token is never written to disk.
+2. Acquire the matching lock under `~/.zephyr/locks` using `proper-lockfile` with retries and stale-lock recovery.
+3. Re-read `ze-ci-auth-token:<scope>` from `~/.zephyr/storage` after acquiring the lock.
+4. Reuse the access token only when the record has the expected version and scope and its JWT remains valid beyond the
+   short-expiry safety window.
+5. On a miss, perform the exchange while holding the lock, persist the derived access token with its JWT lifetime as the
+   storage TTL, and release the lock. Waiting processes then observe the persisted token instead of exchanging again.
+
+Different CI credentials or actors use different cache keys and locks. Browser/server access tokens continue to use the
+`ze-auth-token` record and a separate `auth-token` lock. All credential-bearing storage and lock targets are owner-only on
+POSIX systems.
+
+Authentication cleanup is scoped to authentication records. It must not call `nodePersist.clear()`, because the shared
+store also contains application configuration and deployment results produced by concurrent builds. CI exchange requests
+also skip generic 401 cleanup while holding the cache lock to avoid recursively acquiring the same lock; a rejected
+exchange removes its scoped cache record before surfacing the terminal CI-token error. Other 401 responses use
+compare-and-delete semantics so a delayed response for an older credential cannot remove a newer token written by another
+process.

--- a/docs/git-usage.md
+++ b/docs/git-usage.md
@@ -107,7 +107,8 @@ Local build can still deploy, and Zephyr can infer org/project from `origin`.
   claims locally, then falls back to GitLab's `/job` API from the runner and GitLab's predefined `GITLAB_USER_EMAIL` for
   legacy/non-JWT job tokens. GitHub Actions reads `GITHUB_EVENT_PATH` commit/pusher emails, then falls back to GitHub
   noreply email from `GITHUB_ACTOR_ID` and `GITHUB_ACTOR`. No GitLab/GitHub CI YAML changes are required beyond setting
-  `ZE_CI_TOKEN`. Legacy `ZE_SERVER_TOKEN` behavior is unchanged.
+  `ZE_CI_TOKEN`. Legacy `ZE_SERVER_TOKEN` behavior is unchanged. See [CI Token Identity](./ci-token-identity.md) for
+  access-token caching and cross-process locking details.
 
 ## Troubleshooting
 

--- a/e2e/deployment/src/index.test.ts
+++ b/e2e/deployment/src/index.test.ts
@@ -42,7 +42,7 @@ for (const appName of testTargets) {
     beforeAll(async () => {
       appUidsPromise ??= getAllDeployedApps();
       const appUids = await appUidsPromise;
-      const appUid = appUids.find((uid) => uid.startsWith(replacer(appName)));
+      const appUid = appUids.find((uid) => uid.startsWith(`${replacer(appName)}.`));
       if (!appUid) {
         throw new Error(`Application ${appName} was not found on deployed apps.`);
       }

--- a/e2e/deployment/src/index.test.ts
+++ b/e2e/deployment/src/index.test.ts
@@ -1,11 +1,15 @@
 import { beforeAll, describe, expect, it } from '@rstest/core';
 
-import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { getAllDeployedApps, getAppDeployResult, type DeployResult } from 'zephyr-agent';
+import { getRepositoryRoot, listTurboPackages } from './turbo-selector';
 
-const output = execSync('pnpm exec turbo ls --affected --output=json');
+const repositoryRoot = getRepositoryRoot(import.meta.dirname);
+const output = listTurboPackages(
+  process.env['ZE_FORCE_ALL_EXAMPLES'] === 'true',
+  repositoryRoot
+);
 const affected = JSON.parse(output.toString()) as {
   packages: { items: Array<{ name: string; path: string }> };
 };
@@ -15,12 +19,7 @@ const testTargets = affected.packages.items
     if (!packagePath.startsWith('examples/') || pkg.name === 'zephyr-cli-test') {
       return false;
     }
-    const packageFile = path.resolve(
-      import.meta.dirname,
-      '../../..',
-      packagePath,
-      'package.json'
-    );
+    const packageFile = path.resolve(repositoryRoot, packagePath, 'package.json');
     const packageJson = JSON.parse(readFileSync(packageFile, 'utf8')) as {
       scripts?: Record<string, string>;
     };

--- a/e2e/deployment/src/turbo-selector.test.ts
+++ b/e2e/deployment/src/turbo-selector.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@rstest/core';
+
+import {
+  getRepositoryRoot,
+  getTurboPackageSelector,
+  listTurboPackages,
+} from './turbo-selector';
+
+describe('getTurboPackageSelector', () => {
+  it('selects all examples when explicitly forced', () => {
+    expect(getTurboPackageSelector(true)).toEqual(['--filter=./examples/*']);
+  });
+
+  it('selects only affected packages by default', () => {
+    expect(getTurboPackageSelector(false)).toEqual(['--affected']);
+  });
+
+  it('lists examples relative to the repository root', () => {
+    const output = listTurboPackages(true, getRepositoryRoot(import.meta.dirname));
+    const result = JSON.parse(output.toString()) as {
+      packages: { items: Array<{ path: string }> };
+    };
+
+    expect(
+      result.packages.items.some((pkg) =>
+        pkg.path.replaceAll('\\', '/').startsWith('examples/')
+      )
+    ).toBe(true);
+  });
+});

--- a/e2e/deployment/src/turbo-selector.test.ts
+++ b/e2e/deployment/src/turbo-selector.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe('getTurboPackageSelector', () => {
   it('selects all examples when explicitly forced', () => {
-    expect(getTurboPackageSelector(true)).toEqual(['--filter=./examples/*']);
+    expect(getTurboPackageSelector(true)).toEqual(['--filter=./examples/**']);
   });
 
   it('selects only affected packages by default', () => {

--- a/e2e/deployment/src/turbo-selector.ts
+++ b/e2e/deployment/src/turbo-selector.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+export function getTurboPackageSelector(forceAllExamples: boolean): string[] {
+  return forceAllExamples ? ['--filter=./examples/*'] : ['--affected'];
+}
+
+export function getRepositoryRoot(testSourceDirectory: string): string {
+  return path.resolve(testSourceDirectory, '../../..');
+}
+
+export function listTurboPackages(
+  forceAllExamples: boolean,
+  repositoryRoot: string
+): Buffer {
+  return execFileSync(
+    process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
+    [
+      'exec',
+      'turbo',
+      'ls',
+      ...getTurboPackageSelector(forceAllExamples),
+      '--output=json',
+    ],
+    {
+      cwd: repositoryRoot,
+      shell: process.platform === 'win32',
+    }
+  );
+}

--- a/e2e/deployment/src/turbo-selector.ts
+++ b/e2e/deployment/src/turbo-selector.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 
 export function getTurboPackageSelector(forceAllExamples: boolean): string[] {
-  return forceAllExamples ? ['--filter=./examples/*'] : ['--affected'];
+  return forceAllExamples ? ['--filter=./examples/**'] : ['--affected'];
 }
 
 export function getRepositoryRoot(testSourceDirectory: string): string {

--- a/libs/zephyr-agent/README.md
+++ b/libs/zephyr-agent/README.md
@@ -31,6 +31,12 @@ The agent is structured into several key modules:
 - Handles user authentication and authorization
 - Manages API tokens and session management
 - Provides WebSocket connections for real-time updates
+- Reads `ZE_SECRET_TOKEN` directly without persisting the environment secret
+- Exchanges `ZE_CI_TOKEN` once per CI identity using a persistent, inter-process locked access-token cache
+- Keeps credential cleanup scoped so concurrent deployment and application records remain intact
+
+See [CI Token Identity](../../docs/ci-token-identity.md) for token precedence,
+identity attribution, persistence, and concurrency invariants.
 
 ### Build Context (`lib/build-context/`)
 

--- a/libs/zephyr-agent/src/lib/auth/login.ts
+++ b/libs/zephyr-agent/src/lib/auth/login.ts
@@ -1,4 +1,3 @@
-import * as jose from 'jose';
 import type openBrowser from 'open';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -16,6 +15,7 @@ import { StorageKeys } from '../node-persist/storage-keys';
 import { getToken, removeToken, saveToken } from '../node-persist/token';
 import { AuthListener } from './sse';
 import { TOKEN_EXPIRY } from './auth-flags';
+import { isTokenStillValid } from './token-expiry';
 import { getCiToken } from '../node-persist/ci-token';
 import { getServerToken } from '../node-persist/server-token';
 import { type ZeGitInfo } from '../build-context/ze-util-get-git-info';
@@ -131,29 +131,9 @@ export async function checkAuth(git_config: ZeGitInfo): Promise<void> {
   logFn('', `${green('✓')} You are now logged in to Zephyr Cloud\n`);
 }
 
-/**
- * Decides whether the token is still valid based on its expiration time.
- *
- * @param token The token to check.
- * @param gap In seconds
- * @returns Boolean indicating if the token is still valid.
- */
-export function isTokenStillValid(token: string, gap = 0): boolean {
-  // Attempts to decode the token
-  try {
-    const decodedToken = jose.decodeJwt(token);
-
-    if (decodedToken.exp) {
-      return new Date(decodedToken.exp * 1000) > new Date(Date.now() + gap * 1000);
-    }
-
-    // No expiration date found, invalid token.
-    return false;
-  } catch {
-    // If the token is invalid, return false.
-    return false;
-  }
-}
+// Re-exported from its own module so credential storage can share one JWT-expiry
+// implementation without importing this interactive flow.
+export { isTokenStillValid } from './token-expiry';
 
 /** Prompts the user to choose an authentication action */
 async function promptForAuthAction(

--- a/libs/zephyr-agent/src/lib/auth/token-expiry.ts
+++ b/libs/zephyr-agent/src/lib/auth/token-expiry.ts
@@ -1,0 +1,33 @@
+import * as jose from 'jose';
+
+/**
+ * Reads a JWT's expiration in epoch milliseconds.
+ *
+ * Lives outside `login.ts` so credential storage can share it without importing the
+ * interactive login flow, which itself depends on token storage.
+ *
+ * @param token The token to inspect.
+ * @returns The expiration, or `undefined` when the token is undecodable or has no `exp`.
+ */
+export function getTokenExpirationMs(token: string): number | undefined {
+  try {
+    const { exp } = jose.decodeJwt(token);
+    return typeof exp === 'number' ? exp * 1000 : undefined;
+  } catch {
+    // Not a decodable JWT, so no expiration can be established.
+    return undefined;
+  }
+}
+
+/**
+ * Decides whether the token is still valid based on its expiration time.
+ *
+ * @param token The token to check.
+ * @param gap In seconds
+ * @returns Boolean indicating if the token is still valid.
+ */
+export function isTokenStillValid(token: string, gap = 0): boolean {
+  const expiresAtMs = getTokenExpirationMs(token);
+  // A token without a readable expiration is treated as invalid.
+  return expiresAtMs !== undefined && expiresAtMs > Date.now() + gap * 1000;
+}

--- a/libs/zephyr-agent/src/lib/edge-actions/ze-upload-build-stats.ts
+++ b/libs/zephyr-agent/src/lib/edge-actions/ze-upload-build-stats.ts
@@ -31,6 +31,7 @@ export async function zeUploadBuildStats(dashData: ZephyrBuildStats): Promise<st
         Accept: 'application/json',
         'Idempotency-Key': idempotencyKey,
       },
+      credentialToken: token,
     },
     JSON.stringify(dashData)
   );

--- a/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.ts
@@ -75,6 +75,7 @@ async function loadApplicationConfiguration(
     value: ZeApplicationConfig;
   }>(application_config_url, {
     headers: { Authorization: `Bearer ${token}` },
+    credentialToken: token,
   });
 
   if (!ok || !data?.value || data.value.application_uid !== application_uid) {

--- a/libs/zephyr-agent/src/lib/edge-requests/get-build-id.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-build-id.ts
@@ -17,6 +17,7 @@ export async function getBuildId(application_uid: string): Promise<string> {
       can_write_jwt: jwt,
       Authorization: 'Bearer ' + token,
     },
+    credentialToken: token,
   };
 
   const [ok, cause, data] = await makeRequest<Record<string, string>>(

--- a/libs/zephyr-agent/src/lib/http/http-request.test.ts
+++ b/libs/zephyr-agent/src/lib/http/http-request.test.ts
@@ -110,11 +110,27 @@ describe('Pure HTTP Request Functions', () => {
       const url = new URL('https://api.example.com/endpoint');
       const [ok, error] = await makeHttpRequest(url, {
         headers: { Authorization: 'Bearer rejected-token' },
+        credentialToken: 'rejected-token',
       });
 
       expect(ok).toBe(false);
       expect(error).toBeInstanceOf(Error);
       expect(mockCleanTokens).toHaveBeenCalledWith('rejected-token');
+    });
+
+    it('does not forward the declared credential as a fetch option', async () => {
+      mockFetchWithRetries.mockResolvedValueOnce({
+        status: 200,
+        text: async () => '{}',
+        ok: true,
+      } as Response);
+
+      const url = new URL('https://api.example.com/endpoint');
+      await makeHttpRequest(url, { credentialToken: 'secret-token' });
+
+      const [, requestInit] = mockFetchWithRetries.mock.calls[0];
+      expect(requestInit).not.toHaveProperty('credentialToken');
+      expect(requestInit).not.toHaveProperty('skipTokenCleanup');
     });
 
     it('does not recursively clean tokens when a credential refresh gets a 401', async () => {

--- a/libs/zephyr-agent/src/lib/http/http-request.test.ts
+++ b/libs/zephyr-agent/src/lib/http/http-request.test.ts
@@ -108,11 +108,28 @@ describe('Pure HTTP Request Functions', () => {
       } as Response);
 
       const url = new URL('https://api.example.com/endpoint');
-      const [ok, error] = await makeHttpRequest(url);
+      const [ok, error] = await makeHttpRequest(url, {
+        headers: { Authorization: 'Bearer rejected-token' },
+      });
 
       expect(ok).toBe(false);
       expect(error).toBeInstanceOf(Error);
-      expect(mockCleanTokens).toHaveBeenCalled();
+      expect(mockCleanTokens).toHaveBeenCalledWith('rejected-token');
+    });
+
+    it('does not recursively clean tokens when a credential refresh gets a 401', async () => {
+      mockFetchWithRetries.mockResolvedValueOnce({
+        status: 401,
+        text: async () => 'Unauthorized',
+        ok: false,
+      } as Response);
+
+      const url = new URL('https://api.example.com/endpoint');
+      const [ok, error] = await makeHttpRequest(url, { skipTokenCleanup: true });
+
+      expect(ok).toBe(false);
+      expect(error).toBeInstanceOf(Error);
+      expect(mockCleanTokens).not.toHaveBeenCalled();
     });
 
     it('should handle network errors', async () => {

--- a/libs/zephyr-agent/src/lib/http/http-request.ts
+++ b/libs/zephyr-agent/src/lib/http/http-request.ts
@@ -16,6 +16,13 @@ export type HttpResponse<T> =
   | [ok: false, error: Error];
 
 export interface HttpRequestOptions extends RequestInit {
+  /**
+   * The credential this request authenticates with. A 401 invalidates only this
+   * credential, so a delayed response cannot remove a newer token persisted by another
+   * process. Authenticated callers should always set it alongside the `Authorization`
+   * header; omitting it falls back to invalidating all stored authentication.
+   */
+  credentialToken?: string;
   /** Internal requests which are themselves refreshing credentials must not recurse. */
   skipTokenCleanup?: boolean;
 }
@@ -40,13 +47,6 @@ function applyApiHost(url: URL): URL {
   }
 
   return url;
-}
-
-function getBearerToken(headers: HeadersInit | undefined): string | undefined {
-  if (!headers) return undefined;
-  const value = new Headers(headers).get('authorization');
-  const match = value?.match(/^Bearer\s+(.+)$/i);
-  return match?.[1];
 }
 
 /** Parses the URL string into a URL object */
@@ -89,7 +89,7 @@ export async function makeHttpRequest<T = void>(
   data?: string | Buffer
 ): Promise<HttpResponse<T>> {
   const startTime = Date.now();
-  const { skipTokenCleanup = false, ...requestOptions } = options;
+  const { credentialToken, skipTokenCleanup = false, ...requestOptions } = options;
 
   try {
     const response = await fetchWithRetries(url, {
@@ -101,7 +101,7 @@ export async function makeHttpRequest<T = void>(
 
     if (response.status === 401 && !skipTokenCleanup) {
       // Clean the tokens and throw an error
-      await cleanTokens(getBearerToken(requestOptions.headers));
+      await cleanTokens(credentialToken);
       throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
         message: 'Unauthenticated request',
       });

--- a/libs/zephyr-agent/src/lib/http/http-request.ts
+++ b/libs/zephyr-agent/src/lib/http/http-request.ts
@@ -15,6 +15,11 @@ export type HttpResponse<T> =
   | [ok: true, error: null, data: T]
   | [ok: false, error: Error];
 
+export interface HttpRequestOptions extends RequestInit {
+  /** Internal requests which are themselves refreshing credentials must not recurse. */
+  skipTokenCleanup?: boolean;
+}
+
 export type UrlString =
   | string
   | URL
@@ -35,6 +40,13 @@ function applyApiHost(url: URL): URL {
   }
 
   return url;
+}
+
+function getBearerToken(headers: HeadersInit | undefined): string | undefined {
+  if (!headers) return undefined;
+  const value = new Headers(headers).get('authorization');
+  const match = value?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1];
 }
 
 /** Parses the URL string into a URL object */
@@ -73,22 +85,23 @@ function redactResponse(
 /** Main HTTP request function that handles the request and response */
 export async function makeHttpRequest<T = void>(
   url: URL,
-  options: RequestInit = {},
+  options: HttpRequestOptions = {},
   data?: string | Buffer
 ): Promise<HttpResponse<T>> {
   const startTime = Date.now();
+  const { skipTokenCleanup = false, ...requestOptions } = options;
 
   try {
     const response = await fetchWithRetries(url, {
-      ...options,
+      ...requestOptions,
       body: data as BodyInit | null | undefined,
     });
 
     const resText = await response.text();
 
-    if (response.status === 401) {
+    if (response.status === 401 && !skipTokenCleanup) {
       // Clean the tokens and throw an error
-      await cleanTokens();
+      await cleanTokens(getBearerToken(requestOptions.headers));
       throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
         message: 'Unauthenticated request',
       });
@@ -100,7 +113,7 @@ export async function makeHttpRequest<T = void>(
       });
     }
 
-    const message = redactResponse(url, options, data, resText, startTime);
+    const message = redactResponse(url, requestOptions, data, resText, startTime);
 
     if (resText.trim() === 'Not Implemented') {
       throw new ZephyrError(ZeErrors.ERR_UNKNOWN, {
@@ -123,7 +136,7 @@ export async function makeHttpRequest<T = void>(
           typeof resData === 'string'
             ? redactString(resData)
             : safeStringifyForLogging(resData),
-        method: options.method?.toUpperCase() ?? 'GET',
+        method: requestOptions.method?.toUpperCase() ?? 'GET',
       });
     }
 
@@ -136,7 +149,7 @@ export async function makeHttpRequest<T = void>(
 /** Creates a request that returns a promise for the HTTP response */
 export function makeRequest<T = void>(
   urlStr: UrlString,
-  options: RequestInit = {},
+  options: HttpRequestOptions = {},
   data?: string | Buffer
 ): Promise<HttpResponse<T>> {
   const url = parseUrl(urlStr);

--- a/libs/zephyr-agent/src/lib/logging/ze-log-event.ts
+++ b/libs/zephyr-agent/src/lib/logging/ze-log-event.ts
@@ -120,6 +120,7 @@ export function logger(props: LoggerOptions): ZeLogger {
                 Authorization: `Bearer ${token}`,
                 'Content-Type': 'application/json',
               },
+              credentialToken: token,
             },
             safeStringifyForLogging(
               logs

--- a/libs/zephyr-agent/src/lib/node-persist/ci-token-identity.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/ci-token-identity.test.ts
@@ -17,11 +17,11 @@ describe('inferCiTokenIdentity', () => {
   const originalFetch = global.fetch;
   let tempDirs: string[] = [];
 
-  afterEach(() => {
+  afterEach(async () => {
     global.fetch = originalFetch;
     const dirs = tempDirs;
     tempDirs = [];
-    return Promise.all(dirs.map((dir) => rm(dir, { force: true, recursive: true })));
+    await Promise.all(dirs.map((dir) => rm(dir, { force: true, recursive: true })));
   });
 
   it('infers GitLab actor email from CI_JOB_TOKEN JWT claims', async () => {
@@ -237,6 +237,28 @@ describe('inferCiTokenIdentity', () => {
       issuer: 'https://github.com',
       providerSubject: '12345',
       username: 'octocat',
+      source: 'noreply',
+    });
+  });
+
+  it('keeps the GitHub actor login aligned with the stable actor ID on reruns', async () => {
+    const eventPath = await writeGitHubEvent({});
+
+    const identity = await inferCiTokenIdentity({
+      GITHUB_ACTIONS: 'true',
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_ACTOR: 'original-actor',
+      GITHUB_ACTOR_ID: '12345',
+      GITHUB_TRIGGERING_ACTOR: 'rerun-actor',
+    });
+
+    expect(identity).toEqual({
+      provider: 'github',
+      email: '12345+original-actor@users.noreply.github.com',
+      emails: ['12345+original-actor@users.noreply.github.com'],
+      issuer: 'https://github.com',
+      providerSubject: '12345',
+      username: 'original-actor',
       source: 'noreply',
     });
   });

--- a/libs/zephyr-agent/src/lib/node-persist/ci-token-identity/github.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/ci-token-identity/github.ts
@@ -141,11 +141,7 @@ function getGitHubActor(
   env: NodeJS.ProcessEnv,
   event: GitHubEventPayload | undefined
 ): string | undefined {
-  return (
-    env['GITHUB_TRIGGERING_ACTOR']?.trim() ||
-    env['GITHUB_ACTOR']?.trim() ||
-    event?.sender?.login?.trim()
-  );
+  return env['GITHUB_ACTOR']?.trim() || event?.sender?.login?.trim();
 }
 
 function getGitHubActorId(

--- a/libs/zephyr-agent/src/lib/node-persist/partial-assets-map.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/partial-assets-map.ts
@@ -1,19 +1,16 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { mkdir, open, readFile, rm } from 'node:fs/promises';
+import { readFile, rm } from 'node:fs/promises';
 import * as path from 'node:path';
-import { lock } from 'proper-lockfile';
 import type { ZeBuildAsset, ZeBuildAssetsMap } from 'zephyr-edge-contract';
 import { zeBuildAssets } from '../transformers/ze-build-assets';
 import { writeFileAtomically } from './atomic-file';
-import { storage } from './storage';
 import {
-  ensurePrivateFilePermissions,
   PARTIAL_ASSET_LOCK_STALE_MS,
   StorageKeys,
-  ZE_LOCKS_PATH,
   ZE_PATH,
   ZE_STORAGE_PATH,
 } from './storage-keys';
+import { getStorageLockPath, withStorageLock } from './storage-lock';
 
 export interface PartialAssetMaps {
   [partialKey: string]: ZeBuildAssetsMap;
@@ -383,37 +380,27 @@ export function getLegacyPartialAssetStorePath(application_uid: string): string 
   return path.join(ZE_STORAGE_PATH, legacyKeyDigest);
 }
 
-/** @internal Exposed for persistence-boundary compatibility tests. */
-export function getPartialAssetLockPath(application_uid: string): string {
-  return path.join(
-    ZE_LOCKS_PATH,
-    `partial-assets-${get_application_digest(application_uid)}`
-  );
+function getPartialAssetLockName(application_uid: string): string {
+  return `partial-assets-${get_application_digest(application_uid)}`;
 }
 
-async function withPartialAssetsLock<T>(
+/** @internal Exposed for persistence-boundary compatibility tests. */
+export function getPartialAssetLockPath(application_uid: string): string {
+  return getStorageLockPath(getPartialAssetLockName(application_uid));
+}
+
+function withPartialAssetsLock<T>(
   application_uid: string,
   action: () => Promise<T>
 ): Promise<T> {
-  await storage;
-  // Recreate the private boundary if an external cleanup removed it while this process
-  // was alive. Persistent lock targets are intentional: proper-lockfile coordinates
-  // restarts through a stable path and keeps its transient ownership in `.lock`.
-  await mkdir(ZE_LOCKS_PATH, { recursive: true, mode: 0o700 });
-  const lockPath = getPartialAssetLockPath(application_uid);
-  await (await open(lockPath, 'a', 0o600)).close();
-  ensurePrivateFilePermissions(lockPath);
-  const release = await lock(lockPath, {
-    realpath: false,
+  // Each claim/commit sequence is a multi-step read-modify-write over the atomic store,
+  // so an unavailable lock must fail instead of proceeding unlocked. Contention is
+  // bounded by the finalizers of a single application, hence the short retry budget.
+  return withStorageLock(getPartialAssetLockName(application_uid), action, {
     retries: { retries: 8, factor: 1.5, minTimeout: 25, maxTimeout: 500 },
-    stale: PARTIAL_ASSET_LOCK_STALE_MS,
+    staleMs: PARTIAL_ASSET_LOCK_STALE_MS,
+    whenUnavailable: 'throw',
   });
-
-  try {
-    return await action();
-  } finally {
-    await release();
-  }
 }
 
 async function readJsonFileStrict(filePath: string): Promise<unknown | undefined> {

--- a/libs/zephyr-agent/src/lib/node-persist/storage-keys.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/storage-keys.ts
@@ -117,6 +117,7 @@ export enum StorageKeys {
   ze_fs_cache = 'ze-fs-cache',
   ze_hash_cache = 'ze-hash-cache',
   ze_app_deploy_result = 'ze-app-deploy-result',
+  ze_ci_auth_token = 'ze-ci-auth-token',
   ze_server_token = 'ZE_SERVER_TOKEN',
   ze_ci_token = 'ZE_CI_TOKEN',
   ze_user_email = 'ZE_USER_EMAIL',

--- a/libs/zephyr-agent/src/lib/node-persist/storage-lock.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/storage-lock.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+import { join } from 'node:path';
 
 const mocks = rs.hoisted(() => ({
   close: rs.fn(),
@@ -30,6 +31,8 @@ describe('withStorageLock', () => {
   });
 
   it('uses a private retrying inter-process lock and releases it', async () => {
+    const lockPath = join('/private/locks', 'auth-token');
+
     await expect(withStorageLock('auth-token', async () => 'value')).resolves.toBe(
       'value'
     );
@@ -38,12 +41,10 @@ describe('withStorageLock', () => {
       recursive: true,
       mode: 0o700,
     });
-    expect(mocks.open).toHaveBeenCalledWith('/private/locks/auth-token', 'a', 0o600);
-    expect(mocks.ensurePrivateFilePermissions).toHaveBeenCalledWith(
-      '/private/locks/auth-token'
-    );
+    expect(mocks.open).toHaveBeenCalledWith(lockPath, 'a', 0o600);
+    expect(mocks.ensurePrivateFilePermissions).toHaveBeenCalledWith(lockPath);
     expect(mocks.lock).toHaveBeenCalledWith(
-      '/private/locks/auth-token',
+      lockPath,
       expect.objectContaining({ realpath: false, retries: expect.any(Object) })
     );
     expect(mocks.release).toHaveBeenCalledTimes(1);

--- a/libs/zephyr-agent/src/lib/node-persist/storage-lock.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/storage-lock.test.ts
@@ -59,4 +59,52 @@ describe('withStorageLock', () => {
 
     expect(mocks.release).toHaveBeenCalledTimes(1);
   });
+
+  it('applies caller-supplied stale and retry budgets', async () => {
+    const retries = { retries: 8, factor: 1.5, minTimeout: 25, maxTimeout: 500 };
+
+    await withStorageLock('partial-assets-abc', async () => undefined, {
+      retries,
+      staleMs: 30_000,
+    });
+
+    expect(mocks.lock).toHaveBeenCalledWith(
+      join('/private/locks', 'partial-assets-abc'),
+      {
+        realpath: false,
+        retries,
+        stale: 30_000,
+      }
+    );
+  });
+
+  it('surfaces acquisition failures by default', async () => {
+    mocks.lock.mockRejectedValue(new Error('Lock file is already being held'));
+    const action = rs.fn(async () => 'value');
+
+    await expect(withStorageLock('auth-token', action)).rejects.toThrow(
+      'Lock file is already being held'
+    );
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('runs the action unlocked when the caller opts out of failing on contention', async () => {
+    mocks.lock.mockRejectedValue(new Error('Lock file is already being held'));
+
+    await expect(
+      withStorageLock('auth-token', async () => 'value', { whenUnavailable: 'proceed' })
+    ).resolves.toBe('value');
+    expect(mocks.release).not.toHaveBeenCalled();
+  });
+
+  it('runs the action unlocked when the locks directory is unusable', async () => {
+    mocks.mkdir.mockRejectedValue(
+      Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    );
+
+    await expect(
+      withStorageLock('auth-token', async () => 'value', { whenUnavailable: 'proceed' })
+    ).resolves.toBe('value');
+    expect(mocks.lock).not.toHaveBeenCalled();
+  });
 });

--- a/libs/zephyr-agent/src/lib/node-persist/storage-lock.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/storage-lock.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+
+const mocks = rs.hoisted(() => ({
+  close: rs.fn(),
+  ensurePrivateFilePermissions: rs.fn(),
+  lock: rs.fn(),
+  mkdir: rs.fn(),
+  open: rs.fn(),
+  release: rs.fn(),
+}));
+
+rs.mock('node:fs/promises', () => ({
+  mkdir: mocks.mkdir,
+  open: mocks.open,
+}));
+rs.mock('proper-lockfile', () => ({ lock: mocks.lock }));
+rs.mock('./storage', () => ({ storage: Promise.resolve() }));
+rs.mock('./storage-keys', () => ({
+  ensurePrivateFilePermissions: mocks.ensurePrivateFilePermissions,
+  ZE_LOCKS_PATH: '/private/locks',
+}));
+
+import { withStorageLock } from './storage-lock';
+
+describe('withStorageLock', () => {
+  beforeEach(() => {
+    rs.resetAllMocks();
+    mocks.open.mockResolvedValue({ close: mocks.close });
+    mocks.lock.mockResolvedValue(mocks.release);
+  });
+
+  it('uses a private retrying inter-process lock and releases it', async () => {
+    await expect(withStorageLock('auth-token', async () => 'value')).resolves.toBe(
+      'value'
+    );
+
+    expect(mocks.mkdir).toHaveBeenCalledWith('/private/locks', {
+      recursive: true,
+      mode: 0o700,
+    });
+    expect(mocks.open).toHaveBeenCalledWith('/private/locks/auth-token', 'a', 0o600);
+    expect(mocks.ensurePrivateFilePermissions).toHaveBeenCalledWith(
+      '/private/locks/auth-token'
+    );
+    expect(mocks.lock).toHaveBeenCalledWith(
+      '/private/locks/auth-token',
+      expect.objectContaining({ realpath: false, retries: expect.any(Object) })
+    );
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the lock when the protected operation fails', async () => {
+    await expect(
+      withStorageLock('auth-token', async () => {
+        throw new Error('write failed');
+      })
+    ).rejects.toThrow('write failed');
+
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/zephyr-agent/src/lib/node-persist/storage-lock.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/storage-lock.ts
@@ -1,37 +1,93 @@
 import { mkdir, open } from 'node:fs/promises';
 import path from 'node:path';
-import { lock } from 'proper-lockfile';
+import { lock, type LockOptions } from 'proper-lockfile';
+import { ze_log } from '../logging/debug';
 import { ensurePrivateFilePermissions, ZE_LOCKS_PATH } from './storage-keys';
 import { storage } from './storage';
 
 const STORAGE_LOCK_STALE_MS = 60_000;
 
+/**
+ * Credential coordination fans out across every plugin process in a monorepo build, so
+ * the default budget tolerates a slow holder (~60s of retries) rather than failing fast.
+ * Callers guarding multi-step state should pass a shorter budget and keep the default
+ * `whenUnavailable: 'throw'`.
+ */
+const STORAGE_LOCK_RETRIES: LockOptions['retries'] = {
+  retries: 120,
+  factor: 1.2,
+  minTimeout: 25,
+  maxTimeout: 500,
+  randomize: true,
+};
+
+/**
+ * What to do when the lock cannot be acquired.
+ *
+ * - `throw` (default) surfaces the acquisition error.
+ * - `proceed` runs the action unlocked. Only correct when losing coordination duplicates
+ *   work instead of corrupting state.
+ */
+export type StorageLockUnavailableBehavior = 'throw' | 'proceed';
+
+export interface StorageLockOptions {
+  /** Crash-recovery threshold after which an unrefreshed lock is considered abandoned. */
+  staleMs?: number;
+  /** Acquisition retry budget. */
+  retries?: LockOptions['retries'];
+  whenUnavailable?: StorageLockUnavailableBehavior;
+}
+
+/** Resolve the stable lock anchor for a named storage lock. */
+export function getStorageLockPath(name: string): string {
+  return path.join(ZE_LOCKS_PATH, name);
+}
+
 /** Run an operation under a crash-recoverable inter-process storage lock. */
 export async function withStorageLock<T>(
   name: string,
-  action: () => Promise<T>
+  action: () => Promise<T>,
+  options: StorageLockOptions = {}
 ): Promise<T> {
-  await storage;
-  await mkdir(ZE_LOCKS_PATH, { recursive: true, mode: 0o700 });
-  const lockPath = path.join(ZE_LOCKS_PATH, name);
-  await (await open(lockPath, 'a', 0o600)).close();
-  ensurePrivateFilePermissions(lockPath);
+  const {
+    staleMs = STORAGE_LOCK_STALE_MS,
+    retries = STORAGE_LOCK_RETRIES,
+    whenUnavailable = 'throw',
+  } = options;
 
-  const release = await lock(lockPath, {
-    realpath: false,
-    retries: {
-      retries: 120,
-      factor: 1.2,
-      minTimeout: 25,
-      maxTimeout: 500,
-      randomize: true,
-    },
-    stale: STORAGE_LOCK_STALE_MS,
-  });
+  let release: (() => Promise<void>) | undefined;
+  try {
+    release = await acquireStorageLock(name, staleMs, retries);
+  } catch (error) {
+    if (whenUnavailable === 'throw') throw error;
+    // The caller declared coordination to be an optimization. An exhausted retry budget
+    // or an unusable locks directory must not fail the build when the only cost of
+    // proceeding is repeating work another process already did.
+    ze_log.misc(`Proceeding without the ${name} storage lock:`, error);
+  }
 
   try {
     return await action();
   } finally {
-    await release();
+    await release?.();
   }
+}
+
+async function acquireStorageLock(
+  name: string,
+  staleMs: number,
+  retries: LockOptions['retries']
+): Promise<() => Promise<void>> {
+  await storage;
+  // Recreate the private boundary if an external cleanup removed it while this process
+  // was alive.
+  await mkdir(ZE_LOCKS_PATH, { recursive: true, mode: 0o700 });
+  const lockPath = getStorageLockPath(name);
+  // `realpath: false` means proper-lockfile never opens this path; it is only a stable
+  // anchor for the sibling `.lock` directory holding transient ownership. Pre-create it
+  // privately so no reader can inherit a umask-widened mode.
+  await (await open(lockPath, 'a', 0o600)).close();
+  ensurePrivateFilePermissions(lockPath);
+
+  return lock(lockPath, { realpath: false, retries, stale: staleMs });
 }

--- a/libs/zephyr-agent/src/lib/node-persist/storage-lock.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/storage-lock.ts
@@ -1,0 +1,37 @@
+import { mkdir, open } from 'node:fs/promises';
+import path from 'node:path';
+import { lock } from 'proper-lockfile';
+import { ensurePrivateFilePermissions, ZE_LOCKS_PATH } from './storage-keys';
+import { storage } from './storage';
+
+const STORAGE_LOCK_STALE_MS = 60_000;
+
+/** Run an operation under a crash-recoverable inter-process storage lock. */
+export async function withStorageLock<T>(
+  name: string,
+  action: () => Promise<T>
+): Promise<T> {
+  await storage;
+  await mkdir(ZE_LOCKS_PATH, { recursive: true, mode: 0o700 });
+  const lockPath = path.join(ZE_LOCKS_PATH, name);
+  await (await open(lockPath, 'a', 0o600)).close();
+  ensurePrivateFilePermissions(lockPath);
+
+  const release = await lock(lockPath, {
+    realpath: false,
+    retries: {
+      retries: 120,
+      factor: 1.2,
+      minTimeout: 25,
+      maxTimeout: 500,
+      randomize: true,
+    },
+    stale: STORAGE_LOCK_STALE_MS,
+  });
+
+  try {
+    return await action();
+  } finally {
+    await release();
+  }
+}

--- a/libs/zephyr-agent/src/lib/node-persist/token.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.test.ts
@@ -1,16 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import type { Mock } from '@rstest/core';
 
-import { getToken, saveToken } from './token';
+import * as jose from 'jose';
+import { cleanTokens, getToken, saveToken } from './token';
 import { inferCiTokenIdentity } from './ci-token-identity';
 import { makeRequest } from '../http/http-request';
 import { ZeErrors, ZephyrError } from '../errors';
+import { withStorageLock } from './storage-lock';
 
 rs.mock('node-persist', () => ({
   clear: rs.fn(),
   getItem: rs.fn(),
   removeItem: rs.fn(),
   setItem: rs.fn(),
+}));
+
+rs.mock('jose', () => ({
+  decodeJwt: rs.fn(),
 }));
 
 rs.mock('./storage', () => ({
@@ -22,6 +28,10 @@ rs.mock('./ci-token-identity', () => ({
   inferCiTokenIdentity: rs.fn(),
 }));
 
+rs.mock('./storage-lock', () => ({
+  withStorageLock: rs.fn(),
+}));
+
 rs.mock('../http/http-request', () => ({
   makeRequest: rs.fn(),
 }));
@@ -30,6 +40,18 @@ const mockInferCiTokenIdentity = inferCiTokenIdentity as Mock<
   typeof inferCiTokenIdentity
 >;
 const mockMakeRequest = makeRequest as Mock<typeof makeRequest>;
+const mockDecodeJwt = jose.decodeJwt as Mock<typeof jose.decodeJwt>;
+const mockWithStorageLock = withStorageLock as Mock<typeof withStorageLock>;
+
+const githubIdentity = {
+  provider: 'github' as const,
+  email: '12345+octocat@users.noreply.github.com',
+  emails: ['12345+octocat@users.noreply.github.com'],
+  issuer: 'https://github.com',
+  providerSubject: '12345',
+  username: 'octocat',
+  source: 'noreply' as const,
+};
 
 describe('getToken', () => {
   const originalEnv = process.env;
@@ -39,6 +61,8 @@ describe('getToken', () => {
     process.env = { ...originalEnv, ZE_CI_TOKEN: 'ci-token' };
     delete process.env['ZE_SECRET_TOKEN'];
     delete process.env['ZE_SERVER_TOKEN'];
+    mockDecodeJwt.mockReturnValue({ exp: Date.now() / 1000 + 60 * 60 });
+    mockWithStorageLock.mockImplementation(async (_name, action) => action());
   });
 
   afterEach(() => {
@@ -46,15 +70,7 @@ describe('getToken', () => {
   });
 
   it('throws a CI-token-specific error when exchange is rejected', async () => {
-    mockInferCiTokenIdentity.mockResolvedValue({
-      provider: 'github',
-      email: '12345+octocat@users.noreply.github.com',
-      emails: ['12345+octocat@users.noreply.github.com'],
-      issuer: 'https://github.com',
-      providerSubject: '12345',
-      username: 'octocat',
-      source: 'noreply',
-    });
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
     mockMakeRequest.mockResolvedValue([
       false,
       new Error('GitHub identity is not linked to a Zephyr user'),
@@ -75,22 +91,106 @@ describe('getToken', () => {
     });
   });
 
-  it('does not persist CI-derived access tokens in shared storage', async () => {
-    mockInferCiTokenIdentity.mockResolvedValue({
-      provider: 'github',
-      email: '12345+octocat@users.noreply.github.com',
-      emails: ['12345+octocat@users.noreply.github.com'],
-      issuer: 'https://github.com',
-      providerSubject: '12345',
-      username: 'octocat',
-      source: 'noreply',
-    });
+  it('persists CI-derived access tokens in an identity-scoped cache', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
     mockMakeRequest.mockResolvedValue([true, null, { access_token: 'ci-access-token' }]);
     const { setPrivateItem } = await import('./storage');
 
     await expect(getToken()).resolves.toBe('ci-access-token');
 
+    expect(setPrivateItem).toHaveBeenCalledWith(
+      expect.stringMatching(/^ze-ci-auth-token:[a-f0-9]{64}$/),
+      expect.objectContaining({
+        version: 1,
+        accessToken: 'ci-access-token',
+        scope: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+      expect.objectContaining({ ttl: expect.any(Number) })
+    );
+  });
+
+  it('reuses a valid persisted CI access token without another exchange', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'cached-token' }]);
+    const { getItem } = await import('node-persist');
+    const { setPrivateItem } = await import('./storage');
+
+    await getToken();
+    const [, cachedValue] = (setPrivateItem as Mock<typeof setPrivateItem>).mock.calls[0];
+    (getItem as Mock<typeof getItem>).mockResolvedValue(cachedValue);
+    mockMakeRequest.mockClear();
+
+    await expect(getToken()).resolves.toBe('cached-token');
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent callers so only one exchanges the CI token', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
+    let persisted: unknown;
+    let lockQueue = Promise.resolve();
+    mockWithStorageLock.mockImplementation((_name, action) => {
+      const result = lockQueue.then(action);
+      lockQueue = result.then(
+        () => undefined,
+        () => undefined
+      );
+      return result;
+    });
+    const { getItem } = await import('node-persist');
+    const { setPrivateItem } = await import('./storage');
+    (getItem as Mock<typeof getItem>).mockImplementation(async () => persisted);
+    (setPrivateItem as Mock<typeof setPrivateItem>).mockImplementation(
+      async (_key, value) => {
+        persisted = value;
+      }
+    );
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'shared-token' }]);
+
+    await expect(Promise.all([getToken(), getToken(), getToken()])).resolves.toEqual([
+      'shared-token',
+      'shared-token',
+      'shared-token',
+    ]);
+    expect(mockMakeRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes an expired persisted CI access token', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'initial-token' }]);
+    const { getItem } = await import('node-persist');
+    const { setPrivateItem } = await import('./storage');
+
+    await getToken();
+    const [, cachedValue] = (setPrivateItem as Mock<typeof setPrivateItem>).mock.calls[0];
+    (getItem as Mock<typeof getItem>).mockResolvedValue({
+      ...(cachedValue as object),
+      accessToken: 'expired-token',
+    });
+    mockDecodeJwt.mockImplementation((token) => ({
+      exp: Date.now() / 1000 + (token === 'expired-token' ? -60 : 60 * 60),
+    }));
+    mockMakeRequest.mockClear();
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'refreshed-token' }]);
+
+    await expect(getToken()).resolves.toBe('refreshed-token');
+    expect(mockMakeRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects and does not persist an invalid exchanged access token', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
+    mockDecodeJwt.mockReturnValue({});
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'invalid-token' }]);
+    const { removeItem } = await import('node-persist');
+    const { setPrivateItem } = await import('./storage');
+
+    await expect(getToken()).rejects.toMatchObject({
+      code: ZephyrError.toZeCode(ZeErrors.ERR_CI_TOKEN_AUTH),
+    });
+
     expect(setPrivateItem).not.toHaveBeenCalled();
+    expect(removeItem).toHaveBeenCalledWith(
+      expect.stringMatching(/^ze-ci-auth-token:[a-f0-9]{64}$/)
+    );
   });
 
   it('persists browser access tokens through the private storage writer', async () => {
@@ -139,5 +239,39 @@ describe('getToken', () => {
     await expect(getToken()).resolves.toBe('exchanged-server-access-token');
 
     expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('cleans only authentication records, not all persisted deployment state', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'ci-access-token' }]);
+    const { clear, removeItem } = await import('node-persist');
+
+    await getToken();
+    await cleanTokens();
+
+    expect(clear).not.toHaveBeenCalled();
+    expect(removeItem).toHaveBeenCalledWith('ze-auth-token');
+    expect(removeItem).toHaveBeenCalledWith(
+      expect.stringMatching(/^ze-ci-auth-token:[a-f0-9]{64}$/)
+    );
+  });
+
+  it('does not let a delayed 401 remove a newer persisted token', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'new-token' }]);
+    const { getItem, removeItem } = await import('node-persist');
+    const { setPrivateItem } = await import('./storage');
+
+    await getToken();
+    const [cacheKey, cachedValue] = (setPrivateItem as Mock<typeof setPrivateItem>).mock
+      .calls[0];
+    (getItem as Mock<typeof getItem>).mockImplementation(async (key) =>
+      key === cacheKey ? cachedValue : 'new-token'
+    );
+    (removeItem as Mock<typeof removeItem>).mockClear();
+
+    await cleanTokens('old-token');
+
+    expect(removeItem).not.toHaveBeenCalled();
   });
 });

--- a/libs/zephyr-agent/src/lib/node-persist/token.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.test.ts
@@ -75,6 +75,24 @@ describe('getToken', () => {
     });
   });
 
+  it('does not persist CI-derived access tokens in shared storage', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue({
+      provider: 'github',
+      email: '12345+octocat@users.noreply.github.com',
+      emails: ['12345+octocat@users.noreply.github.com'],
+      issuer: 'https://github.com',
+      providerSubject: '12345',
+      username: 'octocat',
+      source: 'noreply',
+    });
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'ci-access-token' }]);
+    const { setPrivateItem } = await import('./storage');
+
+    await expect(getToken()).resolves.toBe('ci-access-token');
+
+    expect(setPrivateItem).not.toHaveBeenCalled();
+  });
+
   it('persists browser access tokens through the private storage writer', async () => {
     const { setPrivateItem } = await import('./storage');
 

--- a/libs/zephyr-agent/src/lib/node-persist/token.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.test.ts
@@ -124,6 +124,32 @@ describe('getToken', () => {
     expect(mockMakeRequest).not.toHaveBeenCalled();
   });
 
+  it('exchanges a new CI access token when the API gateway changes', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
+    mockMakeRequest
+      .mockResolvedValueOnce([true, null, { access_token: 'dev-token' }])
+      .mockResolvedValueOnce([true, null, { access_token: 'prod-token' }]);
+    const { getItem } = await import('node-persist');
+    const { setPrivateItem } = await import('./storage');
+    const persisted = new Map<string, unknown>();
+    (getItem as Mock<typeof getItem>).mockImplementation(async (key) =>
+      persisted.get(String(key))
+    );
+    (setPrivateItem as Mock<typeof setPrivateItem>).mockImplementation(
+      async (key, value) => {
+        persisted.set(key, value);
+      }
+    );
+
+    process.env['ZE_API_GATE'] = 'https://dev-api.example';
+    await expect(getToken()).resolves.toBe('dev-token');
+    process.env['ZE_API_GATE'] = 'https://prod-api.example';
+    await expect(getToken()).resolves.toBe('prod-token');
+
+    expect(mockMakeRequest).toHaveBeenCalledTimes(2);
+    expect([...persisted.keys()]).toHaveLength(2);
+  });
+
   it('serializes concurrent callers so only one exchanges the CI token', async () => {
     mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
     let persisted: unknown;
@@ -273,5 +299,25 @@ describe('getToken', () => {
     await cleanTokens('old-token');
 
     expect(removeItem).not.toHaveBeenCalled();
+  });
+
+  it('retains CI cache tracking when a delayed 401 preserves a newer token', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubIdentity);
+    mockMakeRequest.mockResolvedValue([true, null, { access_token: 'new-token' }]);
+    const { getItem, removeItem } = await import('node-persist');
+    const { setPrivateItem } = await import('./storage');
+
+    await getToken();
+    const [cacheKey, cachedValue] = (setPrivateItem as Mock<typeof setPrivateItem>).mock
+      .calls[0];
+    (getItem as Mock<typeof getItem>).mockImplementation(async (key) =>
+      key === cacheKey ? cachedValue : undefined
+    );
+    (removeItem as Mock<typeof removeItem>).mockClear();
+
+    await cleanTokens('old-token');
+    await cleanTokens('new-token');
+
+    expect(removeItem).toHaveBeenCalledWith(cacheKey);
   });
 });

--- a/libs/zephyr-agent/src/lib/node-persist/token.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.ts
@@ -125,7 +125,8 @@ async function getTokenFromCiToken(
     throwCiTokenAuthError(identity, cause);
   }
 
-  await saveToken(data?.access_token ?? '');
+  // Concurrent CI builds share ~/.zephyr; persisting this derived token races them all
+  // on one node-persist key, while ZE_CI_TOKEN takes precedence on every subsequent read.
   return data?.access_token;
 }
 

--- a/libs/zephyr-agent/src/lib/node-persist/token.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.ts
@@ -1,10 +1,9 @@
 import { createHash } from 'node:crypto';
-import * as jose from 'jose';
 import nodePersist from 'node-persist';
 import { getSecretToken } from './secret-token';
 import { setPrivateItem, storage } from './storage';
 import { StorageKeys } from './storage-keys';
-import { withStorageLock } from './storage-lock';
+import { withStorageLock, type StorageLockOptions } from './storage-lock';
 import { makeRequest } from '../http/http-request';
 import { getCiToken } from './ci-token';
 import { getServerToken } from './server-token';
@@ -15,10 +14,18 @@ import { type ZeGitInfo } from '../build-context/ze-util-get-git-info';
 import { type CiTokenIdentity, inferCiTokenIdentity } from './ci-token-identity';
 import { ZeErrors, ZephyrError } from '../errors';
 import { TOKEN_EXPIRY } from '../auth/auth-flags';
+import { getTokenExpirationMs, isTokenStillValid } from '../auth/token-expiry';
 
 const CI_TOKEN_CACHE_VERSION = 1;
 const CI_TOKEN_SCOPE_CONTEXT = 'zephyr-ci-token-cache\0';
 const activeCiTokenCacheKeys = new Set<string>();
+
+/**
+ * Token coordination is an optimization, not an invariant. Without the lock, processes
+ * repeat an exchange or race a single-key write, which is exactly the behavior before the
+ * lock existed. An unavailable lock must therefore never fail a build.
+ */
+const TOKEN_LOCK: StorageLockOptions = { whenUnavailable: 'proceed' };
 
 interface StoredCiAccessToken {
   version: typeof CI_TOKEN_CACHE_VERSION;
@@ -27,8 +34,10 @@ interface StoredCiAccessToken {
 }
 
 export async function saveToken(token: string): Promise<void> {
-  await withStorageLock('auth-token', () =>
-    setPrivateItem(StorageKeys.ze_auth_token, token)
+  await withStorageLock(
+    'auth-token',
+    () => setPrivateItem(StorageKeys.ze_auth_token, token),
+    TOKEN_LOCK
   );
 }
 
@@ -63,10 +72,14 @@ export async function getToken(git_config?: ZeGitInfo): Promise<string | undefin
     return await getTokenFromServerToken(server_token, git_config.git.email);
   }
 
-  const token = await withStorageLock('auth-token', async () => {
-    await storage;
-    return nodePersist.getItem(StorageKeys.ze_auth_token);
-  });
+  const token = await withStorageLock(
+    'auth-token',
+    async () => {
+      await storage;
+      return nodePersist.getItem(StorageKeys.ze_auth_token);
+    },
+    TOKEN_LOCK
+  );
   if (token) {
     return token;
   }
@@ -80,13 +93,17 @@ export async function getToken(git_config?: ZeGitInfo): Promise<string | undefin
 }
 
 export async function removeToken(expectedToken?: string): Promise<void> {
-  await withStorageLock('auth-token', async () => {
-    await storage;
-    const storedToken: unknown = await nodePersist.getItem(StorageKeys.ze_auth_token);
-    if (expectedToken === undefined || storedToken === expectedToken) {
-      await nodePersist.removeItem(StorageKeys.ze_auth_token);
-    }
-  });
+  await withStorageLock(
+    'auth-token',
+    async () => {
+      await storage;
+      const storedToken: unknown = await nodePersist.getItem(StorageKeys.ze_auth_token);
+      if (expectedToken === undefined || storedToken === expectedToken) {
+        await nodePersist.removeItem(StorageKeys.ze_auth_token);
+      }
+    },
+    TOKEN_LOCK
+  );
 }
 
 export async function cleanTokens(rejectedToken?: string): Promise<void> {
@@ -94,16 +111,20 @@ export async function cleanTokens(rejectedToken?: string): Promise<void> {
   const cacheKeys = Array.from(activeCiTokenCacheKeys);
   await Promise.all(
     cacheKeys.map((cacheKey) =>
-      withStorageLock(getCiTokenLockName(cacheKey), async () => {
-        await storage;
-        const cached: unknown = await nodePersist.getItem(cacheKey);
-        if (
-          rejectedToken === undefined ||
-          (isStoredCiAccessToken(cached) && cached.accessToken === rejectedToken)
-        ) {
-          await nodePersist.removeItem(cacheKey);
-        }
-      })
+      withStorageLock(
+        getCiTokenLockName(cacheKey),
+        async () => {
+          await storage;
+          const cached: unknown = await nodePersist.getItem(cacheKey);
+          if (
+            rejectedToken === undefined ||
+            (isStoredCiAccessToken(cached) && cached.accessToken === rejectedToken)
+          ) {
+            await nodePersist.removeItem(cacheKey);
+          }
+        },
+        TOKEN_LOCK
+      )
     )
   );
 }
@@ -123,6 +144,9 @@ async function getTokenFromServerToken(
       headers: {
         Authorization: `Bearer ${server_token}`,
       },
+      // ZE_SERVER_TOKEN is a direct credential and is never persisted, so a 401 here
+      // must not invalidate the unrelated browser access token.
+      credentialToken: server_token,
     }
   );
 
@@ -146,52 +170,61 @@ async function getTokenFromCiToken(
   const cacheKey = `${StorageKeys.ze_ci_auth_token}:${scope}`;
   activeCiTokenCacheKeys.add(cacheKey);
 
-  return withStorageLock(getCiTokenLockName(cacheKey), async () => {
-    await storage;
-    const cached: unknown = await nodePersist.getItem(cacheKey);
-    if (isReusableCiAccessToken(cached, scope)) {
-      return cached.accessToken;
-    }
+  return withStorageLock(
+    getCiTokenLockName(cacheKey),
+    async () => {
+      await storage;
+      const cached: unknown = await nodePersist.getItem(cacheKey);
+      if (isReusableCiAccessToken(cached, scope)) {
+        return cached.accessToken;
+      }
 
-    const [ok, cause, data] = await makeRequest<{ access_token: string }>(
-      {
-        path: ze_api_gateway.ci_token_exchange,
-        base: ZE_API_ENDPOINT(),
-        query: {},
-      },
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${ci_token}`,
-          'Content-Type': 'application/json',
+      const [ok, cause, data] = await makeRequest<{ access_token: string }>(
+        {
+          path: ze_api_gateway.ci_token_exchange,
+          base: ZE_API_ENDPOINT(),
+          query: {},
         },
-        skipTokenCleanup: true,
-      },
-      JSON.stringify(identity)
-    );
-
-    if (!ok) {
-      await nodePersist.removeItem(cacheKey);
-      throwCiTokenAuthError(identity, cause);
-    }
-
-    const accessToken = data?.access_token;
-    const expiresIn = accessToken ? getTokenExpirationMs(accessToken) - Date.now() : 0;
-    if (!accessToken || expiresIn <= TOKEN_EXPIRY.SHORT_VALIDITY_CHECK_SEC * 1000) {
-      await nodePersist.removeItem(cacheKey);
-      throwCiTokenAuthError(
-        identity,
-        new Error('CI token exchange returned an invalid or expiring access token')
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${ci_token}`,
+            'Content-Type': 'application/json',
+          },
+          credentialToken: ci_token,
+          skipTokenCleanup: true,
+        },
+        JSON.stringify(identity)
       );
-    }
 
-    await setPrivateItem(
-      cacheKey,
-      { version: CI_TOKEN_CACHE_VERSION, scope, accessToken },
-      { ttl: expiresIn }
-    );
-    return accessToken;
-  });
+      if (!ok) {
+        await nodePersist.removeItem(cacheKey);
+        throwCiTokenAuthError(identity, cause);
+      }
+
+      const accessToken = data?.access_token;
+      if (
+        !accessToken ||
+        !isTokenStillValid(accessToken, TOKEN_EXPIRY.SHORT_VALIDITY_CHECK_SEC)
+      ) {
+        await nodePersist.removeItem(cacheKey);
+        throwCiTokenAuthError(
+          identity,
+          new Error('CI token exchange returned an invalid or expiring access token')
+        );
+      }
+
+      // Validity was just asserted, so the expiration is readable and in the future.
+      const expiresAtMs = getTokenExpirationMs(accessToken) ?? Date.now();
+      await setPrivateItem(
+        cacheKey,
+        { version: CI_TOKEN_CACHE_VERSION, scope, accessToken },
+        { ttl: expiresAtMs - Date.now() }
+      );
+      return accessToken;
+    },
+    TOKEN_LOCK
+  );
 }
 
 function getCiTokenScope(ciToken: string, identity: CiTokenIdentity): string {
@@ -217,24 +250,14 @@ function getCiTokenLockName(cacheKey: string): string {
   return `ci-auth-${cacheKey.substring(cacheKey.lastIndexOf(':') + 1)}`;
 }
 
-function getTokenExpirationMs(token: string): number {
-  try {
-    const expiration = jose.decodeJwt(token).exp;
-    return typeof expiration === 'number' ? expiration * 1000 : 0;
-  } catch {
-    return 0;
-  }
-}
-
 function isReusableCiAccessToken(
   value: unknown,
   scope: string
 ): value is StoredCiAccessToken {
-  return Boolean(
+  return (
     isStoredCiAccessToken(value) &&
-    (value as Partial<StoredCiAccessToken>).scope === scope &&
-    getTokenExpirationMs((value as StoredCiAccessToken).accessToken) >
-      Date.now() + TOKEN_EXPIRY.SHORT_VALIDITY_CHECK_SEC * 1000
+    value.scope === scope &&
+    isTokenStillValid(value.accessToken, TOKEN_EXPIRY.SHORT_VALIDITY_CHECK_SEC)
   );
 }
 

--- a/libs/zephyr-agent/src/lib/node-persist/token.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.ts
@@ -106,9 +106,6 @@ export async function cleanTokens(rejectedToken?: string): Promise<void> {
       })
     )
   );
-  for (const cacheKey of cacheKeys) {
-    activeCiTokenCacheKeys.delete(cacheKey);
-  }
 }
 
 async function getTokenFromServerToken(
@@ -199,6 +196,7 @@ async function getTokenFromCiToken(
 
 function getCiTokenScope(ciToken: string, identity: CiTokenIdentity): string {
   const identityScope = [
+    ZE_API_ENDPOINT(),
     identity.provider,
     identity.source,
     identity.issuer ?? '',

--- a/libs/zephyr-agent/src/lib/node-persist/token.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.ts
@@ -1,7 +1,10 @@
+import { createHash } from 'node:crypto';
+import * as jose from 'jose';
 import nodePersist from 'node-persist';
 import { getSecretToken } from './secret-token';
 import { setPrivateItem, storage } from './storage';
 import { StorageKeys } from './storage-keys';
+import { withStorageLock } from './storage-lock';
 import { makeRequest } from '../http/http-request';
 import { getCiToken } from './ci-token';
 import { getServerToken } from './server-token';
@@ -11,9 +14,22 @@ import { ze_log } from '../logging/debug';
 import { type ZeGitInfo } from '../build-context/ze-util-get-git-info';
 import { type CiTokenIdentity, inferCiTokenIdentity } from './ci-token-identity';
 import { ZeErrors, ZephyrError } from '../errors';
+import { TOKEN_EXPIRY } from '../auth/auth-flags';
+
+const CI_TOKEN_CACHE_VERSION = 1;
+const CI_TOKEN_SCOPE_CONTEXT = 'zephyr-ci-token-cache\0';
+const activeCiTokenCacheKeys = new Set<string>();
+
+interface StoredCiAccessToken {
+  version: typeof CI_TOKEN_CACHE_VERSION;
+  scope: string;
+  accessToken: string;
+}
 
 export async function saveToken(token: string): Promise<void> {
-  await setPrivateItem(StorageKeys.ze_auth_token, token);
+  await withStorageLock('auth-token', () =>
+    setPrivateItem(StorageKeys.ze_auth_token, token)
+  );
 }
 
 export async function getToken(git_config?: ZeGitInfo): Promise<string | undefined> {
@@ -47,8 +63,10 @@ export async function getToken(git_config?: ZeGitInfo): Promise<string | undefin
     return await getTokenFromServerToken(server_token, git_config.git.email);
   }
 
-  await storage;
-  const token = await nodePersist.getItem(StorageKeys.ze_auth_token);
+  const token = await withStorageLock('auth-token', async () => {
+    await storage;
+    return nodePersist.getItem(StorageKeys.ze_auth_token);
+  });
   if (token) {
     return token;
   }
@@ -61,14 +79,36 @@ export async function getToken(git_config?: ZeGitInfo): Promise<string | undefin
   return undefined;
 }
 
-export async function removeToken(): Promise<void> {
-  await storage;
-  await nodePersist.removeItem(StorageKeys.ze_auth_token);
+export async function removeToken(expectedToken?: string): Promise<void> {
+  await withStorageLock('auth-token', async () => {
+    await storage;
+    const storedToken: unknown = await nodePersist.getItem(StorageKeys.ze_auth_token);
+    if (expectedToken === undefined || storedToken === expectedToken) {
+      await nodePersist.removeItem(StorageKeys.ze_auth_token);
+    }
+  });
 }
 
-export async function cleanTokens(): Promise<void> {
-  await storage;
-  await nodePersist.clear();
+export async function cleanTokens(rejectedToken?: string): Promise<void> {
+  await removeToken(rejectedToken);
+  const cacheKeys = Array.from(activeCiTokenCacheKeys);
+  await Promise.all(
+    cacheKeys.map((cacheKey) =>
+      withStorageLock(getCiTokenLockName(cacheKey), async () => {
+        await storage;
+        const cached: unknown = await nodePersist.getItem(cacheKey);
+        if (
+          rejectedToken === undefined ||
+          (isStoredCiAccessToken(cached) && cached.accessToken === rejectedToken)
+        ) {
+          await nodePersist.removeItem(cacheKey);
+        }
+      })
+    )
+  );
+  for (const cacheKey of cacheKeys) {
+    activeCiTokenCacheKeys.delete(cacheKey);
+  }
 }
 
 async function getTokenFromServerToken(
@@ -105,29 +145,109 @@ async function getTokenFromCiToken(
   ci_token: string,
   identity: CiTokenIdentity
 ): Promise<string | undefined> {
-  const [ok, cause, data] = await makeRequest<{ access_token: string }>(
-    {
-      path: ze_api_gateway.ci_token_exchange,
-      base: ZE_API_ENDPOINT(),
-      query: {},
-    },
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${ci_token}`,
-        'Content-Type': 'application/json',
+  const scope = getCiTokenScope(ci_token, identity);
+  const cacheKey = `${StorageKeys.ze_ci_auth_token}:${scope}`;
+  activeCiTokenCacheKeys.add(cacheKey);
+
+  return withStorageLock(getCiTokenLockName(cacheKey), async () => {
+    await storage;
+    const cached: unknown = await nodePersist.getItem(cacheKey);
+    if (isReusableCiAccessToken(cached, scope)) {
+      return cached.accessToken;
+    }
+
+    const [ok, cause, data] = await makeRequest<{ access_token: string }>(
+      {
+        path: ze_api_gateway.ci_token_exchange,
+        base: ZE_API_ENDPOINT(),
+        query: {},
       },
-    },
-    JSON.stringify(identity)
-  );
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${ci_token}`,
+          'Content-Type': 'application/json',
+        },
+        skipTokenCleanup: true,
+      },
+      JSON.stringify(identity)
+    );
 
-  if (!ok) {
-    throwCiTokenAuthError(identity, cause);
+    if (!ok) {
+      await nodePersist.removeItem(cacheKey);
+      throwCiTokenAuthError(identity, cause);
+    }
+
+    const accessToken = data?.access_token;
+    const expiresIn = accessToken ? getTokenExpirationMs(accessToken) - Date.now() : 0;
+    if (!accessToken || expiresIn <= TOKEN_EXPIRY.SHORT_VALIDITY_CHECK_SEC * 1000) {
+      await nodePersist.removeItem(cacheKey);
+      throwCiTokenAuthError(
+        identity,
+        new Error('CI token exchange returned an invalid or expiring access token')
+      );
+    }
+
+    await setPrivateItem(
+      cacheKey,
+      { version: CI_TOKEN_CACHE_VERSION, scope, accessToken },
+      { ttl: expiresIn }
+    );
+    return accessToken;
+  });
+}
+
+function getCiTokenScope(ciToken: string, identity: CiTokenIdentity): string {
+  const identityScope = [
+    identity.provider,
+    identity.source,
+    identity.issuer ?? '',
+    identity.providerSubject ?? '',
+    identity.username ?? '',
+    identity.email ?? '',
+    [...(identity.emails ?? [])].sort(),
+  ];
+  return createHash('sha256')
+    .update(CI_TOKEN_SCOPE_CONTEXT)
+    .update(ciToken)
+    .update('\0')
+    .update(JSON.stringify(identityScope))
+    .digest('hex');
+}
+
+function getCiTokenLockName(cacheKey: string): string {
+  return `ci-auth-${cacheKey.substring(cacheKey.lastIndexOf(':') + 1)}`;
+}
+
+function getTokenExpirationMs(token: string): number {
+  try {
+    const expiration = jose.decodeJwt(token).exp;
+    return typeof expiration === 'number' ? expiration * 1000 : 0;
+  } catch {
+    return 0;
   }
+}
 
-  // Concurrent CI builds share ~/.zephyr; persisting this derived token races them all
-  // on one node-persist key, while ZE_CI_TOKEN takes precedence on every subsequent read.
-  return data?.access_token;
+function isReusableCiAccessToken(
+  value: unknown,
+  scope: string
+): value is StoredCiAccessToken {
+  return Boolean(
+    isStoredCiAccessToken(value) &&
+    (value as Partial<StoredCiAccessToken>).scope === scope &&
+    getTokenExpirationMs((value as StoredCiAccessToken).accessToken) >
+      Date.now() + TOKEN_EXPIRY.SHORT_VALIDITY_CHECK_SEC * 1000
+  );
+}
+
+function isStoredCiAccessToken(value: unknown): value is StoredCiAccessToken {
+  return Boolean(
+    value &&
+    typeof value === 'object' &&
+    (value as Partial<StoredCiAccessToken>).version === CI_TOKEN_CACHE_VERSION &&
+    typeof (value as Partial<StoredCiAccessToken>).scope === 'string' &&
+    typeof (value as Partial<StoredCiAccessToken>).accessToken === 'string'
+  );
 }
 
 function throwCiTokenAuthError(


### PR DESCRIPTION
### What's added in this PR?

- Updates Zephyr Preview Environments to v1.0.0, pinned to its immutable release commit.
- Migrates Ubuntu and Windows preview deployments from `ZE_SECRET_TOKEN` to the organization-scoped `ZE_CI_TOKEN` using the production API defaults.
- Adds the `ci:force-example-builds` PR label. Applying it immediately builds and deploys every buildable example; subsequent PR updates stay in forced mode until the label is removed.
- Keeps label-triggered checks and concurrency separate from required CI, so unrelated labels cannot cancel or replace merge-gating results.
- Makes deployment verification use the same forced/affected selector as the build and resolve Turbo filters from the repository root.
- Serializes force-all example deployments to reduce resource contention while retaining normal affected-build concurrency.
- Adds an identity-scoped, persistent, cross-process single-flight cache for CI-derived access tokens. Concurrent plugin processes share one exchange instead of issuing one authentication request per package.
- Protects browser/server and CI access-token persistence with private, crash-recoverable `proper-lockfile` locks.
- Validates cached JWT expiry, scopes records by the CI credential and inferred actor, and uses compare-and-delete cleanup so delayed 401 responses cannot remove newer tokens.
- Restricts authentication cleanup to token records instead of clearing shared application configuration and deployment results.

#### Screenshots

Not applicable.

### What's the issues or discussion related to this PR ?

The workflow-only action/token migration initially had no affected example packages, so Turbo executed no builds and the preview action correctly found no deployed applications to link. The force label provides an explicit full-preview path for workflow-only PRs and for any PR where every example needs deployment verification.

Force-all runs then exposed a separate concurrency failure. Across repeated runs, Turbo reported every build task as successful but warned that a different example had no output; deployment E2E subsequently could not find that application. Some affected processes stopped after CI-token authentication or application configuration, before compiler completion and deployment, while still exiting with status 0.

The builds run many plugin processes against the same `~/.zephyr` directory. Each process exchanged `ZE_CI_TOKEN` and attempted to persist a derived access token through `node-persist`, whose write queue is process-local and does not coordinate concurrent processes. In addition, the old 401 cleanup used `nodePersist.clear()`, which could remove deployment records produced by other builds.

The agent now coordinates each CI credential/actor scope under an inter-process lock. The first process re-reads the cache, exchanges on a miss, persists the short-lived token with its JWT lifetime, and releases the lock. Waiting processes then reuse that token. Raw `ZE_CI_TOKEN` values remain environment-only. `ZE_SECRET_TOKEN` remains a direct bearer credential and is never persisted.

### What are the steps to test this PR?

- Run `pnpm lint`.
- Run `pnpm format:check`.
- Run `pnpm typecheck`.
- Run `pnpm test:miniapp-wave1`.
- Run `pnpm test:coverage`.
- Run `pnpm --filter zephyr-agent test`.
- Run `pnpm --filter zephyr-agent build`.
- Run the deployment selector and E2E tests in `e2e/deployment`.
- Apply `ci:force-example-builds` and verify the Ubuntu/Windows jobs build all examples and the preview action publishes deployment links.

The agent test suite covers persisted CI-token reuse, concurrent single-flight exchange, identity scoping, JWT expiry refresh, invalid exchanged tokens, lock release, scoped cleanup, delayed-401 compare-and-delete behavior, and recursive-cleanup prevention.

### Documentation update for this PR (if applicable)?

- `README.md` documents the force label and affected-only default.
- `docs/ci-token-identity.md` documents credential lifecycles, cache scoping, persistence, locking, expiry, and cleanup invariants.
- `docs/git-usage.md` links CI identity behavior to the canonical cache/locking documentation.
- `libs/zephyr-agent/README.md` summarizes the agent authentication architecture.

### (Optional) What's left to be done for this PR?

- Confirm the fix with a force-all CI run under the production CI token.
- Remove the legacy personal-token secret after the forced CI-token deployment succeeds.

### (Optional) What's the potential risk and how to mitigate it?

- Forced runs are intentionally expensive. They remain opt-in through the PR label, use distinct check names/concurrency groups, and serialize the full deployment jobs.
- The first process holds the identity-scoped token lock during exchange, so matching processes wait behind a slow authentication request. Lock retries and stale-lock recovery bound this behavior, while separate identities use separate locks.
- Cached tokens are accepted only when the record scope/version match and the JWT remains valid beyond the safety window. Invalid or expiring exchange results are rejected rather than persisted.

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated/opened a PR to [documentation](https://github.com/ZephyrCloudIO/zephyr-documentation) to cover this new behavior (repository-internal CI/auth behavior documented here)
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
