### PR TITLE
chore: bump patch version to 1.2.1

### DIFF
--- a/libs/create-zephyr-apps/.claude-plugin/plugin.json
+++ b/libs/create-zephyr-apps/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "create-zephyr-apps",
   "displayName": "Create Zephyr Apps",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Agent Skill for the create-zephyr-apps package.",
   "author": {
     "name": "ZephyrCloudIO"

--- a/libs/create-zephyr-apps/.codex-plugin/plugin.json
+++ b/libs/create-zephyr-apps/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "create-zephyr-apps",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Agent Skill for the create-zephyr-apps package.",
   "author": {
     "name": "ZephyrCloudIO"

--- a/libs/create-zephyr-apps/.cursor-plugin/plugin.json
+++ b/libs/create-zephyr-apps/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "create-zephyr-apps",
   "displayName": "Create Zephyr Apps",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Agent Skill for the create-zephyr-apps package.",
   "author": {
     "name": "ZephyrCloudIO"

--- a/libs/create-zephyr-apps/package.json
+++ b/libs/create-zephyr-apps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-zephyr-apps",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A CLI tool to create web applications using Zephyr.",
   "keywords": [
     "agent-skill",

--- a/libs/parcel-reporter-zephyr/package.json
+++ b/libs/parcel-reporter-zephyr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-reporter-zephyr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Parcel reporter for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/rollup-plugin-zephyr/package.json
+++ b/libs/rollup-plugin-zephyr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-zephyr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Rollup plugin for Zephyr",
   "keywords": [
     "deploy",

--- a/libs/vite-plugin-tanstack-start-zephyr/package.json
+++ b/libs/vite-plugin-tanstack-start-zephyr/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/vitejs/vite-plugin-registry/refs/heads/main/data/schema/extended-package-json.schema.json",
   "name": "vite-plugin-tanstack-start-zephyr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Vite plugin for Zephyr with TanStack Start support",
   "keywords": [
     "deploy",

--- a/libs/vite-plugin-vinext-zephyr/package.json
+++ b/libs/vite-plugin-vinext-zephyr/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/vitejs/vite-plugin-registry/refs/heads/main/data/schema/extended-package-json.schema.json",
   "name": "vite-plugin-vinext-zephyr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Vite plugin for deploying Vinext applications with Zephyr",
   "keywords": [
     "deploy",

--- a/libs/vite-plugin-zephyr/package.json
+++ b/libs/vite-plugin-zephyr/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/vitejs/vite-plugin-registry/refs/heads/main/data/schema/extended-package-json.schema.json",
   "name": "vite-plugin-zephyr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Vite plugin for Zephyr",
   "keywords": [
     "deploy",

--- a/libs/with-zephyr/package.json
+++ b/libs/with-zephyr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-zephyr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A codemod to automatically add withZephyr plugin to bundler configurations",
   "keywords": [
     "astro",

--- a/libs/zephyr-agent/package.json
+++ b/libs/zephyr-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-agent",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Zephyr plugin agent",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-astro-integration/package.json
+++ b/libs/zephyr-astro-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-astro-integration",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Astro integration for Zephyr Cloud deployment and module federation",
   "keywords": [
     "analytics",

--- a/libs/zephyr-cli/package.json
+++ b/libs/zephyr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "CLI tool for running build commands and uploading assets to Zephyr",
   "keywords": [
     "build",

--- a/libs/zephyr-edge-contract/package.json
+++ b/libs/zephyr-edge-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-edge-contract",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Edge contract for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-metro-plugin/package.json
+++ b/libs/zephyr-metro-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-metro-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Metro bundler plugin for deploying React Native applications with Zephyr Cloud - OTA updates, Module Federation, and seamless deployment",
   "keywords": [
     "android",

--- a/libs/zephyr-modernjs-plugin/package.json
+++ b/libs/zephyr-modernjs-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-modernjs-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Modernjs plugin for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-native-cache/package.json
+++ b/libs/zephyr-native-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-native-cache",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Native caching module for Module Federation Metro bundles",
   "license": "Apache-2.0",
   "repository": {

--- a/libs/zephyr-nuxt-module/package.json
+++ b/libs/zephyr-nuxt-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-nuxt-module",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Nuxt module for deploying Nuxt applications with Zephyr Cloud",
   "keywords": [
     "deployment",

--- a/libs/zephyr-repack-plugin/package.json
+++ b/libs/zephyr-repack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-repack-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Repack plugin for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-rolldown-plugin/package.json
+++ b/libs/zephyr-rolldown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-rolldown-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Rolldown plugin for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-rsbuild-plugin/package.json
+++ b/libs/zephyr-rsbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-rsbuild-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Rsbuild plugin for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-rspack-plugin/package.json
+++ b/libs/zephyr-rspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-rspack-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Repack plugin for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-rspress-plugin/package.json
+++ b/libs/zephyr-rspress-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-rspress-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Rspress plugin for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-tap-runtime/package.json
+++ b/libs/zephyr-tap-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-tap-runtime",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Host-owned TAP lifecycle runtime plugin for Module Federation",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-webpack-plugin/package.json
+++ b/libs/zephyr-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-webpack-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Webpack plugin for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/libs/zephyr-xpack-internal/package.json
+++ b/libs/zephyr-xpack-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-xpack-internal",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Xpack internals for Zephyr",
   "license": "Apache-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-packages",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -95,9 +95,14 @@ function updatePluginManifestVersions(packageDir, newVersion) {
     const manifestPath = path.join(packageDir, relativePath);
     if (!fs.existsSync(manifestPath)) return;
 
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    manifest.version = newVersion;
-    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+    const contents = fs.readFileSync(manifestPath, 'utf8');
+    const versionPattern = /^(\s*"version"\s*:\s*)"[^"]*"/m;
+
+    if (!versionPattern.test(contents)) {
+      throw new Error(`Missing version in plugin manifest: ${manifestPath}`);
+    }
+
+    fs.writeFileSync(manifestPath, contents.replace(versionPattern, `$1"${newVersion}"`));
   });
 }
 

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -96,9 +96,10 @@ function updatePluginManifestVersions(packageDir, newVersion) {
     if (!fs.existsSync(manifestPath)) return;
 
     const contents = fs.readFileSync(manifestPath, 'utf8');
-    const versionPattern = /^(\s*"version"\s*:\s*)"[^"]*"/m;
+    const manifest = JSON.parse(contents);
+    const versionPattern = /^(  "version"\s*:\s*)"[^"]*"/m;
 
-    if (!versionPattern.test(contents)) {
+    if (typeof manifest.version !== 'string' || !versionPattern.test(contents)) {
       throw new Error(`Missing version in plugin manifest: ${manifestPath}`);
     }
 


### PR DESCRIPTION
## Summary
- Bump package versions from 1.2.0 to 1.2.1
- Preserve plugin manifest formatting during future version bumps

## Test plan
- pnpm format:check
- pnpm test:affected
- pnpm lint