### PR TITLE
ci: remove package audit release gates

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -54,9 +54,6 @@ jobs:
             exit 1
           fi
 
-      - name: Verify package integrity
-        run: pnpm audit --audit-level high
-
       - name: Build packages
         run: pnpm build
 
@@ -109,9 +106,6 @@ jobs:
             git status
             exit 1
           fi
-
-      - name: Verify package integrity
-        run: pnpm audit --audit-level high
 
       - name: Build packages
         run: pnpm build
@@ -181,9 +175,6 @@ jobs:
             git status
             exit 1
           fi
-
-      - name: Verify package integrity
-        run: pnpm audit --audit-level high
 
       - name: Build packages
         run: pnpm build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,23 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  verify-package-integrity:
-    runs-on: depot-ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          run_install: false
-      - name: Verify package integrity before release
-        run: pnpm audit --audit-level high
-
   release-please:
-    needs: verify-package-integrity
     runs-on: depot-ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,10 +21,6 @@ creates `vX.Y.Z` and the matching GitHub Release. The release event then starts
 `publish_packages.yml`, which builds and publishes all packages with the npm
 `latest` tag.
 
-Every push to `main` must pass the high-severity package audit before Release
-Please can update its PR or create a stable tag and GitHub Release. The publish
-workflow repeats the audit before npm publication.
-
 The retired `pnpm bump-patch`, `pnpm bump-minor`, and `pnpm bump-major` flow
 must not be recreated. Do not hand-create a stable tag or GitHub Release.
 Manual canary and prerelease publication remain unchanged in


### PR DESCRIPTION
## Summary

Remove package audit gates from release automation so dependency advisories cannot block Release Please or npm publication.

## Changes

- Run Release Please directly on `main` pushes without an audit preflight.
- Remove audit steps from canary, prerelease, and stable npm publishing.
- Update release documentation to match the new workflow.

## Testing

- `actionlint` on both changed workflows, with known Depot and existing shell warnings filtered
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `docs-list`
- `git diff --check`
- Verified no package audit gate references remain
- Autoreview clean with no actionable findings
