### PR TITLE
chore(deps): remediate zephyr packages ts-deepmerge

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,6 +567,7 @@ overrides:
   socket.io-parser@>=4.0.0 <4.2.7: 4.2.7
   svgo@>=3.0.0 <3.3.4: 3.3.4
   svgo@>=4.0.0 <4.0.2: 4.0.2
+  ts-deepmerge@<8.0.0: 8.0.0
   undici@>=7.0.0 <7.29.0: 7.29.0
 
 importers:
@@ -10696,6 +10697,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -15925,8 +15927,8 @@ packages:
       '@typescript/native-preview':
         optional: true
 
-  ts-deepmerge@7.0.3:
-    resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
+  ts-deepmerge@8.0.0:
+    resolution: {integrity: sha512-133O+10nJmVI8w5xeVZPEv5PIrv7iaUae07wv1aH8XJH95Ur6YIhWAPhPyP1YPlbPS9fCVcNIZTu7m8urRVF0A==}
     engines: {node: '>=14.13.1'}
 
   ts-interface-checker@0.1.13:
@@ -19883,7 +19885,7 @@ snapshots:
       postcss-page-break: 3.0.4(postcss@8.5.23)
       rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.8.0)(core-js@3.49.0))(react-server-dom-rspack@0.0.2(@rspack/core@2.1.3(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       rspack-manifest-plugin: 5.2.2(@rspack/core@2.1.3(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23))
-      ts-deepmerge: 7.0.3
+      ts-deepmerge: 8.0.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@parcel/css'
@@ -20025,7 +20027,7 @@ snapshots:
       cloneable-readable: 3.0.0
       flatted: 3.4.2
       hono: 4.12.27
-      ts-deepmerge: 7.0.3
+      ts-deepmerge: 8.0.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
@@ -33744,7 +33746,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  ts-deepmerge@7.0.3: {}
+  ts-deepmerge@8.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -295,6 +295,7 @@ overrides:
   socket.io-parser@>=4.0.0 <4.2.7: 4.2.7
   svgo@>=3.0.0 <3.3.4: 3.3.4
   svgo@>=4.0.0 <4.0.2: 4.0.2
+  ts-deepmerge@<8.0.0: 8.0.0
   undici@>=7.0.0 <7.29.0: 7.29.0
 
 allowBuilds:


### PR DESCRIPTION
## Why

Vanta flagged `ts-deepmerge < 8.0.0` in `zephyr-packages` through the Modern.js tooling path.

## What changed

- Added a focused pnpm override for `ts-deepmerge@<8.0.0` to resolve to `8.0.0`.
- Regenerated the lockfile.
- Left package source and public APIs unchanged.

## Validation

- `rtk pnpm install --lockfile-only` passed.
- `rtk pnpm why ts-deepmerge --recursive --depth 4` showed only `ts-deepmerge@8.0.0`.
- Lockfile grep found no `ts-deepmerge@7.0.3`.
- `rtk pnpm --filter zephyr-modernjs-plugin... build` passed.
- `rtk pnpm --filter zephyr-modernjs-plugin build` passed.
- `rtk pnpm --filter modern-js build` passed with a non-fatal Zephyr auth timeout log.
- `rtk pnpm --filter zephyr-modernjs-plugin test` passed.

## Risk and rollout

Low risk. The dependency is transitive through Modern.js tooling and does not change published Zephyr package APIs. Rollback is reverting the override and lockfile change.
