### PR TITLE
fix(vite): load optional federation peer lazily

### DIFF
--- a/libs/vite-plugin-zephyr/rslib.config.mts
+++ b/libs/vite-plugin-zephyr/rslib.config.mts
@@ -48,7 +48,6 @@ export default defineConfig({
         esm: {
           __filename: true,
           __dirname: true,
-          require: true,
         },
       },
       source: { entry },

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.spec.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, rs } from '@rstest/core';
+import type * as NodeModule from 'node:module';
 import type { Plugin, ResolvedConfig } from 'vite' with {
   'resolution-mode': 'import',
 };
@@ -34,8 +35,16 @@ rs.mock('vite', () => ({
   version: '7.0.0',
 }));
 
-rs.mockRequire('@module-federation/vite', () => {
-  return { federation: mocks.federation };
+rs.mock('node:module', () => {
+  const actual = rs.requireActual('node:module') as typeof NodeModule;
+  const actualRequire = actual.createRequire(__filename);
+  return {
+    ...actual,
+    createRequire: () => (specifier: string) =>
+      specifier === '@module-federation/vite'
+        ? { federation: mocks.federation }
+        : actualRequire(specifier),
+  };
 });
 
 rs.mock('zephyr-agent', () => {

--- a/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
+++ b/libs/vite-plugin-zephyr/src/lib/vite-plugin-zephyr.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { createHash, randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import MagicString from 'magic-string';
 import type { Plugin, ResolvedConfig, UserConfig } from 'vite' with {
@@ -52,6 +53,7 @@ import {
 
 const DEFAULT_LIBRARY_TYPE = 'module';
 const VITE_ENVIRONMENT_OUTPUT_PREFIX = 'vite-environment:';
+const runtimeRequire = createRequire(__filename);
 
 export interface WithZephyrOptions {
   /** Zephyr build target, including the `tap-app` mini-app artifact family. */
@@ -301,7 +303,7 @@ function loadModuleFederationPlugin() {
   };
 
   try {
-    moduleFederation = require('@module-federation/vite') as {
+    moduleFederation = runtimeRequire('@module-federation/vite') as {
       federation: (options: ModuleFederationOptions) => Plugin[];
     };
   } catch (error) {

--- a/libs/vite-plugin-zephyr/src/package-output.spec.ts
+++ b/libs/vite-plugin-zephyr/src/package-output.spec.ts
@@ -1,0 +1,221 @@
+import { afterAll, beforeAll, describe, expect, test } from '@rstest/core';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const packageRoot = path.resolve(import.meta.dirname, '..');
+const requiredDependencies = [
+  'acorn',
+  'acorn-walk',
+  'magic-string',
+  'rollup',
+  'vite',
+  'zephyr-agent',
+];
+
+let tempRoot: string;
+let tarballPath: string;
+
+function run(command: string, args: string[], cwd: string) {
+  const env = { ...process.env };
+  delete env['NODE_PATH'];
+
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `${command} ${args.join(' ')} exited with ${String(result.status)}`,
+        result.stdout,
+        result.stderr,
+      ]
+        .filter(Boolean)
+        .join('\n')
+    );
+  }
+
+  return result.stdout;
+}
+
+async function linkDependency(consumerRoot: string, dependency: string) {
+  const source = await realpath(path.join(packageRoot, 'node_modules', dependency));
+  const destination = path.join(consumerRoot, 'node_modules', dependency);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await symlink(source, destination, process.platform === 'win32' ? 'junction' : 'dir');
+}
+
+async function createConsumer(name: string, includeFederationPeer = false) {
+  const consumerRoot = path.join(tempRoot, name);
+  const nodeModules = path.join(consumerRoot, 'node_modules');
+  await mkdir(nodeModules, { recursive: true });
+  await writeFile(
+    path.join(consumerRoot, 'package.json'),
+    JSON.stringify({ name, private: true, type: 'module' })
+  );
+
+  run('tar', ['-xzf', tarballPath, '-C', nodeModules], consumerRoot);
+  await rename(
+    path.join(nodeModules, 'package'),
+    path.join(nodeModules, 'vite-plugin-zephyr')
+  );
+
+  for (const dependency of requiredDependencies) {
+    await linkDependency(consumerRoot, dependency);
+  }
+  if (includeFederationPeer) {
+    await linkDependency(consumerRoot, '@module-federation/vite');
+  }
+
+  return consumerRoot;
+}
+
+function runNode(consumerRoot: string, source: string, esm = true) {
+  return run(
+    process.execPath,
+    [...(esm ? ['--input-type=module'] : []), '-e', source],
+    consumerRoot
+  );
+}
+
+async function findFiles(directory: string, extension: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await findFiles(entryPath, extension)));
+    } else if (entry.name.endsWith(extension)) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+beforeAll(async () => {
+  tempRoot = await mkdtemp(path.join(tmpdir(), 'vite-plugin-zephyr-package-'));
+  tarballPath = path.join(tempRoot, 'vite-plugin-zephyr.tgz');
+  const pnpmCli = process.env['npm_execpath'];
+  if (pnpmCli) {
+    run(process.execPath, [pnpmCli, 'pack', '--out', tarballPath], packageRoot);
+  } else if (process.platform === 'win32') {
+    run(
+      process.env['ComSpec'] ?? 'cmd.exe',
+      ['/d', '/s', '/c', `pnpm pack --out "${tarballPath}"`],
+      packageRoot
+    );
+  } else {
+    run('pnpm', ['pack', '--out', tarballPath], packageRoot);
+  }
+});
+
+afterAll(async () => {
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true, maxRetries: 3 });
+  }
+});
+
+describe('published optional federation peer', () => {
+  test('does not emit a static ESM import for the optional peer', async () => {
+    const consumerRoot = await createConsumer('artifact-inspection');
+    const packageDirectory = path.join(
+      consumerRoot,
+      'node_modules',
+      'vite-plugin-zephyr'
+    );
+    const esmFiles = await findFiles(packageDirectory, '.mjs');
+
+    expect(esmFiles.length).toBeGreaterThan(0);
+    for (const file of esmFiles) {
+      const source = await readFile(file, 'utf8');
+      expect(source).not.toMatch(/^\s*import\b[^\n]*["']@module-federation\/vite["']/mu);
+    }
+  });
+
+  test('imports through ESM and CommonJS without the optional peer', async () => {
+    const consumerRoot = await createConsumer('without-federation-peer');
+
+    runNode(
+      consumerRoot,
+      `
+        import { createRequire } from 'node:module';
+        const consumerRequire = createRequire(new URL('./package.json', import.meta.url));
+        try {
+          consumerRequire.resolve('@module-federation/vite');
+          throw new Error('optional federation peer unexpectedly resolved');
+        } catch (error) {
+          if (String(error).includes('unexpectedly resolved')) throw error;
+        }
+        const plugin = await import('vite-plugin-zephyr');
+        if (typeof plugin.withZephyr !== 'function') throw new Error('missing withZephyr');
+      `
+    );
+
+    runNode(
+      consumerRoot,
+      `
+        const plugin = require('vite-plugin-zephyr');
+        if (typeof plugin.withZephyr !== 'function') throw new Error('missing withZephyr');
+      `,
+      false
+    );
+  });
+
+  test('reports the missing peer only when federation is requested', async () => {
+    const consumerRoot = await createConsumer('missing-federation-feature');
+    const assertion = `
+      try {
+        withZephyr({ mfConfig: { name: 'probe', exposes: {} } });
+        throw new Error('expected federation dependency error');
+      } catch (error) {
+        const message = String(error?.message ?? error);
+        if (!message.includes('@module-federation/vite is required when mfConfig is provided')) {
+          throw error;
+        }
+      }
+    `;
+
+    runNode(
+      consumerRoot,
+      `const { withZephyr } = await import('vite-plugin-zephyr'); ${assertion}`
+    );
+    runNode(
+      consumerRoot,
+      `const { withZephyr } = require('vite-plugin-zephyr'); ${assertion}`,
+      false
+    );
+  });
+
+  test('loads the real peer when ESM and CommonJS consumers request federation', async () => {
+    const consumerRoot = await createConsumer('with-federation-peer', true);
+    const assertion = `
+      const plugins = withZephyr({ mfConfig: { name: 'probe', exposes: {} } });
+      if (!Array.isArray(plugins) || !plugins.some((plugin) => plugin.name === 'with-zephyr')) {
+        throw new Error('Zephyr plugins were not created');
+      }
+    `;
+
+    runNode(
+      consumerRoot,
+      `const { withZephyr } = await import('vite-plugin-zephyr'); ${assertion}`
+    );
+    runNode(
+      consumerRoot,
+      `const { withZephyr } = require('vite-plugin-zephyr'); ${assertion}`,
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace the ESM require shim with a runtime `createRequire` loader for `@module-federation/vite`
- preserve the targeted setup error when federation is requested without its optional peer
- add packed, isolated ESM and CommonJS regressions for absent-peer and present-peer consumers

## Verification
- `pnpm exec turbo run build --filter=vite-plugin-zephyr --force`
- `pnpm --filter vite-plugin-zephyr test`
- `pnpm --filter vite-plugin-zephyr typecheck`
- `pnpm test:affected`
- `pnpm lint`
- `pnpm format:check`

Closes #603