### PR TITLE
fix(agent): clarify DNS lookup failures

### DIFF
--- a/libs/zephyr-agent/src/lib/http/fetch-with-retries.test.ts
+++ b/libs/zephyr-agent/src/lib/http/fetch-with-retries.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
-import { ZephyrError } from '../errors';
+import { ZeErrors, ZephyrError } from '../errors';
 import { DEFAULT_HTTP_DEADLINE_MS, fetchWithRetries } from './fetch-with-retries';
 
 const mocks = rs.hoisted(() => ({
@@ -96,6 +96,34 @@ describe('fetchWithRetries', () => {
     );
 
     expect(response.status).toBe(503);
+    expect(mocks.axiosInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it('explains DNS lookup failures without claiming a POST was retried', async () => {
+    const signature = 'raw-dns-signature';
+    const missingUrl = new URL(
+      `https://missing.example.com/api?X-Amz-Signature=${signature}`
+    );
+    mocks.axiosInstance.mockRejectedValue({
+      code: 'ENOTFOUND',
+      message: `getaddrinfo ENOTFOUND missing.example.com?token=${signature}`,
+    });
+
+    let error: unknown;
+    try {
+      await fetchWithRetries(missingUrl, { method: 'POST' }, 3);
+    } catch (caught) {
+      error = caught;
+    }
+
+    const serialized = JSON.stringify(error);
+    expect(ZephyrError.is(error, ZeErrors.ERR_HTTP_ERROR)).toBe(true);
+    expect(serialized).toContain('DNS lookup failed');
+    expect(serialized).toContain('missing.example.com');
+    expect(serialized).toContain('ENOTFOUND');
+    expect(serialized).toContain("Verify the hostname's DNS record");
+    expect(serialized).not.toContain('after retries');
+    expect(serialized).not.toContain(signature);
     expect(mocks.axiosInstance).toHaveBeenCalledTimes(1);
   });
 

--- a/libs/zephyr-agent/src/lib/http/fetch-with-retries.test.ts
+++ b/libs/zephyr-agent/src/lib/http/fetch-with-retries.test.ts
@@ -127,6 +127,35 @@ describe('fetchWithRetries', () => {
     expect(mocks.axiosInstance).toHaveBeenCalledTimes(1);
   });
 
+  it('reports the proxy hostname when proxy DNS lookup fails', async () => {
+    const proxyHostname = 'missing-proxy.internal';
+    const proxyUrl = `http://${proxyHostname}:8080`;
+    process.env['HTTPS_PROXY'] = proxyUrl;
+    mocks.axiosInstance.mockRejectedValue({
+      code: 'ENOTFOUND',
+      message: `getaddrinfo ENOTFOUND ${proxyHostname}`,
+      cause: {
+        code: 'ENOTFOUND',
+        hostname: proxyHostname,
+        syscall: 'getaddrinfo',
+      },
+    });
+
+    let error: unknown;
+    try {
+      await fetchWithRetries(url, { method: 'POST' });
+    } catch (caught) {
+      error = caught;
+    }
+
+    const serialized = JSON.stringify(error);
+    expect(ZephyrError.is(error, ZeErrors.ERR_HTTP_ERROR)).toBe(true);
+    expect(serialized).toContain('DNS lookup failed');
+    expect(serialized).toContain(proxyHostname);
+    expect(mocks.proxyAgent).toHaveBeenCalledWith(proxyUrl);
+    expect(mocks.axiosInstance).toHaveBeenCalledTimes(1);
+  });
+
   it('retries POST requests only when the caller supplies an idempotency key', async () => {
     mocks.axiosInstance
       .mockResolvedValueOnce({

--- a/libs/zephyr-agent/src/lib/http/fetch-with-retries.ts
+++ b/libs/zephyr-agent/src/lib/http/fetch-with-retries.ts
@@ -91,6 +91,10 @@ function getHttpsProxyAgent(url: URL): HttpsProxyAgent<string> | undefined {
 interface HttpLikeError {
   code?: string;
   message?: string;
+  hostname?: unknown;
+  cause?: {
+    hostname?: unknown;
+  };
   response?: {
     status: number;
     data?: unknown;
@@ -221,10 +225,17 @@ function normalizeRequestError(error: unknown, url: URL, method: string): Error 
   }
 
   if (candidate.code === 'ENOTFOUND') {
+    let failedHostname = url.hostname;
+    if (typeof candidate.hostname === 'string') {
+      failedHostname = candidate.hostname;
+    } else if (typeof candidate.cause?.hostname === 'string') {
+      failedHostname = candidate.cause.hostname;
+    }
+
     return new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
       status: -1,
       url: redactUrl(url),
-      content: `DNS lookup failed for hostname "${redactString(url.hostname)}" (ENOTFOUND). Verify the hostname's DNS record.`,
+      content: `DNS lookup failed for hostname "${redactString(failedHostname)}" (ENOTFOUND). Verify the hostname's DNS record.`,
       method,
     });
   }

--- a/libs/zephyr-agent/src/lib/http/fetch-with-retries.ts
+++ b/libs/zephyr-agent/src/lib/http/fetch-with-retries.ts
@@ -220,6 +220,15 @@ function normalizeRequestError(error: unknown, url: URL, method: string): Error 
     });
   }
 
+  if (candidate.code === 'ENOTFOUND') {
+    return new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
+      status: -1,
+      url: redactUrl(url),
+      content: `DNS lookup failed for hostname "${redactString(url.hostname)}" (ENOTFOUND). Verify the hostname's DNS record.`,
+      method,
+    });
+  }
+
   if (isRetryableNetworkError(error) || candidate.code === 'ERR_CANCELED') {
     return new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
       status: -1,


### PR DESCRIPTION
## 🎫 Ticket

- https://app.clickup.com/t/9013031642/ZE-1607

## 🧠 Why

An unresolved edge-provider hostname was reported as a generic network failure, directing users to troubleshoot their local connection even when authoritative DNS was misconfigured.

## 📝 What changed

- Normalize ENOTFOUND separately from generic transient network failures.
- Report the sanitized hostname, DNS lookup failure, and DNS-record guidance without claiming a non-idempotent POST was retried.
- Preserve existing error code and URL redaction behavior.
- Add focused regression coverage for upload-style POST requests and secret redaction.

The malformed `ze.akamai-zephyr.dev` CNAME remains an operational DNS follow-up because authoritative DNS is not managed in this repository.

## 🧪 How to test

| Step | Expected result |
|------|-----------------|
| Run `pnpm --filter zephyr-agent exec rstest run src/lib/http/fetch-with-retries.test.ts` | All focused HTTP retry tests pass |
| Run `pnpm --filter zephyr-agent typecheck` | Type-check passes |
| Run `pnpm --filter zephyr-agent build` | Package build passes |
| Trigger an ENOTFOUND upload failure | Error identifies DNS resolution and the unresolved hostname |

## 📸 Screenshots

Not applicable; this is CLI/agent error output.