### PR TITLE
ci: streamline generated release PR checks

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -23,11 +23,63 @@ env:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: changes
+    runs-on: depot-ubuntu-latest
+    outputs:
+      release_pr: ${{ steps.scope.outputs.release_pr }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Classify changed files
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            all:
+              - '**'
+            release:
+              - '.release-please-manifest.json'
+              - 'CHANGELOG.md'
+              - 'package.json'
+              - 'libs/*/package.json'
+              - 'libs/create-zephyr-apps/.claude-plugin/plugin.json'
+              - 'libs/create-zephyr-apps/.codex-plugin/plugin.json'
+              - 'libs/create-zephyr-apps/.cursor-plugin/plugin.json'
+      - name: Resolve generated release scope
+        id: scope
+        env:
+          ACTOR: ${{ github.actor }}
+          ALL_COUNT: ${{ steps.filter.outputs.all_count }}
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          RELEASE_COUNT: ${{ steps.filter.outputs.release_count }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          release_pr=false
+          if [ "$EVENT_NAME" = 'pull_request' ] \
+            && [ "$ACTOR" = 'zephyr-workflows-automation[bot]' ] \
+            && [ "$BASE_REF" = 'main' ] \
+            && [ "$HEAD_REPOSITORY" = "$REPOSITORY" ] \
+            && [ "$PR_AUTHOR" = 'zephyr-workflows-automation[bot]' ] \
+            && [[ "$HEAD_REF" = release-please--branches--* ]] \
+            && [ "$RELEASE_COUNT" -gt 0 ] \
+            && [ "$RELEASE_COUNT" -eq "$ALL_COUNT" ]; then
+            release_pr=true
+          fi
+          echo "release_pr=$release_pr" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: changes
     name: ${{ github.event.action == 'labeled' && 'Force example previews (ubuntu-latest)' || 'End-to-end test of examples (ubuntu-latest)' }}
-    if: github.event.action != 'labeled' || github.event.label.name == 'ci:force-example-builds'
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'ci:force-example-builds') ||
+      (github.event.action != 'labeled' && needs.changes.outputs.release_pr != 'true')
     runs-on: depot-ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -68,8 +120,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   build-windows:
+    needs: changes
     name: ${{ github.event.action == 'labeled' && 'Force example previews (windows-latest)' || 'End-to-end test of examples (windows-latest)' }}
-    if: github.event.action != 'labeled' || github.event.label.name == 'ci:force-example-builds'
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'ci:force-example-builds') ||
+      (github.event.action != 'labeled' && needs.changes.outputs.release_pr != 'true')
     # Modern.js/Rspack currently aborts with 0xC0000409 on Depot's Windows
     # Server 2025 image (`depot-windows-latest`). Pin the supported 2022 image.
     runs-on: depot-windows-2022
@@ -131,8 +186,9 @@ jobs:
         run: pnpm typecheck
 
   test:
+    needs: changes
     name: ${{ github.event.action == 'labeled' && format('Force example previews (test skipped, {0})', matrix.os) || format('test ({0})', matrix.os) }}
-    if: github.event.action != 'labeled'
+    if: github.event.action != 'labeled' && needs.changes.outputs.release_pr != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -10,6 +10,10 @@
     "**/coverage/**",
     "**/.turbo/**",
     "pnpm-lock.yaml",
-    "**/*.gen.ts"
+    "**/*.gen.ts",
+    "CHANGELOG.md",
+    "libs/create-zephyr-apps/.claude-plugin/plugin.json",
+    "libs/create-zephyr-apps/.codex-plugin/plugin.json",
+    "libs/create-zephyr-apps/.cursor-plugin/plugin.json"
   ]
 }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -36,3 +36,11 @@ Release Please mints a Zephyr Workflow Automation GitHub App token from
 issue write access. The default `GITHUB_TOKEN` is not used because GitHub
 suppresses follow-on workflow events created by it. Stable release PRs always
 require human review.
+
+Trusted same-repository release PRs authored by the Zephyr Workflow Automation
+App run the lint, formatting, and typecheck lane. Package tests and preview
+deployments are skipped because Release Please changes only generated release
+metadata, and the App is not a Zephyr preview-deployment identity. Any changed
+file, triggering actor, author, repository, branch, or base mismatch restores
+normal CI. Apply the `ci:force-example-builds` label to run preview builds
+explicitly.


### PR DESCRIPTION
## Summary

Keep generated Release Please PRs on a safe lightweight CI lane.

## Changes

- ignore Release Please-owned `CHANGELOG.md` and host plugin manifests in Oxfmt
- classify generated release PRs by App trigger, author, same-repository branch, `main` base, and a closed file allowlist
- skip package tests and preview deployments only when every trust and file-scope check passes
- keep lint, formatting, and typecheck required
- preserve `ci:force-example-builds` as an explicit preview-build override

## Failure evidence

- run `33076168401`, lint job `98530806993`: Oxfmt rejected four Release Please-generated files
- run `33076168401`, Ubuntu E2E job `98530807292`: the Zephyr Workflow Automation App is not a preview-deployment identity, so `ZE_CI_TOKEN` exchange returned 422

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm lint`
- `actionlint` with known Depot labels ignored
- commit hook: 47/47 affected tasks passed
- exact PR #542 replay: Oxfmt passed; 29/29 changed files matched the release allowlist
- autoreview: clean, no actionable findings
