### PR TITLE
fix(deps): patch ts-deepmerge vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,6 +567,7 @@ overrides:
   socket.io-parser@>=4.0.0 <4.2.7: 4.2.7
   svgo@>=3.0.0 <3.3.4: 3.3.4
   svgo@>=4.0.0 <4.0.2: 4.0.2
+  ts-deepmerge: 8.0.0
   undici@>=7.0.0 <7.29.0: 7.29.0
 
 importers:
@@ -15925,8 +15926,8 @@ packages:
       '@typescript/native-preview':
         optional: true
 
-  ts-deepmerge@7.0.3:
-    resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
+  ts-deepmerge@8.0.0:
+    resolution: {integrity: sha512-133O+10nJmVI8w5xeVZPEv5PIrv7iaUae07wv1aH8XJH95Ur6YIhWAPhPyP1YPlbPS9fCVcNIZTu7m8urRVF0A==}
     engines: {node: '>=14.13.1'}
 
   ts-interface-checker@0.1.13:
@@ -19883,7 +19884,7 @@ snapshots:
       postcss-page-break: 3.0.4(postcss@8.5.23)
       rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0))(react-server-dom-rspack@0.0.2(@rspack/core@2.1.3(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       rspack-manifest-plugin: 5.2.2(@rspack/core@2.1.3(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))
-      ts-deepmerge: 7.0.3
+      ts-deepmerge: 8.0.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@parcel/css'
@@ -20025,7 +20026,7 @@ snapshots:
       cloneable-readable: 3.0.0
       flatted: 3.4.2
       hono: 4.12.27
-      ts-deepmerge: 7.0.3
+      ts-deepmerge: 8.0.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
@@ -33744,7 +33745,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  ts-deepmerge@7.0.3: {}
+  ts-deepmerge@8.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -295,6 +295,7 @@ overrides:
   socket.io-parser@>=4.0.0 <4.2.7: 4.2.7
   svgo@>=3.0.0 <3.3.4: 3.3.4
   svgo@>=4.0.0 <4.0.2: 4.0.2
+  ts-deepmerge: 8.0.0
   undici@>=7.0.0 <7.29.0: 7.29.0
 
 allowBuilds:


### PR DESCRIPTION
## 🎫 Ticket
https://app.clickup.com/t/86ak3jdrb

## 🧠 Why
Patch CVE-2026-12644 by resolving transitive `ts-deepmerge` to the first fixed release, 8.0.0.

## 📝 What changed
- Add the workspace override.
- Refresh the lockfile.

## 🧪 How to test
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm typecheck`
- `pnpm test`

## 📸 Screenshots
N/A — dependency-only change.