### PR TITLE
feat(zephyr-agent): report GitHub CI bot actors

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -120,15 +120,14 @@ jobs:
           ZE_IS_PREVIEW: true
           # ZE_API and ZE_API_GATE intentionally use the production defaults.
           ZE_CI_TOKEN: ${{ secrets.ZE_CI_TOKEN }}
-        # Forced runs serialize because building every example concurrently exhausts
-        # Windows session resources: bundler tasks abort with 0xC0000142
-        # (STATUS_DLL_INIT_FAILED) and concurrent `git` spawns fail, which the agent
-        # reports as "Not a git repository". Serializing costs ~45s here (3m00s versus
-        # Linux's 2m16s at full concurrency), so the cap is close to free. A cap above 1
-        # is untested; do not raise it without a green forced Windows run.
+        # Windows builds serialize because forced runs and shared-package changes can
+        # make every example affected. Parallel bundlers exhaust session resources and
+        # abort with 0xC0000142 or 0xC0000409; concurrent git spawns can also fail.
+        # A cap above 1 is untested; do not raise it without a green full Windows run.
         run: >-
           pnpm exec turbo run build
-          ${{ env.ZE_FORCE_ALL_EXAMPLES == 'true' && '--filter=./examples/** --concurrency=1' || '--affected' }}
+          ${{ env.ZE_FORCE_ALL_EXAMPLES == 'true' && '--filter=./examples/**' || '--affected' }}
+          --concurrency=1
           --force --env-mode=loose --output-logs=new-only
       - name: run deployment e2e tests
         run: pnpm exec turbo run e2e-test --filter=e2e-deployment --env-mode=loose --output-logs=new-only

--- a/docs/ci-token-identity.md
+++ b/docs/ci-token-identity.md
@@ -18,7 +18,7 @@ Each provider adapter:
 1. Detects its CI environment from predefined variables.
 2. Infers a Git provider actor identity from provider-native job identity data, using provider APIs from the runner when
    needed.
-3. Sends `{ provider, issuer, providerSubject, username, emails, email, source }` to `POST /v2/ci-token/exchange` on
+3. Sends `{ provider, issuer, providerSubject, username, providerActorType, emails, email, source }` to `POST /v2/ci-token/exchange` on
    cloud-io.
 
 GitLab reads `CI_JOB_TOKEN` as a JWT when possible and extracts `user_id`, `user_login`, `user_email`, or `email`. If the token is legacy/non-JWT
@@ -29,7 +29,8 @@ available from JWT claims or the `/job` response, they must match `CI_JOB_ID`, `
 GitHub Actions reads the local webhook payload from `GITHUB_EVENT_PATH`. It prefers the matching commit author email,
 then commit committer email, then `head_commit`, then `pusher.email`. It always sends the stable GitHub actor ID from
 `GITHUB_ACTOR_ID` when available, keeps it paired with `GITHUB_ACTOR` on reruns, and includes GitHub's noreply email
-shape as an email candidate. This requires no
+shape as an email candidate. When the event sender matches that actor, the adapter forwards GitHub's `User` or `Bot`
+classification as `providerActorType`. This requires no
 workflow YAML changes beyond setting `ZE_CI_TOKEN`. Reliable multi-email attribution requires the user's GitHub account
 to be linked in cloud-io as a `GitProviderIdentity`; email candidates are only a fallback.
 
@@ -40,7 +41,8 @@ the CI token against its separate CI-token table and mints a short-lived Zephyr 
 When `ZE_CI_TOKEN` is present, token exchange failures are terminal. The plugin does not fall back to interactive browser
 login in CI. A rejected exchange usually means the workflow actor's Git provider identity is not linked to a Zephyr user.
 The error should tell the user to link that Git provider account in Zephyr Cloud and rerun the workflow, while also
-checking that the CI token secret belongs to the right Zephyr workspace.
+checking that the CI token secret belongs to the right Zephyr workspace. Cloud authorizes reported bots through the CI
+token creator's active organization membership and keeps the bot identity as separate deployment attribution.
 
 ## Access-token caching and concurrency
 

--- a/libs/zephyr-agent/src/lib/errors/codes.ts
+++ b/libs/zephyr-agent/src/lib/errors/codes.ts
@@ -442,10 +442,11 @@ ZE_CI_TOKEN could not be exchanged for a Zephyr access token.
 Zephyr detected this CI actor:
 - provider: {{ provider }}
 - username: {{ username }}
+- actor type: {{ actorType }}
 - identity source: {{ source }}
 - issuer: {{ issuer }}
 
-Link this CI actor's Git provider account in Zephyr Cloud, then rerun the workflow. Zephyr uses linked Git provider identities to map provider-native CI actor data, such as GitHub actor IDs or GitLab user IDs/emails, to a Zephyr user.
+{{ resolution }}
 
 Also check:
 - ZE_CI_TOKEN is the repository or organization secret created for this Zephyr workspace.

--- a/libs/zephyr-agent/src/lib/node-persist/ci-token-identity.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/ci-token-identity.test.ts
@@ -241,6 +241,55 @@ describe('inferCiTokenIdentity', () => {
     });
   });
 
+  it('reports a GitHub bot when the event sender matches the workflow actor', async () => {
+    const eventPath = await writeGitHubEvent({
+      sender: {
+        id: 29139614,
+        login: 'renovate[bot]',
+        type: 'Bot',
+      },
+    });
+
+    const identity = await inferCiTokenIdentity({
+      GITHUB_ACTIONS: 'true',
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_ACTOR: 'renovate[bot]',
+      GITHUB_ACTOR_ID: '29139614',
+    });
+
+    expect(identity).toEqual({
+      provider: 'github',
+      email: '29139614+renovate[bot]@users.noreply.github.com',
+      emails: ['29139614+renovate[bot]@users.noreply.github.com'],
+      issuer: 'https://github.com',
+      providerSubject: '29139614',
+      username: 'renovate[bot]',
+      providerActorType: 'bot',
+      source: 'noreply',
+    });
+  });
+
+  it('ignores sender type when the sender does not match the workflow actor', async () => {
+    const eventPath = await writeGitHubEvent({
+      sender: {
+        id: 29139614,
+        login: 'renovate[bot]',
+        type: 'Bot',
+      },
+    });
+
+    const identity = await inferCiTokenIdentity({
+      GITHUB_ACTIONS: 'true',
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_ACTOR: 'octocat',
+      GITHUB_ACTOR_ID: '12345',
+    });
+
+    expect(identity?.providerActorType).toBeUndefined();
+    expect(identity?.providerSubject).toBe('12345');
+    expect(identity?.username).toBe('octocat');
+  });
+
   it('keeps the GitHub actor login aligned with the stable actor ID on reruns', async () => {
     const eventPath = await writeGitHubEvent({});
 

--- a/libs/zephyr-agent/src/lib/node-persist/ci-token-identity/github.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/ci-token-identity/github.ts
@@ -17,6 +17,7 @@ interface GitHubEventPayload {
   sender?: {
     id?: number | string | null;
     login?: string | null;
+    type?: string | null;
   } | null;
   pusher?: {
     email?: string | null;
@@ -44,6 +45,7 @@ async function inferGitHubIdentity(
   const emails = getEmails([...eventEmails, noreplyEmail]);
   const providerSubject = getGitHubActorId(env, event);
   const username = getGitHubActor(env, event);
+  const providerActorType = getGitHubActorType(env, event);
 
   if (eventEmails.length > 0 || providerSubject) {
     return {
@@ -53,6 +55,7 @@ async function inferGitHubIdentity(
       issuer: getGitHubIssuer(env),
       providerSubject,
       username,
+      ...(providerActorType && { providerActorType }),
       source: eventEmails.length > 0 ? 'event' : 'noreply',
     };
   }
@@ -65,6 +68,7 @@ async function inferGitHubIdentity(
       issuer: getGitHubIssuer(env),
       providerSubject,
       username,
+      ...(providerActorType && { providerActorType }),
       source: 'noreply',
     };
   }
@@ -149,6 +153,30 @@ function getGitHubActorId(
   event: GitHubEventPayload | undefined
 ): string | undefined {
   return env['GITHUB_ACTOR_ID']?.trim() || stringifyId(event?.sender?.id);
+}
+
+function getGitHubActorType(
+  env: NodeJS.ProcessEnv,
+  event: GitHubEventPayload | undefined
+): CiTokenIdentity['providerActorType'] {
+  const senderType = event?.sender?.type?.trim().toLowerCase();
+  if (senderType !== 'bot' && senderType !== 'user') {
+    return undefined;
+  }
+
+  const envActorId = env['GITHUB_ACTOR_ID']?.trim();
+  const senderId = stringifyId(event?.sender?.id);
+  if (envActorId && senderId) {
+    return envActorId === senderId ? senderType : undefined;
+  }
+
+  const envActor = env['GITHUB_ACTOR']?.trim().toLowerCase();
+  const senderLogin = event?.sender?.login?.trim().toLowerCase();
+  if (envActor && senderLogin && envActor !== senderLogin) {
+    return undefined;
+  }
+
+  return senderType;
 }
 
 function getGitHubIssuer(env: NodeJS.ProcessEnv): string {

--- a/libs/zephyr-agent/src/lib/node-persist/ci-token-identity/types.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/ci-token-identity/types.ts
@@ -7,6 +7,7 @@ export interface CiTokenIdentity {
   issuer?: string;
   providerSubject?: string;
   username?: string;
+  providerActorType?: 'user' | 'bot';
   source: 'jwt' | 'api' | 'env' | 'event' | 'noreply';
 }
 

--- a/libs/zephyr-agent/src/lib/node-persist/token.test.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.test.ts
@@ -53,6 +53,13 @@ const githubIdentity = {
   source: 'noreply' as const,
 };
 
+const githubBotIdentity = {
+  ...githubIdentity,
+  providerSubject: '29139614',
+  username: 'renovate[bot]',
+  providerActorType: 'bot' as const,
+};
+
 describe('getToken', () => {
   const originalEnv = process.env;
 
@@ -88,6 +95,19 @@ describe('getToken', () => {
     await expect(getToken()).rejects.toMatchObject({
       code: ZephyrError.toZeCode(ZeErrors.ERR_CI_TOKEN_AUTH),
       message: expect.stringContaining('no supported CI identity was detected'),
+    });
+  });
+
+  it('gives bot-specific authorization guidance when exchange is rejected', async () => {
+    mockInferCiTokenIdentity.mockResolvedValue(githubBotIdentity);
+    mockMakeRequest.mockResolvedValue([
+      false,
+      new Error('CI token creator is not an active organization member'),
+    ]);
+
+    await expect(getToken()).rejects.toMatchObject({
+      code: ZephyrError.toZeCode(ZeErrors.ERR_CI_TOKEN_AUTH),
+      message: expect.stringContaining('This bot is authorized by the CI token creator'),
     });
   });
 

--- a/libs/zephyr-agent/src/lib/node-persist/token.ts
+++ b/libs/zephyr-agent/src/lib/node-persist/token.ts
@@ -235,6 +235,7 @@ function getCiTokenScope(ciToken: string, identity: CiTokenIdentity): string {
     identity.issuer ?? '',
     identity.providerSubject ?? '',
     identity.username ?? '',
+    identity.providerActorType ?? '',
     identity.email ?? '',
     [...(identity.emails ?? [])].sort(),
   ];
@@ -284,6 +285,11 @@ function throwCiTokenAuthError(
     username: identity?.username ?? 'unknown',
     source: identity?.source ?? 'unknown',
     issuer: identity?.issuer ?? 'unknown',
+    actorType: identity?.providerActorType ?? 'unknown',
+    resolution:
+      identity?.providerActorType === 'bot'
+        ? 'This bot is authorized by the CI token creator. Check that the token creator is still an active member of the Zephyr organization.'
+        : "Link this CI actor's Git provider account in Zephyr Cloud, then rerun the workflow. Zephyr uses linked Git provider identities to map provider-native CI actor data, such as GitHub actor IDs or GitLab user IDs/emails, to a Zephyr user.",
     details,
   });
 }


### PR DESCRIPTION
## Summary

- infer GitHub `User` or `Bot` actor type from the event sender only when it matches the workflow actor
- send `providerActorType` during CI-token exchange and include it in the access-token cache scope
- give bot-specific authorization guidance instead of asking GitHub App bots to link a browser account
- document Cloud's separate bot attribution and CI-token creator authorization
- serialize Windows example builds when shared-package changes make the full example graph affected

## Dependency

- Cloud support: https://github.com/ZephyrCloudIO/zephyr-cloud-io/pull/3685
- merge and deploy the Cloud PR before releasing this zephyr-agent change

## Validation

- focused zephyr-agent identity/token suite: 25 tests passed
- `pnpm --filter zephyr-agent typecheck`
- `pnpm --filter zephyr-agent build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`: 28 tasks passed
- `pnpm test`: 32 tasks passed
- sequential full library build: 23 tasks passed
- commit affected gate: 42 tasks passed
- source-blind behavior contract: matching bot and mismatched-sender probes passed
- `actionlint`: workflow syntax passed; only existing unconfigured Depot custom-runner labels were reported

## CI follow-up

The first PR run passed lint, Linux tests, and Linux deployment E2E. Windows deployment E2E launched 56 affected builds concurrently and `mf-react-rsbuild-provider` aborted with `0xC0000409`. The workflow already serialized forced full-example runs for this Windows resource limit; the follow-up commit applies that cap whenever the Windows example job runs.

The follow-up run is green across all five checks. Serialized Windows deployment E2E passed in 9m35s.

## Review note

Structured autoreview refused the bundle before model execution because the CI-token test fixture matched its secret-like-content scanner. The fixture contains a test-only token value. Manual review and all package gates passed.
