### PR TITLE
fix(ci): run checks for labeled pull requests

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -8,9 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Label-triggered runs must not cancel or replace the required checks for the
-  # same commit. Their jobs use separate check names below for the same reason.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.action == 'labeled' && format('label-{0}', github.event.label.name) || 'ci' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
@@ -31,7 +29,7 @@ jobs:
   # App output plus required human review intentionally replace a runner-based
   # changed-file check for this zero-runner path.
   build:
-    name: ${{ github.event.action == 'labeled' && 'Force example previews (ubuntu-latest)' || 'End-to-end test of examples (ubuntu-latest)' }}
+    name: End-to-end test of examples (ubuntu-latest)
     if: >-
       !(
         github.event_name == 'pull_request' &&
@@ -41,8 +39,7 @@ jobs:
         github.event.pull_request.base.ref == 'main' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
-      ) &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ci:force-example-builds')
+      )
     runs-on: depot-ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -83,7 +80,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   build-windows:
-    name: ${{ github.event.action == 'labeled' && 'Force example previews (windows-latest)' || 'End-to-end test of examples (windows-latest)' }}
+    name: End-to-end test of examples (windows-latest)
     if: >-
       !(
         github.event_name == 'pull_request' &&
@@ -93,8 +90,7 @@ jobs:
         github.event.pull_request.base.ref == 'main' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
-      ) &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ci:force-example-builds')
+      )
     # Modern.js/Rspack currently aborts with 0xC0000409 on Depot's Windows
     # Server 2025 image (`depot-windows-latest`). Pin the supported 2022 image.
     runs-on: depot-windows-2022
@@ -137,7 +133,7 @@ jobs:
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only
 
   lint:
-    name: ${{ github.event.action == 'labeled' && 'Force example previews (lint skipped)' || 'lint' }}
+    name: lint
     if: >-
       !(
         github.event_name == 'pull_request' &&
@@ -147,8 +143,7 @@ jobs:
         github.event.pull_request.base.ref == 'main' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
-      ) &&
-      github.event.action != 'labeled'
+      )
     runs-on: depot-ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -166,7 +161,6 @@ jobs:
         run: pnpm typecheck
 
   test:
-    name: ${{ github.event.action == 'labeled' && format('Force example previews (test skipped, {0})', matrix.os) || format('test ({0})', matrix.os) }}
     if: >-
       !(
         github.event_name == 'pull_request' &&
@@ -176,8 +170,7 @@ jobs:
         github.event.pull_request.base.ref == 'main' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
-      ) &&
-      github.event.action != 'labeled'
+      )
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Label runs must not wait for custom runners to cancel the required PR run.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.action == 'labeled' && format('label-{0}', github.event.label.name) || 'ci' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ For the opaque `tap-app` build-target contract, see
 - `pnpm test:examples` - Runs example unit tests and the production deployment E2E suite
 
 PR CI builds and deploys affected examples by default. Apply the
-`ci:force-example-builds` label to build and deploy every example with a build
-script and refresh the Zephyr preview links. Remove the label to return future
-PR updates to affected-only builds.
+`ci:force-example-builds` label to rerun required PR CI, build and deploy every
+example with a build script, and refresh the Zephyr preview links. Remove the
+label to return future PR updates to affected-only builds.
 
 ### Linting & Formatting
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -41,7 +41,9 @@ Every CI job skips App-triggered, same-repository release PR events authored by
 the Zephyr Workflow Automation App, targeting `main`, and using Release
 Please's generated branch prefix. GitHub records the workflow run with skipped
 jobs, but no runner starts: release PRs run no lint, formatting, typecheck,
-package test, or preview deployment jobs. Human review remains required.
+package test, or preview deployment jobs. Required preview jobs keep their
+normal check names so GitHub records the trusted skip instead of leaving those
+contexts pending. Human review remains required.
 
 The skip is intentionally job-level. Commit-message skip directives would also
 suppress the `push` workflow after merge and prevent Release Please from


### PR DESCRIPTION
### What's added in this PR?

- Run every CI job for non-Release-Please pull request events, including label events.
- Keep required check names stable instead of exposing unevaluated expressions.
- Isolate label-triggered concurrency so custom-runner cancellation cannot stall the required PR run.
- Preserve the zero-runner exception for trusted automated Release Please PR events.

#### Screenshots

Not applicable.

### What's the issues or discussion related to this PR?

PR #548 entered a misleading skipped state when Renovate added its `dependencies` label immediately after opening the PR. The label event started a second CI run, but every job skipped and GitHub displayed raw job-name expressions while required checks remained expected.

### What are the steps to test this PR?

1. Open a non-Release-Please PR and add an unrelated label.
2. Confirm the label event runs all CI jobs with their normal names.
3. Apply `ci:force-example-builds` and confirm the required CI reruns with all examples selected.
4. Confirm a trusted automated Release Please PR still records skipped jobs without starting runners.

Local validation:

- `actionlint -ignore 'label "depot-(ubuntu-latest|windows-2022)" is unknown' .github/workflows/on_pull_request.yml`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `docs-list`

Live regression proof: adding the unrelated `dependencies` label created run `33616733910` on the same head SHA. All five jobs ran and passed with stable names. The opening run `33616697961` also passed.

### Documentation update for this PR

Updated the repository README and release automation documentation.

### (Optional) What's left to be done for this PR?

Nothing.

### (Optional) What's the potential risk and how to mitigate it?

Any label event now reruns CI in its own concurrency group. This can overlap with the opening run, but avoids a label event waiting on slow custom-runner cancellation.

### (Required) Pre-PR/Merge checklist

- [ ] External documentation PR is not applicable; repository documentation is updated here.
- [x] I have added an explanation of my changes.
- [x] Workflow assertions and live PR behavior cover the regression.
- [x] I have tested this locally with the repository's pinned Node version.
- [x] I have run the full local gate.
