### PR TITLE
feat(vite-plugin-zephyr): support disableRuntimePlugin option

### DIFF
--- a/libs/vite-plugin-zephyr/src/lib/internal/mf-vite-etl/__test__/ensure_runtime_plugin.test.ts
+++ b/libs/vite-plugin-zephyr/src/lib/internal/mf-vite-etl/__test__/ensure_runtime_plugin.test.ts
@@ -24,4 +24,13 @@ describe('ensureRuntimePlugin', () => {
 
     expect(matches).toHaveLength(1);
   });
+
+  test('skips injecting the zephyr runtime plugin when disableRuntimePlugin is true', () => {
+    const mfConfig = ensureRuntimePlugin({
+      name: 'host',
+      disableRuntimePlugin: true,
+    });
+
+    expect(mfConfig.runtimePlugins).toBeUndefined();
+  });
 });

--- a/libs/vite-plugin-zephyr/src/lib/internal/mf-vite-etl/ensure_runtime_plugin.ts
+++ b/libs/vite-plugin-zephyr/src/lib/internal/mf-vite-etl/ensure_runtime_plugin.ts
@@ -27,6 +27,7 @@ export interface ModuleFederationOptions {
   shared?: Record<string, unknown>;
   manifest?: boolean | ModuleFederationManifestOptions;
   dts?: boolean | Record<string, unknown>;
+  disableRuntimePlugin?: boolean;
   [key: string]: unknown;
 }
 
@@ -40,6 +41,10 @@ export function getRuntimePluginPath() {
 export function ensureRuntimePlugin(
   mfConfig: ModuleFederationOptions
 ): ModuleFederationOptions {
+  if (mfConfig.disableRuntimePlugin) {
+    return mfConfig;
+  }
+
   const runtimePlugins = [...(mfConfig.runtimePlugins ?? [])];
 
   if (!runtimePlugins.includes(ZEPHYR_MF_RUNTIME_PLUGIN_ID)) {

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
@@ -66,6 +66,11 @@ export interface WithZephyrOptions {
   entrypoint?: string;
   /** Correlates intentionally separate withZephyrPartial producer processes. */
   partialBuild?: VitePartialBuildOptions;
+  /**
+   * Disables the automatic injection of the Zephyr Module Federation runtime plugin.
+   * Useful when remotes or manifests are resolved server-side or via custom plugins.
+   */
+  disableRuntimePlugin?: boolean;
 }
 
 function mergeClaimedPartialMaps(
@@ -345,8 +350,10 @@ function withZephyrCore(options: WithZephyrOptions = {}): Plugin {
 
   let cachedSpecifier: string | undefined;
   let entrypoint: string;
+  const skipRuntimePlugin =
+    preservesLockedArtifactPaths || Boolean(options.disableRuntimePlugin);
   const configureModuleFederationRuntime = (config: ModuleFederationOptions) =>
-    preservesLockedArtifactPaths ? config : ensureRuntimePlugin(config);
+    skipRuntimePlugin ? config : ensureRuntimePlugin(config);
   const mfConfigSources = toModuleFederationConfigArray(options.mfConfig).map(
     configureModuleFederationRuntime
   );
@@ -1097,11 +1104,11 @@ export function withZephyr(options: WithZephyrOptions = {}): Plugin[] {
   if (mfConfigs.length > 0) {
     const federation = loadModuleFederationPlugin();
     const preservesLockedArtifactPaths = options.target === 'tap-app';
+    const skipRuntimePlugin =
+      preservesLockedArtifactPaths || Boolean(options.disableRuntimePlugin);
     for (const mfConfig of mfConfigs) {
       plugins.push(
-        ...federation(
-          preservesLockedArtifactPaths ? mfConfig : ensureRuntimePlugin(mfConfig)
-        )
+        ...federation(skipRuntimePlugin ? mfConfig : ensureRuntimePlugin(mfConfig))
       );
     }
   }


### PR DESCRIPTION
### What's added in this PR?

- Adds `disableRuntimePlugin?: boolean` to `WithZephyrOptions` in `vite-plugin-zephyr`.
- Adds `disableRuntimePlugin?: boolean` to `ModuleFederationOptions` and updates `ensureRuntimePlugin` to bypass runtime plugin injection when enabled.
- Adds unit tests verifying that runtime plugin injection is skipped when `disableRuntimePlugin: true`.

### What's the issues or discussion related to this PR ?

When consumers resolve micro-frontend remotes server-side (e.g. via BFF/SSR or custom runtime loaders), the default `zephyr-mf-runtime-plugin` causes redundant runtime fetch requests to `/zephyr-manifest.json` against the host origin, leading to unnecessary 404s in multi-tenant/portal architectures.

This option allows consumers to opt out of the automatic client-side manifest runtime plugin while retaining all other Zephyr build-time bundling, asset mapping, and deployment capabilities.

### What are the steps to test this PR?

1. Run `pnpm turbo run test --filter=vite-plugin-zephyr...`
2. Verify `ensure_runtime_plugin.test.ts` passes with the new test case.

### (Required) Pre-PR/Merge checklist

- [x] I have added an explanation of my changes
- [x] I have written new tests (if applicable)
- [x] I have tested this locally
- [x] All formatting (oxfmt) and linting (oxlint) pass cleanly