### PR TITLE
feat(agent): distinguish deployment failure reasons

### DIFF
--- a/docs/git-usage.md
+++ b/docs/git-usage.md
@@ -103,6 +103,8 @@ Local build can still deploy, and Zephyr can infer org/project from `origin`.
   remote-origin inference, not deployment history.
 - Without commits in local, Zephyr uses placeholder commit metadata (`no-git-commit`) but keeps local flow working.
 - If no Git metadata is available at all, Zephyr falls back to global Git config, then token/user-based fallback metadata.
+- The local user fallback requires authentication. In an interactive terminal Zephyr opens the normal browser-login flow and retries the user lookup once. Non-interactive builds must provide a valid token.
+- Authentication (`ZE10018`), target access (`ZE10022`), and service availability (`ZE40035`) failures are not Git setup failures. Their diagnostics retain the failing operation and reason instead of reporting `ZE10016`.
 - In CI with `ZE_CI_TOKEN`, Zephyr infers the build actor in the plugin. GitLab reads built-in `CI_JOB_TOKEN` JWT
   claims locally, then falls back to GitLab's `/job` API from the runner and GitLab's predefined `GITLAB_USER_EMAIL` for
   legacy/non-JWT job tokens. GitHub Actions reads `GITHUB_EVENT_PATH` commit/pusher emails, then falls back to GitHub
@@ -118,3 +120,7 @@ If you see `Git repository not found`:
 2. Confirm origin: `git remote -v`
 3. For CI failures, confirm commit exists: `git rev-parse HEAD`
 4. If CI still fails, ensure checkout step fetches commit history (not detached shallow state without commit metadata)
+
+If the diagnostic reports `ZE10018`, complete normal browser login from an interactive terminal or provide the supported token for the environment. Do not print, export, or share files from `~/.zephyr`.
+
+If the diagnostic reports `ZE10022`, verify the configured application target and request access from an organization administrator. Re-running Git setup will not change target authorization.

--- a/libs/zephyr-agent/src/index.ts
+++ b/libs/zephyr-agent/src/index.ts
@@ -33,7 +33,7 @@ export {
 } from './lib/upload-output-to-zephyr';
 
 // errors
-export { ZeErrors, ZephyrError } from './lib/errors';
+export { ZeErrors, ZephyrError, type ZephyrErrorOperation } from './lib/errors';
 export { handleGlobalError } from './lib/errors';
 
 // Project configuration

--- a/libs/zephyr-agent/src/lib/auth/login-flow.test.ts
+++ b/libs/zephyr-agent/src/lib/auth/login-flow.test.ts
@@ -24,9 +24,11 @@ const mocks = rs.hoisted(() => ({
 }));
 
 rs.mock('jose', () => ({ decodeJwt: rs.fn() }));
+rs.mock('ci-info', () => ({ isCI: false }));
 rs.mock('node:readline', () => ({
   createInterface: rs.fn(() => ({ question: mocks.question })),
 }));
+rs.mock('node:tty', () => ({ isatty: rs.fn(() => mocks.interactive) }));
 rs.mock('zephyr-edge-contract', () => ({
   ZE_API_ENDPOINT: rs.fn(() => 'https://api.example/'),
   formatString: rs.fn((message: string) => message),
@@ -50,9 +52,7 @@ rs.mock('../logging/picocolor', () => ({
   bold: (value: string) => value,
   gray: (value: string) => value,
   green: (value: string) => value,
-  get isTTY() {
-    return mocks.interactive;
-  },
+  isTTY: true,
   white: (value: string) => value,
   yellow: (value: string) => value,
 }));

--- a/libs/zephyr-agent/src/lib/auth/login-flow.test.ts
+++ b/libs/zephyr-agent/src/lib/auth/login-flow.test.ts
@@ -7,6 +7,7 @@ const mocks = rs.hoisted(() => ({
   debugLog: rs.fn(),
   disposeSession: rs.fn(),
   getToken: rs.fn().mockResolvedValue(undefined),
+  interactive: true,
   logFn: rs.fn(),
   makeRequest: rs
     .fn()
@@ -49,7 +50,9 @@ rs.mock('../logging/picocolor', () => ({
   bold: (value: string) => value,
   gray: (value: string) => value,
   green: (value: string) => value,
-  isTTY: true,
+  get isTTY() {
+    return mocks.interactive;
+  },
   white: (value: string) => value,
   yellow: (value: string) => value,
 }));
@@ -82,6 +85,20 @@ import { checkAuth } from './login';
 describe('interactive authentication cleanup', () => {
   beforeEach(() => {
     rs.clearAllMocks();
+    mocks.interactive = true;
+  });
+
+  it('fails with authentication guidance instead of waiting outside a terminal', async () => {
+    mocks.interactive = false;
+
+    await expect(checkAuth()).rejects.toMatchObject({
+      code: 'ZE10018',
+      template: {
+        message: expect.stringContaining('Interactive login is unavailable'),
+      },
+    });
+    expect(mocks.makeRequest).not.toHaveBeenCalled();
+    expect(mocks.waitForToken).not.toHaveBeenCalled();
   });
 
   it('removes the private fallback artifact when authentication fails or times out', async () => {

--- a/libs/zephyr-agent/src/lib/auth/login.ts
+++ b/libs/zephyr-agent/src/lib/auth/login.ts
@@ -32,7 +32,7 @@ interface PrivateAuthenticationArtifact {
  *
  * @returns The token as a string.
  */
-export async function checkAuth(git_config: ZeGitInfo): Promise<void> {
+export async function checkAuth(git_config?: ZeGitInfo): Promise<void> {
   const secret_token = getSecretToken();
   const server_token = getServerToken();
   const ci_token = getCiToken();
@@ -69,6 +69,10 @@ export async function checkAuth(git_config: ZeGitInfo): Promise<void> {
   // since user cannot interact with it.
   if (!isTTY) {
     logFn('warn', `Could not load ${StorageKeys.ze_secret_token}.`);
+    throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+      message:
+        'Interactive login is unavailable. Run the deployment in a terminal or provide a valid authentication token.',
+    });
   }
 
   // No valid token found; initiate authentication.

--- a/libs/zephyr-agent/src/lib/auth/login.ts
+++ b/libs/zephyr-agent/src/lib/auth/login.ts
@@ -1,8 +1,10 @@
 import type openBrowser from 'open';
+import { isCI } from 'ci-info';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as readline from 'node:readline';
+import { isatty } from 'node:tty';
 import { ZE_API_ENDPOINT, ze_api_gateway } from 'zephyr-edge-contract';
 import { ZeErrors, ZephyrError } from '../errors';
 import { makeRequest } from '../http/http-request';
@@ -67,7 +69,7 @@ export async function checkAuth(git_config?: ZeGitInfo): Promise<void> {
 
   // In non-TTY environments it's expected that a ZE_SECRET_TOKEN is present
   // since user cannot interact with it.
-  if (!isTTY) {
+  if (isCI || !isatty(process.stdin.fd) || !isatty(process.stdout.fd)) {
     logFn('warn', `Could not load ${StorageKeys.ze_secret_token}.`);
     throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
       message:

--- a/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-ci.test.ts
+++ b/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-ci.test.ts
@@ -95,9 +95,14 @@ describe('getGitInfo - CI environments', () => {
     // Every git command fails => not a git repository.
     mockGit(() => ({ error: new Error('Not a git repository') }));
 
-    await expect(getGitInfo()).rejects.toThrow(
-      'Stable Git branch and commit information is required in CI environments'
-    );
+    await expect(getGitInfo()).rejects.toMatchObject({
+      code: 'ZE10016',
+      operation: 'resolve-git-metadata',
+      reason: 'ZE10016',
+      message: expect.stringContaining(
+        'Stable Git branch and commit information is required in CI environments'
+      ),
+    });
   });
 
   it('does not let configured identity create timestamp metadata in CI', async () => {

--- a/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-non-git.test.ts
+++ b/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-non-git.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, rs } from '@rstest/core';
 import type { Mock } from '@rstest/core';
 
 import { execFile as node_execFile } from 'node:child_process';
+import { ZeErrors, ZephyrError } from '../../errors';
 import { getGitInfo } from '../ze-util-get-git-info';
 
 rs.mock('node:child_process', () => ({
@@ -37,6 +38,7 @@ rs.mock('../../http/http-request', () => ({
 }));
 
 rs.mock('../../auth/login', () => ({
+  checkAuth: rs.fn(),
   isTokenStillValid: rs.fn(),
 }));
 
@@ -94,6 +96,7 @@ describe('getGitInfo - non-git environments', () => {
   let mockGitLog: Mock;
   let mockLogFn: Mock;
   let mockGetPackageJson: Mock;
+  let mockCheckAuth: Mock;
 
   beforeEach(() => {
     rs.clearAllMocks();
@@ -121,8 +124,13 @@ describe('getGitInfo - non-git environments', () => {
 
     // Mock authentication and API calls for fallback scenarios
     const { getToken } = require('../../node-persist/token');
-    const { isTokenStillValid } = require('../../auth/login');
+    const { hasSecretToken } = require('../../node-persist/secret-token');
+    const { checkAuth, isTokenStillValid } = require('../../auth/login');
     const { makeRequest } = require('../../http/http-request');
+
+    mockCheckAuth = checkAuth;
+    mockCheckAuth.mockResolvedValue(undefined);
+    hasSecretToken.mockReturnValue(false);
 
     // Default token setup
     getToken.mockResolvedValue('valid-token');
@@ -184,6 +192,158 @@ describe('getGitInfo - non-git environments', () => {
     expect(result.app.project).toBe('test-project'); // from package.json
   });
 
+  it('authenticates interactively once before retrying the user fallback', async () => {
+    noGitRepo();
+    const { getToken } = require('../../node-persist/token');
+    const { makeRequest } = require('../../http/http-request');
+    getToken.mockReset();
+    getToken.mockResolvedValueOnce(undefined).mockResolvedValue('new-token');
+
+    const result = await getGitInfo();
+
+    expect(mockCheckAuth).toHaveBeenCalledTimes(1);
+    expect(mockCheckAuth).toHaveBeenCalledWith();
+    expect(result.git.email).toBe('api@example.com');
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/v2/user/me' }),
+      {
+        headers: { Authorization: 'Bearer new-token' },
+        credentialToken: 'new-token',
+      }
+    );
+  });
+
+  it('reports authentication when browser login cannot complete', async () => {
+    noGitRepo();
+    const { getToken } = require('../../node-persist/token');
+    getToken.mockReset();
+    getToken.mockResolvedValue(undefined);
+    mockCheckAuth.mockRejectedValue(
+      new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+        message: 'Browser authentication timed out',
+      })
+    );
+
+    await expect(getGitInfo()).rejects.toMatchObject({
+      code: 'ZE10018',
+      operation: 'get-user-info',
+      reason: 'ZE10018',
+    });
+    const warnings = mockLogFn.mock.calls.map((call) => String(call[1])).join('\n');
+    expect(warnings).not.toContain('git init');
+    expect(warnings).not.toContain('git remote add origin');
+  });
+
+  it('replaces an expired token through browser login before user lookup', async () => {
+    noGitRepo();
+    const { getToken } = require('../../node-persist/token');
+    const { isTokenStillValid } = require('../../auth/login');
+    getToken.mockReset();
+    getToken.mockResolvedValueOnce('expired-token').mockResolvedValue('new-token');
+    isTokenStillValid.mockReturnValueOnce(false).mockReturnValue(true);
+
+    await expect(getGitInfo()).resolves.toMatchObject({
+      git: { email: 'api@example.com' },
+    });
+
+    expect(mockCheckAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries one user request after an authentication response', async () => {
+    noGitRepo();
+    const { getToken } = require('../../node-persist/token');
+    const { makeRequest } = require('../../http/http-request');
+    getToken.mockReset();
+    getToken.mockResolvedValueOnce('rejected-token').mockResolvedValue('refreshed-token');
+    makeRequest.mockReset();
+    makeRequest
+      .mockResolvedValueOnce([
+        false,
+        new ZephyrError(ZeErrors.ERR_AUTH_ERROR, { message: 'Token expired' }),
+      ])
+      .mockResolvedValueOnce([
+        true,
+        null,
+        {
+          value: {
+            name: 'API User',
+            email: 'api@example.com',
+            id: 'user-123',
+          },
+        },
+      ]);
+
+    await expect(getGitInfo()).resolves.toMatchObject({
+      git: { email: 'api@example.com' },
+    });
+
+    expect(mockCheckAuth).toHaveBeenCalledTimes(1);
+    expect(makeRequest).toHaveBeenCalledTimes(2);
+    expect(makeRequest.mock.calls[1]?.[1]).toEqual({
+      headers: { Authorization: 'Bearer refreshed-token' },
+      credentialToken: 'refreshed-token',
+    });
+  });
+
+  it('does not start browser login for a rejected environment credential', async () => {
+    noGitRepo();
+    const { hasSecretToken } = require('../../node-persist/secret-token');
+    const { makeRequest } = require('../../http/http-request');
+    hasSecretToken.mockReturnValue(true);
+    makeRequest.mockResolvedValue([
+      false,
+      new ZephyrError(ZeErrors.ERR_AUTH_ERROR, { message: 'Token expired' }),
+    ]);
+
+    await expect(getGitInfo()).rejects.toMatchObject({
+      code: 'ZE10018',
+      operation: 'get-user-info',
+      reason: 'ZE10018',
+    });
+    expect(mockCheckAuth).not.toHaveBeenCalled();
+    expect(makeRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves a forbidden user lookup without another Git or login attempt', async () => {
+    noGitRepo();
+    const token = 'forbidden-user-token';
+    const cause = new ZephyrError(ZeErrors.ERR_AUTH_FORBIDDEN_ERROR, {
+      message: 'Target access denied',
+      data: { Authorization: `Bearer ${token}` },
+    });
+    const { makeRequest } = require('../../http/http-request');
+    makeRequest.mockResolvedValue([false, cause]);
+
+    const error = await getGitInfo().catch((value) => value);
+
+    expect(error).toMatchObject({
+      code: 'ZE10022',
+      operation: 'get-user-info',
+      reason: 'ZE10022',
+    });
+    expect(mockCheckAuth).not.toHaveBeenCalled();
+    expect(JSON.stringify(error)).not.toContain(token);
+  });
+
+  it('preserves user API unavailability separately from denied access', async () => {
+    noGitRepo();
+    const cause = new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
+      method: 'GET',
+      url: 'https://api.zephyr-cloud.io/v2/user/me',
+      status: 503,
+      content: 'Service unavailable',
+    });
+    const { makeRequest } = require('../../http/http-request');
+    makeRequest.mockResolvedValue([false, cause]);
+
+    await expect(getGitInfo()).rejects.toMatchObject({
+      code: 'ZE40035',
+      operation: 'get-user-info',
+      reason: 'ZE40035',
+    });
+    expect(mockCheckAuth).not.toHaveBeenCalled();
+  });
+
   it('should still work normally when git is available', async () => {
     gitAvailable({
       'config user.name': 'John Doe',
@@ -230,6 +390,28 @@ describe('getGitInfo - non-git environments', () => {
     for (const call of mockExecFile.mock.calls) {
       expect(call[2]).toEqual({ cwd: context });
     }
+  });
+
+  it('uses authenticated fallback metadata with a configured application target', async () => {
+    noGitRepo();
+
+    const result = await getGitInfo('/workspace/apps/configured-no-git', {
+      org: 'configured-org',
+      project: 'configured-project',
+    });
+
+    expect(result.app).toEqual({
+      org: 'configured-org',
+      project: 'configured-project',
+    });
+    expect(result.git).toMatchObject({
+      name: 'API User',
+      email: 'api@example.com',
+    });
+    expect(mockLogFn).not.toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('Using organization')
+    );
   });
 
   it('lets a partial config override one field inferred from origin', async () => {

--- a/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-non-git.test.ts
+++ b/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-non-git.test.ts
@@ -239,6 +239,22 @@ describe('getGitInfo - non-git environments', () => {
     expect(warnings).not.toContain('git remote add origin');
   });
 
+  it('attributes token resolution failures to the user lookup operation', async () => {
+    noGitRepo();
+    const { getToken } = require('../../node-persist/token');
+    getToken.mockRejectedValue(
+      new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+        message: 'CI token exchange failed',
+      })
+    );
+
+    await expect(getGitInfo()).rejects.toMatchObject({
+      code: 'ZE10018',
+      operation: 'get-user-info',
+      reason: 'ZE10018',
+    });
+  });
+
   it('replaces an expired token through browser login before user lookup', async () => {
     noGitRepo();
     const { getToken } = require('../../node-persist/token');

--- a/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-non-git.test.ts
+++ b/libs/zephyr-agent/src/lib/build-context/__tests__/ze-util-get-git-info-non-git.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, rs } from '@rstest/core';
 import type { Mock } from '@rstest/core';
 
 import { execFile as node_execFile } from 'node:child_process';
+import { ZE_API_ENDPOINT } from 'zephyr-edge-contract';
 import { ZeErrors, ZephyrError } from '../../errors';
 import { getGitInfo } from '../ze-util-get-git-info';
 
@@ -205,7 +206,11 @@ describe('getGitInfo - non-git environments', () => {
     expect(mockCheckAuth).toHaveBeenCalledWith();
     expect(result.git.email).toBe('api@example.com');
     expect(makeRequest).toHaveBeenCalledWith(
-      expect.objectContaining({ path: '/v2/user/me' }),
+      {
+        path: '/user-info',
+        base: ZE_API_ENDPOINT(),
+        query: {},
+      },
       {
         headers: { Authorization: 'Bearer new-token' },
         credentialToken: 'new-token',
@@ -329,7 +334,7 @@ describe('getGitInfo - non-git environments', () => {
     noGitRepo();
     const cause = new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
       method: 'GET',
-      url: 'https://api.zephyr-cloud.io/v2/user/me',
+      url: 'https://zeapi.zephyrcloud.app/user-info',
       status: 503,
       content: 'Service unavailable',
     });

--- a/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
@@ -3,7 +3,7 @@ import { execFile as node_execFile } from 'node:child_process';
 import { sep } from 'node:path';
 import { promisify } from 'node:util';
 import type { ZephyrPluginOptions } from 'zephyr-edge-contract';
-import { ZEPHYR_API_ENDPOINT } from 'zephyr-edge-contract';
+import { ZE_API_ENDPOINT, ze_api_gateway } from 'zephyr-edge-contract';
 import { checkAuth, isTokenStillValid } from '../auth/login';
 import { ZeErrors, ZephyrError } from '../errors';
 import { makeRequest } from '../http/http-request';
@@ -443,8 +443,8 @@ async function getUserInfoFromAPI(): Promise<UserInfo> {
 
     const [ok, cause, response] = await makeRequest<{ value: UserInfo }>(
       {
-        path: '/v2/user/me',
-        base: ZEPHYR_API_ENDPOINT(),
+        path: ze_api_gateway.user_info,
+        base: ZE_API_ENDPOINT(),
         query: {},
       },
       {

--- a/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
@@ -4,6 +4,7 @@ import { sep } from 'node:path';
 import { promisify } from 'node:util';
 import type { ZephyrPluginOptions } from 'zephyr-edge-contract';
 import { ZE_API_ENDPOINT, ze_api_gateway } from 'zephyr-edge-contract';
+import { TOKEN_EXPIRY } from '../auth/auth-flags';
 import { checkAuth, isTokenStillValid } from '../auth/login';
 import { ZeErrors, ZephyrError } from '../errors';
 import { makeRequest } from '../http/http-request';
@@ -417,63 +418,62 @@ async function loadGlobalGitInfo(
 
 /** Get user info from API endpoint instead of JWT decoding */
 async function getUserInfoFromAPI(): Promise<UserInfo> {
-  let authenticationAttempted = false;
-  const authenticate = async () => {
-    authenticationAttempted = true;
-    try {
+  try {
+    let authenticationAttempted = false;
+    const authenticate = async () => {
+      authenticationAttempted = true;
       await checkAuth();
-    } catch (error) {
-      throw ZephyrError.withContext(error, 'get-user-info');
-    }
-  };
+    };
 
-  while (true) {
-    const token = await getToken();
-    if (!token || !isTokenStillValid(token, 60)) {
-      if (authenticationAttempted) {
-        throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
-          message: 'No valid authentication token was available after login.',
-          operation: 'get-user-info',
-        });
-      }
+    while (true) {
+      const token = await getToken();
+      if (!token || !isTokenStillValid(token, TOKEN_EXPIRY.SHORT_VALIDITY_CHECK_SEC)) {
+        if (authenticationAttempted) {
+          throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+            message: 'No valid authentication token was available after login.',
+          });
+        }
 
-      await authenticate();
-      continue;
-    }
-
-    const [ok, cause, response] = await makeRequest<{ value: UserInfo }>(
-      {
-        path: ze_api_gateway.user_info,
-        base: ZE_API_ENDPOINT(),
-        query: {},
-      },
-      {
-        headers: { Authorization: `Bearer ${token}` },
-        credentialToken: token,
-      }
-    );
-
-    if (!ok) {
-      if (
-        !authenticationAttempted &&
-        !hasSecretToken() &&
-        ZephyrError.is(cause, ZeErrors.ERR_AUTH_ERROR)
-      ) {
         await authenticate();
         continue;
       }
 
-      throw ZephyrError.withContext(cause, 'get-user-info');
+      const [ok, cause, response] = await makeRequest<{ value: UserInfo }>(
+        {
+          path: ze_api_gateway.user_info,
+          base: ZE_API_ENDPOINT(),
+          query: {},
+        },
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          credentialToken: token,
+        }
+      );
+
+      if (!ok) {
+        if (
+          !authenticationAttempted &&
+          !hasSecretToken() &&
+          ZephyrError.is(cause, ZeErrors.ERR_AUTH_ERROR)
+        ) {
+          await authenticate();
+          continue;
+        }
+
+        throw cause;
+      }
+
+      const userData = response.value;
+
+      ze_log.git('Retrieved user info from API:', {
+        name: userData.name,
+        email: userData.email,
+      });
+
+      return userData;
     }
-
-    const userData = response.value;
-
-    ze_log.git('Retrieved user info from API:', {
-      name: userData.name,
-      email: userData.email,
-    });
-
-    return userData;
+  } catch (error) {
+    throw ZephyrError.withContext(error, 'get-user-info');
   }
 }
 

--- a/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
+++ b/libs/zephyr-agent/src/lib/build-context/ze-util-get-git-info.ts
@@ -3,8 +3,8 @@ import { execFile as node_execFile } from 'node:child_process';
 import { sep } from 'node:path';
 import { promisify } from 'node:util';
 import type { ZephyrPluginOptions } from 'zephyr-edge-contract';
-import { ZE_API_ENDPOINT } from 'zephyr-edge-contract';
-import { isTokenStillValid } from '../auth/login';
+import { ZEPHYR_API_ENDPOINT } from 'zephyr-edge-contract';
+import { checkAuth, isTokenStillValid } from '../auth/login';
 import { ZeErrors, ZephyrError } from '../errors';
 import { makeRequest } from '../http/http-request';
 import { ze_log } from '../logging';
@@ -67,8 +67,12 @@ export async function getGitInfo(
   context?: string,
   zephyrConfig: ResolvedZephyrConfig = getZephyrConfig(context)
 ): Promise<ZeGitInfo> {
-  // Always gather fresh git info for build accuracy
-  return await gatherGitInfo(resolveZephyrContextDirectory(context), zephyrConfig);
+  try {
+    // Always gather fresh git info for build accuracy
+    return await gatherGitInfo(resolveZephyrContextDirectory(context), zephyrConfig);
+  } catch (error) {
+    throw ZephyrError.withContext(error, 'resolve-git-metadata');
+  }
 }
 
 /** Internal function that actually gathers git information. */
@@ -111,40 +115,15 @@ async function gatherGitInfo(
       });
     }
 
-    if (!hasConfiguredApp(zephyrConfig)) {
-      // If git repo info is not available, try global git config
-      logFn(
-        'warn',
-        'Git repository not found. Zephyr REQUIRES a git repository with remote origin.'
-      );
-      logFn(
-        'warn',
-        'Manual configuration is NOT recommended and WILL cause errors in production.'
-      );
-      logFn('warn', '');
-      logFn('warn', 'To properly use Zephyr, you MUST:');
-      logFn('warn', '1. Initialize git: git init');
-      logFn('warn', '2. Add remote: git remote add origin git@github.com:ORG/REPO.git');
-      logFn(
-        'warn',
-        '3. For CI/production reliability, add at least one commit: git add . && git commit -m "Initial commit"'
-      );
-      logFn('warn', '');
-      logFn(
-        'warn',
-        'Alternative: Use our CLI for automatic setup: npx create-zephyr-apps'
-      );
-      logFn('warn', '📝 Documentation: https://docs.zephyr-cloud.io');
-    }
     ze_log.git('Git repository not found, falling back to global git config');
 
     try {
       const globalGitInfo = await loadGlobalGitInfo(context, zephyrConfig);
       return globalGitInfo;
     } catch {
-      // If global git config also fails, use defaults
-      logFn('warn', 'Global git config not found, using auto-generated defaults');
-      ze_log.git('Global git config not found, using auto-generated defaults');
+      // If global git config also fails, use authenticated user metadata.
+      logFn('warn', 'Global git config not found, checking authenticated user metadata');
+      ze_log.git('Global git config not found, checking authenticated user metadata');
 
       const fallbackInfo = await getFallbackGitInfo(context, zephyrConfig);
       return fallbackInfo;
@@ -438,35 +417,64 @@ async function loadGlobalGitInfo(
 
 /** Get user info from API endpoint instead of JWT decoding */
 async function getUserInfoFromAPI(): Promise<UserInfo> {
-  const token = await getToken();
-  if (!token || !isTokenStillValid(token, 60)) {
-    throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
-      message: 'No valid authentication token found. Please login first.',
+  let authenticationAttempted = false;
+  const authenticate = async () => {
+    authenticationAttempted = true;
+    try {
+      await checkAuth();
+    } catch (error) {
+      throw ZephyrError.withContext(error, 'get-user-info');
+    }
+  };
+
+  while (true) {
+    const token = await getToken();
+    if (!token || !isTokenStillValid(token, 60)) {
+      if (authenticationAttempted) {
+        throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+          message: 'No valid authentication token was available after login.',
+          operation: 'get-user-info',
+        });
+      }
+
+      await authenticate();
+      continue;
+    }
+
+    const [ok, cause, response] = await makeRequest<{ value: UserInfo }>(
+      {
+        path: '/v2/user/me',
+        base: ZEPHYR_API_ENDPOINT(),
+        query: {},
+      },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        credentialToken: token,
+      }
+    );
+
+    if (!ok) {
+      if (
+        !authenticationAttempted &&
+        !hasSecretToken() &&
+        ZephyrError.is(cause, ZeErrors.ERR_AUTH_ERROR)
+      ) {
+        await authenticate();
+        continue;
+      }
+
+      throw ZephyrError.withContext(cause, 'get-user-info');
+    }
+
+    const userData = response.value;
+
+    ze_log.git('Retrieved user info from API:', {
+      name: userData.name,
+      email: userData.email,
     });
+
+    return userData;
   }
-
-  const [ok, cause, response] = await makeRequest<{ value: UserInfo }>({
-    path: '/v2/user/me',
-    base: ZE_API_ENDPOINT(),
-    query: {},
-  });
-
-  if (!ok) {
-    throw new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
-      message:
-        'Failed to get user information from API. Please ensure you are logged in with a valid token.',
-      cause,
-    });
-  }
-
-  const userData = response.value;
-
-  ze_log.git('Retrieved user info from API:', {
-    name: userData.name,
-    email: userData.email,
-  });
-
-  return userData;
 }
 
 /** Generate fallback git info when git is completely unavailable */

--- a/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.test.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.test.ts
@@ -138,6 +138,20 @@ describe('getApplicationConfiguration', () => {
     });
   });
 
+  it('attributes token resolution failures to the configuration operation', async () => {
+    mockGetToken.mockRejectedValue(
+      new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+        message: 'Authentication token unavailable',
+      })
+    );
+
+    await expect(getApplicationConfiguration({ application_uid })).rejects.toMatchObject({
+      code: 'ZE10018',
+      operation: 'get-application-config',
+      reason: 'ZE10018',
+    });
+  });
+
   // Test in-memory caching
   it('should use cached config and not call getAppConfig again', async () => {
     // First call - sets up the cache

--- a/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.test.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.test.ts
@@ -3,6 +3,7 @@ import {
   getApplicationConfiguration,
   invalidateApplicationConfigCache,
 } from './get-application-configuration';
+import { ZeErrors, ZephyrError } from '../errors';
 
 const mocks = rs.hoisted(() => ({
   makeRequest: rs.fn(),
@@ -41,6 +42,7 @@ rs.mock('../node-persist/application-configuration', () => ({
 rs.mock('../logging', () => ({ ze_log: { app: rs.fn() } }));
 rs.mock('../logging/ze-log-event', () => ({ logFn: rs.fn() }));
 rs.mock('zephyr-edge-contract', () => ({
+  formatString: (message: string) => message,
   ze_api_gateway: {
     application_config: '/api/v1/application-config',
   },
@@ -119,6 +121,21 @@ describe('getApplicationConfiguration', () => {
     expect(mockMakeRequest).toHaveBeenCalled();
     expect(mockSaveAppConfig).toHaveBeenCalled();
     expect(result).toMatchObject(newConfig);
+  });
+
+  it('preserves a forbidden reason while naming the configuration operation', async () => {
+    const cause = new ZephyrError(ZeErrors.ERR_AUTH_FORBIDDEN_ERROR, {
+      message: 'Target access denied',
+    });
+    mockGetAppConfig.mockResolvedValue(null);
+    mockMakeRequest.mockResolvedValue([false, cause]);
+
+    await expect(getApplicationConfiguration({ application_uid })).rejects.toMatchObject({
+      code: 'ZE20014',
+      operation: 'get-application-config',
+      reason: 'ZE10022',
+      cause,
+    });
   });
 
   // Test in-memory caching

--- a/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.ts
@@ -104,61 +104,65 @@ async function loadApplicationConfiguration(
 export async function getApplicationConfiguration({
   application_uid,
 }: GetApplicationConfigurationProps): Promise<ZeApplicationConfig> {
-  if (!application_uid) {
-    throw new ZephyrError(ZeErrors.ERR_MISSING_APPLICATION_UID);
-  }
-
-  // Token resolution must happen before every fast-cache lookup. The scope stores only
-  // its one-way fingerprint, so a rotated principal cannot hit a previous principal's
-  // memory cache, single-flight request, or persisted record.
-  const token = await getToken();
-  const scope = getApplicationConfigStorageScope(token);
-  const identity = getApplicationIdentity(scope, application_uid);
-  const cachedConfig = cachedConfigByIdentity.get(identity);
-
-  // Fast path: we already have a valid cached config
-  if (isValidConfig(cachedConfig, application_uid)) {
-    ze_log.app('Using cached application configuration');
-    return cachedConfig;
-  }
-  cachedConfigByIdentity.delete(identity);
-
-  // Another request for this identity is already in flight → piggy-back on it
-  const existingRequest = inFlightByIdentity.get(identity);
-  if (existingRequest) return existingRequest;
-
-  // We're the first caller → actually start the fetch
-  ze_log.app('Getting application configuration from node-persist');
-
-  const request = (async () => {
-    const storedAppConfig = await getAppConfig(application_uid, scope);
-
-    if (!isValidConfig(storedAppConfig, application_uid)) {
-      ze_log.app('Loading Application Configuration from API...');
-      const loadedAppConfig = await loadApplicationConfiguration(
-        { application_uid },
-        scope,
-        token
-      );
-      ze_log.app('Saving Application Configuration to node-persist...');
-      await saveAppConfig(application_uid, loadedAppConfig, scope);
-      return loadedAppConfig;
-    } else {
-      return storedAppConfig;
+  try {
+    if (!application_uid) {
+      throw new ZephyrError(ZeErrors.ERR_MISSING_APPLICATION_UID);
     }
-  })()
-    .then((config) => {
-      cachedConfigByIdentity.set(identity, config);
-      return config;
-    })
-    .finally(() => {
-      if (inFlightByIdentity.get(identity) === request) {
-        inFlightByIdentity.delete(identity);
-      }
-    });
 
-  inFlightByIdentity.set(identity, request);
-  return request;
+    // Token resolution must happen before every fast-cache lookup. The scope stores only
+    // its one-way fingerprint, so a rotated principal cannot hit a previous principal's
+    // memory cache, single-flight request, or persisted record.
+    const token = await getToken();
+    const scope = getApplicationConfigStorageScope(token);
+    const identity = getApplicationIdentity(scope, application_uid);
+    const cachedConfig = cachedConfigByIdentity.get(identity);
+
+    // Fast path: we already have a valid cached config
+    if (isValidConfig(cachedConfig, application_uid)) {
+      ze_log.app('Using cached application configuration');
+      return cachedConfig;
+    }
+    cachedConfigByIdentity.delete(identity);
+
+    // Another request for this identity is already in flight → piggy-back on it
+    const existingRequest = inFlightByIdentity.get(identity);
+    if (existingRequest) return existingRequest;
+
+    // We're the first caller → actually start the fetch
+    ze_log.app('Getting application configuration from node-persist');
+
+    const request = (async () => {
+      const storedAppConfig = await getAppConfig(application_uid, scope);
+
+      if (!isValidConfig(storedAppConfig, application_uid)) {
+        ze_log.app('Loading Application Configuration from API...');
+        const loadedAppConfig = await loadApplicationConfiguration(
+          { application_uid },
+          scope,
+          token
+        );
+        ze_log.app('Saving Application Configuration to node-persist...');
+        await saveAppConfig(application_uid, loadedAppConfig, scope);
+        return loadedAppConfig;
+      } else {
+        return storedAppConfig;
+      }
+    })()
+      .then((config) => {
+        cachedConfigByIdentity.set(identity, config);
+        return config;
+      })
+      .finally(() => {
+        if (inFlightByIdentity.get(identity) === request) {
+          inFlightByIdentity.delete(identity);
+        }
+      });
+
+    inFlightByIdentity.set(identity, request);
+    return await request;
+  } catch (error) {
+    throw ZephyrError.withContext(error, 'get-application-config');
+  }
 }
 
 /** Invalidate the cached application configuration */

--- a/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-application-configuration.ts
@@ -81,6 +81,7 @@ async function loadApplicationConfiguration(
   if (!ok || !data?.value || data.value.application_uid !== application_uid) {
     throw new ZephyrError(ZeErrors.ERR_LOAD_APP_CONFIG, {
       application_uid,
+      operation: 'get-application-config',
       cause,
       data: {
         url: application_config_url.toString(),

--- a/libs/zephyr-agent/src/lib/edge-requests/get-build-id.test.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-build-id.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+import { ZeErrors, ZephyrError } from '../errors';
+import { getBuildId } from './get-build-id';
+
+const mocks = rs.hoisted(() => ({
+  getApplicationConfiguration: rs.fn(),
+  getToken: rs.fn(),
+  makeRequest: rs.fn(),
+}));
+
+rs.mock('./get-application-configuration', () => ({
+  getApplicationConfiguration: mocks.getApplicationConfiguration,
+}));
+rs.mock('../node-persist/token', () => ({ getToken: mocks.getToken }));
+rs.mock('../http/http-request', () => ({ makeRequest: mocks.makeRequest }));
+rs.mock('../logging', () => ({ ze_log: { app: rs.fn() } }));
+
+describe('getBuildId', () => {
+  beforeEach(() => {
+    rs.clearAllMocks();
+    mocks.getApplicationConfiguration.mockResolvedValue({
+      BUILD_ID_ENDPOINT: 'https://build-id.example/',
+      user_uuid: 'user-123',
+      jwt: 'write-capability',
+      username: 'developer',
+    });
+    mocks.getToken.mockResolvedValue('access-token');
+  });
+
+  it('preserves a forbidden reason while naming the Build-ID operation', async () => {
+    const cause = new ZephyrError(ZeErrors.ERR_AUTH_FORBIDDEN_ERROR, {
+      message: 'Write access denied for app.project.org',
+    });
+    mocks.makeRequest.mockResolvedValue([false, cause]);
+
+    await expect(getBuildId('app.project.org')).rejects.toMatchObject({
+      code: 'ZE10019',
+      operation: 'create-build-id',
+      reason: 'ZE10022',
+      cause,
+    });
+  });
+
+  it('does not retain an unexpected Build-ID response payload', async () => {
+    mocks.makeRequest.mockResolvedValue([
+      true,
+      null,
+      { unexpected: 'private-authentication-payload' },
+    ]);
+
+    const error = await getBuildId('app.project.org').catch((value) => value);
+
+    expect(error).toMatchObject({
+      code: 'ZE10019',
+      operation: 'create-build-id',
+      reason: 'ZE10019',
+      data: { responseKeys: ['unexpected'] },
+    });
+    expect(JSON.stringify(error)).not.toContain('private-authentication-payload');
+  });
+
+  it('preserves service unavailability as the Build-ID reason', async () => {
+    const cause = new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
+      method: 'GET',
+      url: 'https://build-id.example/',
+      status: 503,
+      content: 'Service unavailable',
+    });
+    mocks.makeRequest.mockResolvedValue([false, cause]);
+
+    await expect(getBuildId('app.project.org')).rejects.toMatchObject({
+      code: 'ZE10019',
+      operation: 'create-build-id',
+      reason: 'ZE40035',
+      cause,
+    });
+  });
+
+  it('returns a Build ID using scoped authentication credentials', async () => {
+    mocks.makeRequest.mockResolvedValue([true, null, { 'user-123': 'build-456' }]);
+
+    await expect(getBuildId('app.project.org')).resolves.toBe('build-456');
+    expect(mocks.makeRequest).toHaveBeenCalledWith('https://build-id.example/', {
+      headers: {
+        can_write_jwt: 'write-capability',
+        Authorization: 'Bearer access-token',
+      },
+      credentialToken: 'access-token',
+    });
+  });
+});

--- a/libs/zephyr-agent/src/lib/edge-requests/get-build-id.test.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-build-id.test.ts
@@ -76,6 +76,35 @@ describe('getBuildId', () => {
     });
   });
 
+  it('attributes token resolution failures to the Build-ID operation', async () => {
+    mocks.getToken.mockRejectedValue(
+      new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+        message: 'Authentication token unavailable',
+      })
+    );
+
+    await expect(getBuildId('app.project.org')).rejects.toMatchObject({
+      code: 'ZE10018',
+      operation: 'create-build-id',
+      reason: 'ZE10018',
+    });
+  });
+
+  it('preserves application configuration context during Build-ID setup', async () => {
+    mocks.getApplicationConfiguration.mockRejectedValue(
+      new ZephyrError(ZeErrors.ERR_LOAD_APP_CONFIG, {
+        application_uid: 'app.project.org',
+        operation: 'get-application-config',
+      })
+    );
+
+    await expect(getBuildId('app.project.org')).rejects.toMatchObject({
+      code: 'ZE20014',
+      operation: 'get-application-config',
+      reason: 'ZE20014',
+    });
+  });
+
   it('returns a Build ID using scoped authentication credentials', async () => {
     mocks.makeRequest.mockResolvedValue([true, null, { 'user-123': 'build-456' }]);
 

--- a/libs/zephyr-agent/src/lib/edge-requests/get-build-id.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-build-id.ts
@@ -29,8 +29,9 @@ export async function getBuildId(application_uid: string): Promise<string> {
     throw new ZephyrError(ZeErrors.ERR_GET_BUILD_ID, {
       application_uid,
       username,
+      operation: 'create-build-id',
       cause,
-      data,
+      data: { responseKeys: Object.keys(data ?? {}) },
     });
   }
 

--- a/libs/zephyr-agent/src/lib/edge-requests/get-build-id.ts
+++ b/libs/zephyr-agent/src/lib/edge-requests/get-build-id.ts
@@ -5,36 +5,39 @@ import { getToken } from '../node-persist/token';
 import { getApplicationConfiguration } from './get-application-configuration';
 
 export async function getBuildId(application_uid: string): Promise<string> {
-  const { BUILD_ID_ENDPOINT, user_uuid, jwt, username } =
-    await getApplicationConfiguration({
-      application_uid,
-    });
+  try {
+    const { BUILD_ID_ENDPOINT, user_uuid, jwt, username } =
+      await getApplicationConfiguration({
+        application_uid,
+      });
 
-  const token = await getToken();
+    const token = await getToken();
 
-  const options = {
-    headers: {
-      can_write_jwt: jwt,
-      Authorization: 'Bearer ' + token,
-    },
-    credentialToken: token,
-  };
+    const options = {
+      headers: {
+        can_write_jwt: jwt,
+        Authorization: 'Bearer ' + token,
+      },
+      credentialToken: token,
+    };
 
-  const [ok, cause, data] = await makeRequest<Record<string, string>>(
-    BUILD_ID_ENDPOINT,
-    options
-  );
+    const [ok, cause, data] = await makeRequest<Record<string, string>>(
+      BUILD_ID_ENDPOINT,
+      options
+    );
 
-  if (!ok || !data[user_uuid]) {
-    throw new ZephyrError(ZeErrors.ERR_GET_BUILD_ID, {
-      application_uid,
-      username,
-      operation: 'create-build-id',
-      cause,
-      data: { responseKeys: Object.keys(data ?? {}) },
-    });
+    if (!ok || !data[user_uuid]) {
+      throw new ZephyrError(ZeErrors.ERR_GET_BUILD_ID, {
+        application_uid,
+        username,
+        cause,
+        data: { responseKeys: Object.keys(data ?? {}) },
+      });
+    }
+
+    ze_log.app('Build ID retrieved...', data);
+    return data[user_uuid];
+  } catch (error) {
+    throw ZephyrError.withContext(error, 'create-build-id');
   }
-
-  ze_log.app('Build ID retrieved...', data);
-  return data[user_uuid];
 }

--- a/libs/zephyr-agent/src/lib/errors/codes.ts
+++ b/libs/zephyr-agent/src/lib/errors/codes.ts
@@ -128,9 +128,9 @@ Failed to load git information:
   ERR_AUTH_ERROR: {
     id: '018',
     message: `
-Failed to authenticate with Zephyr.
+Zephyr authentication is missing, invalid, or expired.
 
-Please make sure you have a valid Zephyr account and you are logged in.
+Run the deployment in an interactive terminal to complete normal browser login, or provide a valid authentication token in non-interactive environments.
 
 {{ message }}
 `,
@@ -140,13 +140,9 @@ Please make sure you have a valid Zephyr account and you are logged in.
   ERR_GET_BUILD_ID: {
     id: '019',
     message: `
-Could not generate Build ID. Ensure you meet the following requirements:
+Could not create a Build ID for {{ application_uid }} as {{ username }}.
 
-1. Your Zephyr Account ({{ username }}) has write access to {{ application_uid }}
-2. You own the repository or is a collaborator with write access.
-3. This repository has commit history and has a proper git remote origin url.
-
-When trying out public examples, make sure to fork the repository to your account so you can have write access.
+Review the reported reason below. Authentication, target access, and service availability require different recovery actions.
 
 `,
     kind: 'build',
@@ -170,9 +166,9 @@ When trying out public examples, make sure to fork the repository to your accoun
   ERR_AUTH_FORBIDDEN_ERROR: {
     id: '022',
     message: `
-User not allowed to access the requested resource.
+The authenticated Zephyr account is not allowed to access the requested target.
 
-Please make sure you are logged in with the correct Zephyr account.
+Verify the application target and account, or ask an organization administrator for access. Reconfiguring Git will not grant target access.
 
 {{ message }}
 `,
@@ -240,7 +236,7 @@ Please make sure you have set them correctly in your package.json and git reposi
 
 Failed to load Application Configuration for {{ application_uid }}.
 
-Try to remove ~/.zephyr folder and try again.
+Review the reported reason below before retrying. Do not print, export, or share credential-file contents.
 
     `,
     kind: 'deploy',

--- a/libs/zephyr-agent/src/lib/errors/zephyr-error-security.test.ts
+++ b/libs/zephyr-agent/src/lib/errors/zephyr-error-security.test.ts
@@ -47,4 +47,38 @@ describe('ZephyrError security serialization', () => {
     }
     expect(details).toContain('[Circular]');
   });
+
+  it('preserves an operation and actionable reason without changing the outer code', () => {
+    const token = 'build-id-secret-token';
+    const cause = new ZephyrError(ZeErrors.ERR_AUTH_FORBIDDEN_ERROR, {
+      message: 'Write access denied for app.project.org',
+      data: { Authorization: `Bearer ${token}` },
+    });
+    const error = new ZephyrError(ZeErrors.ERR_GET_BUILD_ID, {
+      application_uid: 'app.project.org',
+      username: 'developer',
+      operation: 'create-build-id',
+      reason: cause.code,
+      cause,
+    });
+
+    const formatted = stripAnsi(ZephyrError.format(error));
+    const serialized = JSON.stringify(error);
+    const file = formatted.match(/Complete error details available at (.+\.json)/u)?.[1];
+
+    expect(file).toBeDefined();
+    temporaryFiles.push(file as string);
+    const details = readFileSync(file as string, 'utf8');
+
+    expect(error.code).toBe('ZE10019');
+    expect(error.operation).toBe('create-build-id');
+    expect(error.reason).toBe('ZE10022');
+    expect(formatted).toContain('/errors/ze10019');
+    for (const output of [formatted, serialized, details]) {
+      expect(output).toContain('create-build-id');
+      expect(output).toContain('ZE10022');
+      expect(output).toContain('Write access denied for app.project.org');
+      expect(output).not.toContain(token);
+    }
+  });
 });

--- a/libs/zephyr-agent/src/lib/errors/zephyr-error.ts
+++ b/libs/zephyr-agent/src/lib/errors/zephyr-error.ts
@@ -31,7 +31,16 @@ import {
 export type ZephyrErrorOpts<T extends ZeErrorType> = {
   cause?: unknown;
   data?: Record<string, unknown>;
+  operation?: ZephyrErrorOperation;
+  reason?: ZeErrorCodes;
 } & Record<FindTemplates<T['message']>, string | number | boolean>;
+
+/** Stable initialization operations exposed to users and automated recovery tooling. */
+export type ZephyrErrorOperation =
+  | 'resolve-git-metadata'
+  | 'get-user-info'
+  | 'get-application-config'
+  | 'create-build-id';
 
 export const docsUrl = 'https://docs.zephyr-cloud.io/errors';
 export const discordUrl = 'https://zephyr-cloud.io/discord';
@@ -54,7 +63,13 @@ export class ZephyrError<
   public data?: Record<string, unknown>;
 
   /** Data used when templating the message */
-  readonly template?: Omit<ZephyrErrorOpts<T>, 'cause' | 'data'>;
+  readonly template?: Omit<ZephyrErrorOpts<T>, 'cause' | 'data' | 'operation' | 'reason'>;
+
+  /** The deployment operation that failed. */
+  operation?: ZephyrErrorOperation;
+
+  /** The stable error code identifying the actionable failure reason. */
+  reason!: ZeErrorCodes;
 
   /**
    * Indicates the specific original cause of the error.
@@ -93,11 +108,18 @@ export class ZephyrError<
     this.code = ZephyrError.toZeCode<K>(type);
 
     if (opts) {
-      const { cause, data, ...template } = opts;
+      const { cause, data, operation, reason, ...template } = opts;
       this.template = template;
       this.data = data;
       this.cause = cause;
+      this.operation = operation;
+      this.reason =
+        reason ??
+        (ZephyrError.is(cause)
+          ? (cause.reason ?? (cause.code as ZeErrorCodes))
+          : (this.code as ZeErrorCodes));
     }
+    this.reason ??= this.code as ZeErrorCodes;
 
     // Simpler stack traces in VIte
     if (process.env['VITE']) {
@@ -120,6 +142,22 @@ export class ZephyrError<
     }
 
     return ZephyrError.toZeCode(codeOrType) === err.code;
+  }
+
+  /** Add stable operation context without replacing an existing public error code. */
+  static withContext(
+    error: unknown,
+    operation: ZephyrErrorOperation
+  ): ZephyrError<ZeErrorKeys> {
+    const zeError = ZephyrError.is(error)
+      ? error
+      : new ZephyrError(ZeErrors.ERR_UNKNOWN, {
+          message: (error as Error)?.message || String(error),
+          cause: error,
+        });
+
+    zeError.operation ??= operation;
+    return zeError;
   }
 
   /** Formats a Zephyr error code. */
@@ -188,9 +226,11 @@ export class ZephyrError<
     const messages = [
       `${bold(underline(zeError.code))}: ${redactString(zeError.message)}`,
 
+      formatDiagnosticContext(zeError),
+
       `
 
-Visit ${cyanBright(`${docsUrl}/${zeError.code}`)} for more information
+Visit ${cyanBright(`${docsUrl}/${zeError.code.toLowerCase()}`)} for more information
 Or join our ${blue('Discord')} server at ${cyanBright(discordUrl)}
 
 `.trim(),
@@ -247,6 +287,8 @@ function format_error(err: unknown): unknown {
   return sanitizeForLogging({
     name: error.name,
     code: error.code,
+    operation: error.operation,
+    reason: error.reason,
     template: undefined,
     ...error?.template,
     data: error?.data,
@@ -254,6 +296,23 @@ function format_error(err: unknown): unknown {
     stack: split_stack(error.stack, error.message),
     cause: error.cause,
   });
+}
+
+function formatDiagnosticContext(error: ZephyrError<ZeErrorKeys>): string | undefined {
+  if (!error.operation && error.reason === error.code) {
+    return undefined;
+  }
+
+  const cause = ZephyrError.is(error.cause) ? error.cause : undefined;
+  const reasonMessage =
+    cause && cause.code === error.reason ? redactString(cause.message) : undefined;
+
+  return [
+    error.operation && `Operation: ${error.operation}`,
+    error.reason && `Reason: ${error.reason}${reasonMessage ? `: ${reasonMessage}` : ''}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
 }
 
 function split_stack(stack?: string, message?: string) {

--- a/libs/zephyr-agent/src/lib/http/http-request.test.ts
+++ b/libs/zephyr-agent/src/lib/http/http-request.test.ts
@@ -15,6 +15,7 @@ rs.mock('./fetch-with-retries', () => ({
 rs.mock('../node-persist/token', () => ({ cleanTokens: mocks.cleanTokens }));
 rs.mock('../logging/debug', () => ({
   ze_log: {
+    error: rs.fn(),
     http: mocks.httpLog,
   },
 }));
@@ -115,6 +116,27 @@ describe('Pure HTTP Request Functions', () => {
 
       expect(ok).toBe(false);
       expect(error).toBeInstanceOf(Error);
+      expect(mockCleanTokens).toHaveBeenCalledWith('rejected-token');
+    });
+
+    it('preserves 401 classification when credential cleanup fails', async () => {
+      mockFetchWithRetries.mockResolvedValueOnce({
+        status: 401,
+        text: async () => 'Unauthorized',
+        ok: false,
+      } as Response);
+      mockCleanTokens.mockRejectedValueOnce(new Error('credential storage unavailable'));
+
+      const [ok, error] = await makeHttpRequest(
+        new URL('https://api.example.com/endpoint'),
+        {
+          headers: { Authorization: 'Bearer rejected-token' },
+          credentialToken: 'rejected-token',
+        }
+      );
+
+      expect(ok).toBe(false);
+      expect(error).toMatchObject({ code: 'ZE10018', reason: 'ZE10018' });
       expect(mockCleanTokens).toHaveBeenCalledWith('rejected-token');
     });
 

--- a/libs/zephyr-agent/src/lib/http/http-request.test.ts
+++ b/libs/zephyr-agent/src/lib/http/http-request.test.ts
@@ -144,7 +144,23 @@ describe('Pure HTTP Request Functions', () => {
       const [ok, error] = await makeHttpRequest(url, { skipTokenCleanup: true });
 
       expect(ok).toBe(false);
-      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({ code: 'ZE10018', reason: 'ZE10018' });
+      expect(mockCleanTokens).not.toHaveBeenCalled();
+    });
+
+    it('classifies a 403 response as forbidden access', async () => {
+      mockFetchWithRetries.mockResolvedValueOnce({
+        status: 403,
+        text: async () => 'Forbidden',
+        ok: false,
+      } as Response);
+
+      const [ok, error] = await makeHttpRequest(
+        new URL('https://api.example.com/application-config')
+      );
+
+      expect(ok).toBe(false);
+      expect(error).toMatchObject({ code: 'ZE10022', reason: 'ZE10022' });
       expect(mockCleanTokens).not.toHaveBeenCalled();
     });
 

--- a/libs/zephyr-agent/src/lib/http/http-request.ts
+++ b/libs/zephyr-agent/src/lib/http/http-request.ts
@@ -99,17 +99,18 @@ export async function makeHttpRequest<T = void>(
 
     const resText = await response.text();
 
-    if (response.status === 401 && !skipTokenCleanup) {
-      // Clean the tokens and throw an error
-      await cleanTokens(credentialToken);
+    if (response.status === 401) {
+      if (!skipTokenCleanup) {
+        await cleanTokens(credentialToken);
+      }
       throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
-        message: 'Unauthenticated request',
+        message: 'The request authentication is invalid or expired.',
       });
     }
 
     if (response.status === 403) {
       throw new ZephyrError(ZeErrors.ERR_AUTH_FORBIDDEN_ERROR, {
-        message: 'Unauthorized request',
+        message: 'The authenticated account does not have access to this target.',
       });
     }
 

--- a/libs/zephyr-agent/src/lib/http/http-request.ts
+++ b/libs/zephyr-agent/src/lib/http/http-request.ts
@@ -100,12 +100,19 @@ export async function makeHttpRequest<T = void>(
     const resText = await response.text();
 
     if (response.status === 401) {
-      if (!skipTokenCleanup) {
-        await cleanTokens(credentialToken);
-      }
-      throw new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+      const authenticationError = new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
         message: 'The request authentication is invalid or expired.',
       });
+
+      if (!skipTokenCleanup) {
+        try {
+          await cleanTokens(credentialToken);
+        } catch (error) {
+          ze_log.error('Failed to remove rejected authentication credentials:', error);
+        }
+      }
+
+      throw authenticationError;
     }
 
     if (response.status === 403) {

--- a/libs/zephyr-agent/src/zephyr-engine/__test__/engine-lifecycle.test.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/__test__/engine-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, rs } from '@rstest/core';
 import type { ZeApplicationConfig } from '../../lib/node-persist/upload-provider-options';
-import { ApplicationContext, ZephyrEngine } from '../index';
+import { ZeErrors, ZephyrError } from '../../lib/errors';
+import { ApplicationContext, ZephyrEngine } from '../../index';
 
 const mocks = rs.hoisted(() => ({
   getBuildId: rs.fn(),
@@ -111,7 +112,12 @@ describe('ZephyrEngine build lifecycle', () => {
     mocks.getPackageJson.mockResolvedValue({ name: 'package-app', version: '1.0.0' });
     mocks.getGitInfo.mockResolvedValue({
       app: { org: config.org, project: config.project },
-      git: { name: 'Developer', email: 'developer@example.com', branch: 'main' },
+      git: {
+        name: 'Developer',
+        email: 'developer@example.com',
+        branch: 'no-git-user-id-20260908',
+        commit: 'fallback-deployment-1788912000000',
+      },
     });
     mocks.getApplicationConfiguration.mockResolvedValue(appConfig());
     mocks.getBuildId.mockResolvedValue('configured-build-id');
@@ -137,6 +143,91 @@ describe('ZephyrEngine build lifecycle', () => {
       'configured-app.configured-project.configured-org'
     );
     value.build_failed();
+  });
+
+  it('preserves each stable reason through the public engine entry', async () => {
+    const failures = [
+      new ZephyrError(ZeErrors.ERR_NO_GIT_INFO, {
+        message: 'Stable Git metadata is required',
+        operation: 'resolve-git-metadata',
+      }),
+      new ZephyrError(ZeErrors.ERR_AUTH_ERROR, {
+        message: 'Browser authentication timed out',
+        operation: 'get-user-info',
+      }),
+      new ZephyrError(ZeErrors.ERR_AUTH_FORBIDDEN_ERROR, {
+        message: 'Target access denied',
+        operation: 'get-user-info',
+      }),
+      new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
+        method: 'GET',
+        url: 'https://api.zephyr-cloud.io/v2/user/me',
+        status: 503,
+        content: 'Service unavailable',
+        operation: 'get-user-info',
+      }),
+    ];
+    mocks.getZephyrConfig.mockReturnValue({});
+    mocks.getPackageJson.mockResolvedValue({ name: 'package-app', version: '1.0.0' });
+
+    for (const failure of failures) {
+      mocks.getGitInfo.mockRejectedValueOnce(failure);
+      await expect(
+        ZephyrEngine.create({ builder: 'vite', context: '/workspace/no-git-app' })
+      ).rejects.toBe(failure);
+      expect(failure.reason).toBe(failure.code);
+    }
+  });
+
+  it('preserves configuration and Build-ID reasons through the public engine entry', async () => {
+    const forbidden = new ZephyrError(ZeErrors.ERR_AUTH_FORBIDDEN_ERROR, {
+      message: 'Target access denied',
+    });
+    const configFailure = new ZephyrError(ZeErrors.ERR_LOAD_APP_CONFIG, {
+      application_uid: 'app.project.org',
+      operation: 'get-application-config',
+      cause: forbidden,
+    });
+    const unavailable = new ZephyrError(ZeErrors.ERR_HTTP_ERROR, {
+      method: 'GET',
+      url: 'https://build-id.example/',
+      status: 503,
+      content: 'Service unavailable',
+    });
+    const buildIdFailure = new ZephyrError(ZeErrors.ERR_GET_BUILD_ID, {
+      application_uid: 'app.project.org',
+      username: 'developer',
+      operation: 'create-build-id',
+      cause: unavailable,
+    });
+    mocks.getZephyrConfig.mockReturnValue({});
+    mocks.getPackageJson.mockResolvedValue({ name: 'app', version: '1.0.0' });
+    mocks.getGitInfo.mockResolvedValue({
+      app: { org: 'org', project: 'project' },
+      git: { name: 'Developer', email: 'developer@example.com', branch: 'main' },
+    });
+
+    mocks.getApplicationConfiguration.mockRejectedValueOnce(configFailure);
+    mocks.getBuildId.mockResolvedValueOnce('unused-build-id');
+    await expect(
+      ZephyrEngine.create({ builder: 'vite', context: '/workspace/app' })
+    ).rejects.toBe(configFailure);
+    expect(configFailure).toMatchObject({
+      code: 'ZE20014',
+      operation: 'get-application-config',
+      reason: 'ZE10022',
+    });
+
+    mocks.getApplicationConfiguration.mockResolvedValueOnce(appConfig());
+    mocks.getBuildId.mockRejectedValueOnce(buildIdFailure);
+    await expect(
+      ZephyrEngine.create({ builder: 'vite', context: '/workspace/app' })
+    ).rejects.toBe(buildIdFailure);
+    expect(buildIdFailure).toMatchObject({
+      code: 'ZE10019',
+      operation: 'create-build-id',
+      reason: 'ZE40035',
+    });
   });
 
   it('reports active ownership until the generation is rolled back', () => {

--- a/libs/zephyr-agent/src/zephyr-engine/__test__/public-error-contract.test.ts
+++ b/libs/zephyr-agent/src/zephyr-engine/__test__/public-error-contract.test.ts
@@ -1,0 +1,170 @@
+// Given controlled API failures, when the public engine initializes, then operation and reason survive every internal boundary.
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+import { execFile as nodeExecFile } from 'node:child_process';
+import { ZephyrEngine } from '../../index';
+import { invalidateApplicationConfigCache } from '../../lib/edge-requests/get-application-configuration';
+
+const mocks = rs.hoisted(() => ({
+  checkAuth: rs.fn(),
+  cleanTokens: rs.fn(),
+  fetchWithRetries: rs.fn(),
+  getAppConfig: rs.fn(),
+  getHashList: rs.fn(),
+  getPackageJson: rs.fn(),
+  getToken: rs.fn(),
+  logger: rs.fn(),
+  saveAppConfig: rs.fn(),
+}));
+
+rs.mock('ci-info', () => ({ isCI: false }));
+rs.mock('node:child_process', () => ({ execFile: rs.fn() }));
+rs.mock('../../lib/auth/login', () => ({
+  checkAuth: mocks.checkAuth,
+  isTokenStillValid: rs.fn(() => true),
+}));
+rs.mock('../../lib/build-context/ze-util-read-package-json', () => ({
+  getPackageJson: mocks.getPackageJson,
+}));
+rs.mock('../../lib/build-context/zephyr-config', () => ({
+  getZephyrConfig: rs.fn(() => ({
+    org: 'test-org',
+    project: 'test-project',
+    appName: 'test-app',
+  })),
+  mergeRemoteDependencies: rs.fn(),
+  resolveZephyrContextDirectory: rs.fn((context: string) => context),
+}));
+rs.mock('../../lib/edge-hash-list/distributed-hash-control', () => ({
+  get_hash_list: mocks.getHashList,
+}));
+rs.mock('../../lib/http/fetch-with-retries', () => ({
+  fetchWithRetries: mocks.fetchWithRetries,
+}));
+rs.mock('../../lib/logging', () => ({
+  ze_log: {
+    app: rs.fn(),
+    auth: rs.fn(),
+    git: rs.fn(),
+    init: rs.fn(),
+  },
+}));
+rs.mock('../../lib/logging/debug', () => ({
+  ze_log: { error: rs.fn(), http: rs.fn() },
+}));
+rs.mock('../../lib/logging/ze-log-event', () => ({
+  logger: rs.fn(() => mocks.logger),
+  logFn: rs.fn(),
+}));
+rs.mock('../../lib/node-persist/application-configuration', () => ({
+  getAppConfig: mocks.getAppConfig,
+  getApplicationConfigStorageScope: rs.fn(() => ({
+    apiEndpoint: 'https://api.example',
+    apiGatewayEndpoint: 'https://gateway.example',
+    environment: null,
+    preview: false,
+    principalFingerprint: 'test-principal',
+  })),
+  saveAppConfig: mocks.saveAppConfig,
+}));
+rs.mock('../../lib/node-persist/secret-token', () => ({
+  getSecretToken: rs.fn(() => 'test-access-token'),
+  hasSecretToken: rs.fn(() => true),
+}));
+rs.mock('../../lib/node-persist/token', () => ({
+  cleanTokens: mocks.cleanTokens,
+  getToken: mocks.getToken,
+}));
+rs.mock('../../lib/version/outdated-plugin-warning', () => ({
+  maybeShowOutdatedPluginWarning: rs.fn(),
+}));
+
+type ExecCallback = (error: Error, stdout: string, stderr: string) => void;
+
+function jsonResponse(status: number, value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('public initialization error contract', () => {
+  beforeEach(() => {
+    rs.clearAllMocks();
+    invalidateApplicationConfigCache();
+    mocks.checkAuth.mockResolvedValue(undefined);
+    mocks.getAppConfig.mockResolvedValue(null);
+    mocks.getHashList.mockResolvedValue({ hash_set: new Set<string>() });
+    mocks.getPackageJson.mockResolvedValue({ name: 'test-app', version: '1.0.0' });
+    mocks.getToken.mockResolvedValue('test-access-token');
+    mocks.saveAppConfig.mockImplementation(
+      async (_applicationUid: string, config: unknown) => config
+    );
+    (nodeExecFile as unknown as ReturnType<typeof rs.fn>).mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecCallback) =>
+        callback(new Error('Not a git repository'), '', 'fatal: not a repository')
+    );
+  });
+
+  it.each([
+    [401, 'ZE10018', 'ZE10018'],
+    [403, 'ZE10022', 'ZE10022'],
+    [503, 'ZE40035', 'ZE40035'],
+  ] as const)(
+    'preserves a %i user-info failure through the package entry',
+    async (status, code, reason) => {
+      mocks.fetchWithRetries.mockResolvedValueOnce(jsonResponse(status, { status }));
+
+      await expect(
+        ZephyrEngine.create({ builder: 'vite', context: '/workspace/test-app' })
+      ).rejects.toMatchObject({ code, operation: 'get-user-info', reason });
+    }
+  );
+
+  it('preserves application access denial through the package entry', async () => {
+    mocks.fetchWithRetries
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          value: { name: 'Test User', email: 'user@example.com', id: 'user-id' },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse(403, { message: 'Forbidden' }));
+
+    await expect(
+      ZephyrEngine.create({ builder: 'vite', context: '/workspace/test-app' })
+    ).rejects.toMatchObject({
+      code: 'ZE20014',
+      operation: 'get-application-config',
+      reason: 'ZE10022',
+    });
+  });
+
+  it('preserves Build-ID service failure through the package entry', async () => {
+    mocks.fetchWithRetries
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          value: { name: 'Test User', email: 'user@example.com', id: 'user-id' },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          value: {
+            application_uid: 'test-app.test-project.test-org',
+            BUILD_ID_ENDPOINT: 'https://build-id.example',
+            EDGE_URL: 'https://edge.example',
+            jwt: 'write-capability',
+            user_uuid: 'user-id',
+            username: 'test-user',
+          },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse(503, { message: 'Unavailable' }));
+
+    await expect(
+      ZephyrEngine.create({ builder: 'vite', context: '/workspace/test-app' })
+    ).rejects.toMatchObject({
+      code: 'ZE10019',
+      operation: 'create-build-id',
+      reason: 'ZE40035',
+    });
+  });
+});

--- a/libs/zephyr-edge-contract/src/lib/api-contract-negotiation/get-api-contract.ts
+++ b/libs/zephyr-edge-contract/src/lib/api-contract-negotiation/get-api-contract.ts
@@ -19,6 +19,7 @@ export const ze_api_gateway = {
   authorize_link: '/authorize-link',
   resolve: '/resolve',
   application_config: '/application-config',
+  user_info: '/user-info',
   websocket: '/websocket',
   get_access_token_by_server_token: 'get-access-token-by-server-token',
   ci_token_exchange: 'ci-token-exchange',


### PR DESCRIPTION
## Summary

- preserve stable Git, authentication, forbidden, service, application-config, and Build-ID failure reasons through initialization
- add public `operation` and `reason` diagnostics without renumbering existing ZE codes
- run normal browser authentication once for interactive no-Git fallback, while keeping CI and non-TTY execution fail-closed
- route authenticated user lookup through the canonical API gateway `/user-info` contract with scoped credential invalidation
- keep 401 classification independent from credential cleanup
- redact unexpected Build-ID payloads and align recovery guidance with the failing reason

## Verification

- `pnpm --filter zephyr-edge-contract test`
- `pnpm --filter zephyr-edge-contract typecheck`
- `pnpm --filter zephyr-edge-contract build`
- `pnpm --filter zephyr-agent test` (376 tests, 371 passed, 5 skipped)
- `pnpm --filter zephyr-agent typecheck`
- `pnpm --filter zephyr-agent build`
- repository pre-commit affected tests and lint
- `pnpm format:check`
- `git diff --check`

## Cross-repository dependency

Depends on ZephyrCloudIO/zephyr-mono#577, which adds `/user-info` and proxies it to the environment-specific `/v2/user/me` API while preserving authorization and upstream responses.

Required rollout order:

1. Merge zephyr-mono#577.
2. Verify the automatic staging gateway deployment.
3. Release/deploy the zephyr-mono production gateway.
4. Smoke-test production `/user-info`.
5. Merge and release this package change.

This remains a draft while the gateway rollout, separate `zephyr-documentation` ZE10016/ZE10018/ZE10019/ZE10022 pages, and TAP downstream regression coverage are coordinated.

Closes #604