### PR TITLE
fix(rspress): publish browser federation metadata

### DIFF
--- a/libs/zephyr-rspress-plugin/README.md
+++ b/libs/zephyr-rspress-plugin/README.md
@@ -96,6 +96,13 @@ Add these scripts to your \`package.json\`:
 
 After running \`build\`, your site will automatically be uploaded to Zephyr Cloud if the plugin is enabled and configured.
 
+### SSG with Module Federation
+
+No target-specific Zephyr configuration is required. Rspress builds browser and Node
+compilers during SSG; Zephyr publishes Module Federation metadata from the deployable
+browser compiler only, while uploading every emitted file from the shared output directory,
+including Node/SSG artifacts.
+
 ---
 
 ## Requirements

--- a/libs/zephyr-rspress-plugin/src/__test__/zephyrRspressSSGPlugin.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/__test__/zephyrRspressSSGPlugin.spec.ts
@@ -114,7 +114,11 @@ describe('zephyrRspressSSGPlugin', () => {
   });
 
   it('forwards every federation configuration to the SSG deployment', async () => {
-    const mockFiles = ['manifest.tap.json', 'targets/desktop/remoteEntry.mjs'];
+    const mockFiles = [
+      'manifest.tap.json',
+      'targets/desktop/remoteEntry.mjs',
+      'static/ssg-node.js',
+    ];
     const mfConfig = [
       {
         name: 'RspackModuleFederationPlugin',

--- a/libs/zephyr-rspress-plugin/src/internal/__test__/moduleFederationPublicPathPlugin.spec.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/__test__/moduleFederationPublicPathPlugin.spec.ts
@@ -30,15 +30,24 @@ describe('moduleFederationPublicPathPlugin', () => {
   });
 
   it('does not bypass Rspress node compiler absolute-public-path requirements', () => {
-    const config = {
-      name: 'node',
-      output: { publicPath: 'http://localhost:4178/' },
-      plugins: [remotePlugin()],
-    };
+    const configs = [
+      {
+        name: 'node',
+        output: { publicPath: 'http://localhost:4178/' },
+        plugins: [remotePlugin()],
+      },
+      {
+        name: 'ssg',
+        target: ['node20', 'es2022'],
+        output: { publicPath: 'http://localhost:4178/' },
+        plugins: [remotePlugin()],
+      },
+    ];
 
-    setPortableModuleFederationPublicPath(config);
-
-    expect(config.output.publicPath).toBe('http://localhost:4178/');
+    for (const config of configs) {
+      setPortableModuleFederationPublicPath(config);
+      expect(config.output.publicPath).toBe('http://localhost:4178/');
+    }
   });
 
   it('preserves consumer, non-MF, and already portable browser configs', () => {
@@ -112,7 +121,34 @@ describe('moduleFederationPublicPathPlugin', () => {
     expect(bundlerConfigs[1]?.output.publicPath).toBe('http://localhost:4178/');
   });
 
-  it('retains every compiler federation plugin for SSG publication metadata', () => {
+  it('publishes browser federation metadata without duplicating the SSG node target', () => {
+    const onModuleFederationPlugins = rs.fn();
+    const plugin = moduleFederationPublicPathPlugin({ onModuleFederationPlugins });
+    const onBeforeCreateCompiler = rs.fn();
+    plugin.setup({ onBeforeCreateCompiler });
+    const [{ handler }] = onBeforeCreateCompiler.mock.calls[0] as [
+      { handler: (args: { bundlerConfigs: unknown[] }) => void },
+    ];
+    const desktop = remotePlugin({
+      name: 'desktop',
+      filename: 'targets/desktop/remoteEntry.mjs',
+    });
+    const ssg = remotePlugin({
+      name: 'desktop',
+      filename: 'targets/ssg/remoteEntry.mjs',
+    });
+
+    handler({
+      bundlerConfigs: [
+        { name: 'web', target: 'web', plugins: [desktop] },
+        { name: 'ssg', target: ['node20', 'es2022'], plugins: [ssg] },
+      ],
+    });
+
+    expect(onModuleFederationPlugins).toHaveBeenCalledWith([desktop]);
+  });
+
+  it('retains distinct browser compiler federation metadata', () => {
     const onModuleFederationPlugins = rs.fn();
     const plugin = moduleFederationPublicPathPlugin({ onModuleFederationPlugins });
     const onBeforeCreateCompiler = rs.fn();
@@ -131,8 +167,8 @@ describe('moduleFederationPublicPathPlugin', () => {
 
     handler({
       bundlerConfigs: [
-        { name: 'web', plugins: [desktop] },
-        { name: 'worker', plugins: [worker] },
+        { name: 'web', target: 'web', plugins: [desktop] },
+        { name: 'worker', target: 'webworker', plugins: [worker] },
       ],
     });
 

--- a/libs/zephyr-rspress-plugin/src/internal/assets/moduleFederationPublicPathPlugin.ts
+++ b/libs/zephyr-rspress-plugin/src/internal/assets/moduleFederationPublicPathPlugin.ts
@@ -10,6 +10,7 @@ type RsbuildOnBeforeCreateCompilerArgs = {
 
 type RspackConfig = {
   name?: string;
+  target?: unknown;
   output?: { publicPath?: unknown };
   plugins?: unknown[];
 };
@@ -41,9 +42,9 @@ export interface ModuleFederationPublicPathPluginOptions {
   /** TAP artifacts are SDK-locked and must retain their emitted public path verbatim. */
   target?: ZephyrBuildTarget;
   /**
-   * Receives every Module Federation plugin materialized across Rspress's compilers. The
-   * SSG upload runs later and uses this reference to publish snapshot and build-stat
-   * federation metadata without selecting an arbitrary first compiler.
+   * Receives Module Federation plugins from Rspress's deployable browser compilers. The
+   * build-time node compiler emits SSG artifacts under the same container identity, so it
+   * must not publish a second, conflicting metadata record for that identity.
    */
   onModuleFederationPlugins?: (plugins: ModuleFederationPlugin[]) => void;
 }
@@ -59,11 +60,14 @@ export function moduleFederationPublicPathPlugin(
         handler({ bundlerConfigs }) {
           const configs = bundlerConfigs ?? [];
           options.onModuleFederationPlugins?.(
-            configs.flatMap((config) =>
-              (config.plugins ?? []).filter((plugin): plugin is ModuleFederationPlugin =>
-                isModuleFederationPlugin(plugin as never)
+            configs
+              .filter((config) => !isNodeCompiler(config))
+              .flatMap((config) =>
+                (config.plugins ?? []).filter(
+                  (plugin): plugin is ModuleFederationPlugin =>
+                    isModuleFederationPlugin(plugin as never)
+                )
               )
-            )
           );
 
           if (options.target !== 'tap-app') {
@@ -85,13 +89,24 @@ export function moduleFederationPublicPathPlugin(
  * `auto` for that compiler.
  */
 export function setPortableModuleFederationPublicPath(config: RspackConfig): void {
-  if (config.name === 'node' || !hasExposedModuleFederationRemote(config.plugins)) {
+  if (isNodeCompiler(config) || !hasExposedModuleFederationRemote(config.plugins)) {
     return;
   }
 
   if (isHttpPublicPath(config.output?.publicPath)) {
     config.output = { ...config.output, publicPath: 'auto' };
   }
+}
+
+function isNodeCompiler(config: RspackConfig): boolean {
+  return config.name === 'node' || hasNodeTarget(config.target);
+}
+
+function hasNodeTarget(target: unknown): boolean {
+  const targets = Array.isArray(target) ? target : [target];
+  return targets.some(
+    (value) => typeof value === 'string' && value.toLowerCase().includes('node')
+  );
 }
 
 function hasExposedModuleFederationRemote(plugins: unknown[] = []): boolean {

--- a/libs/zephyr-rspress-plugin/src/types/index.ts
+++ b/libs/zephyr-rspress-plugin/src/types/index.ts
@@ -10,7 +10,7 @@ export interface ZephyrRspressPluginOptions {
   outDir: string;
   files: string[];
   hooks?: ZephyrBuildHooks;
-  /** Every compiler's Module Federation plugin, retained for publication metadata. */
+  /** Deployable browser compilers' Module Federation plugins for publication metadata. */
   mfConfig?: ModuleFederationPlugin[] | ModuleFederationPlugin;
 }
 

--- a/libs/zephyr-rspress-plugin/src/with-zephyr.ts
+++ b/libs/zephyr-rspress-plugin/src/with-zephyr.ts
@@ -70,9 +70,10 @@ export function withZephyr<TConfig extends RspressUserConfig = RspressUserConfig
     assertZephyrBuildTarget(options.target, 'withZephyr({ target })');
   }
 
-  // Rspress materializes one configuration per compiler. Keep all of their federation
-  // plugins in this mutable collection so the SSG hook can forward the complete set to
-  // xpack after the build, when snapshot and dashboard metadata are produced.
+  // Rspress materializes one configuration per compiler. Keep deployable browser
+  // federation plugins in this mutable collection so the SSG hook can forward them to
+  // xpack after the build, when snapshot and dashboard metadata are produced. The
+  // build-time node compiler still contributes files through the shared output directory.
   const mfConfigs: ModuleFederationPlugin[] = [];
   const portableFederationPlugin = moduleFederationPublicPathPlugin({
     target: options?.target,


### PR DESCRIPTION
### What's added in this PR?

Rspress SSG now publishes Module Federation metadata only from deployable browser compilers. Build-time Node compiler artifacts remain part of the shared output upload, and distinct browser compiler metadata remains supported.

- Detect Node compilers from Rspack `target`, with the existing `name: 'node'` fallback.
- Keep Node/SSG absolute public paths unchanged.
- Exclude Node/SSG federation plugins before xpack metadata merging, preventing duplicate container identities.
- Document the supported Rspress SSG setup.

#### Screenshots

N/A.

### What's the issues or discussion related to this PR ?

Reported by `module-federation/core#4981`.

Rspress materializes browser and Node/SSG Module Federation plugins from one application config. Both use the same container name, such as `mf_doc`, but their target-specific options differ. Forwarding both as deployable containers causes xpack's conflict guard to raise `ZE20024`.

The Node compiler is a build-time SSG input, not a second deployed Module Federation container. Its emitted files still belong in the snapshot; only its duplicate publication metadata must be omitted.

### What are the steps to test this PR?

- `pnpm lint`
- `pnpm format:check`
- `GIT_CONFIG_GLOBAL=/dev/null pnpm exec turbo run build test typecheck --filter='./libs/*' --output-logs=errors-only --env-mode=loose` (69/69 tasks passed)
- `pnpm exec turbo run build test typecheck --filter=zephyr-rspress-plugin --output-logs=full` (50 package tests passed)
- Structured autoreview: clean, no actionable findings

### Documentation update for this PR (if applicable)?

Updated `libs/zephyr-rspress-plugin/README.md` with the supported SSG + Module Federation behavior. External documentation PR is not required because this removes a broken internal publication detail and adds no user configuration.

### (Optional) What's left to be done for this PR?

After the fix is released, `module-federation/core#4981` can remove its temporary pnpm patch and consume the released plugin version.

### (Optional) What's the potential risk and how to mitigate it?

Risk: filtering too broadly could remove valid multi-container metadata. Mitigation: filtering is limited to Node targets; tests retain distinct `web` and `webworker` compiler metadata and preserve the legacy compiler-name fallback.

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated/opened a PR to documentation to cover this new behavior (package README; external docs N/A)
- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally (standing from a first time user point of view, never touch this app before)
- [x] I have/will run tests, or ask for help to add test
