### PR TITLE
fix(metro): install publication commands in codemod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ tasks/
 **/.claude/**/*.local.*
 
 .serena
+.playwright-mcp/
 
 # Turborepo
 .turbo

--- a/libs/with-zephyr/README.md
+++ b/libs/with-zephyr/README.md
@@ -263,6 +263,17 @@ The codemod recognizes and handles various configuration patterns:
 ### Metro (React Native)
 
 - `module.exports = ...` config exports (wrapped with async `withZephyr` call)
+- React Native CLI projects get `bundle-mf-host` and `bundle-mf-remote` through
+  the existing `react-native.config.js`, `.cjs`, `.ts`, or `.mjs` file
+- RNEF projects register `zephyrMetroRNEFPlugin` in the active
+  `rnef.config.js`, `.ts`, or `.mjs` file
+- Ambiguous React Native CLI/RNEF projects are left unchanged and receive manual
+  registration instructions
+- `zephyr-metro-plugin` and `@module-federation/metro` are installed for command
+  registration; the Metro companion is pinned to the compatible `^2.9.0` range
+
+The Metro `withZephyr` wrapper is configuration-only; publication happens only
+when a registered bundle command completes its upload.
 
 ### Vite/Rolldown
 

--- a/libs/with-zephyr/README.md
+++ b/libs/with-zephyr/README.md
@@ -275,7 +275,10 @@ The codemod recognizes and handles various configuration patterns:
 - Each Metro project's own `package.json` receives `zephyr-metro-plugin@^1.4.0`
   and `@module-federation/metro@^2.9.0`; a workspace install can still run once
   at the invocation root
-- Command registration requires verifiable React Native 0.79+ and Metro 0.82+
+- Command registration follows `@module-federation/metro@2.9.0`'s peer contract:
+  React 19+, React Native 0.79+, `@babel/types` at `>=7.25.0 <8.0.0`, plus
+  `metro`, `metro-config`, `metro-file-map`, `metro-resolver`, and
+  `metro-source-map` all at `>=0.82.1 <0.83.0`
 
 The Metro `withZephyr` wrapper is configuration-only; publication happens only
 when a registered bundle command completes its upload.

--- a/libs/with-zephyr/README.md
+++ b/libs/with-zephyr/README.md
@@ -263,14 +263,19 @@ The codemod recognizes and handles various configuration patterns:
 ### Metro (React Native)
 
 - `module.exports = ...` config exports (wrapped with async `withZephyr` call)
+- Publication commands are registered only when `metro.config.*` already uses
+  `withModuleFederation` from `@module-federation/metro`; Module Federation is
+  never scaffolded automatically
 - React Native CLI projects get `bundle-mf-host` and `bundle-mf-remote` through
   the existing `react-native.config.js`, `.cjs`, `.ts`, or `.mjs` file
 - RNEF projects register `zephyrMetroRNEFPlugin` in the active
   `rnef.config.js`, `.ts`, or `.mjs` file
 - Ambiguous React Native CLI/RNEF projects are left unchanged and receive manual
   registration instructions
-- `zephyr-metro-plugin` and `@module-federation/metro` are installed for command
-  registration; the Metro companion is pinned to the compatible `^2.9.0` range
+- Each Metro project's own `package.json` receives `zephyr-metro-plugin@^1.4.0`
+  and `@module-federation/metro@^2.9.0`; a workspace install can still run once
+  at the invocation root
+- Command registration requires verifiable React Native 0.79+ and Metro 0.82+
 
 The Metro `withZephyr` wrapper is configuration-only; publication happens only
 when a registered bundle command completes its upload.

--- a/libs/with-zephyr/src/engine/ast-grep.ts
+++ b/libs/with-zephyr/src/engine/ast-grep.ts
@@ -25,7 +25,7 @@ export interface AstGrepResult {
 }
 
 export interface ExportedConfigCallOptions extends AstGrepRunOptions {
-  propertyName: 'commands' | 'plugins';
+  propertyName?: 'commands' | 'plugins';
   allowDirectExport?: boolean;
 }
 
@@ -186,16 +186,42 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
       return Boolean(identifier && exportedIdentifiers.has(identifier));
     };
 
-    return calls.some((call) => {
-      if (options.allowDirectExport) {
-        for (const ancestor of call.ancestors()) {
-          for (const pattern of ['module.exports = $VALUE', 'export default $VALUE']) {
-            if (ancestor.matches(pattern) && call.parent()?.id() === ancestor.id()) {
-              return true;
-            }
+    const isDirectlyExportedExpression = (call: SgNode): boolean => {
+      let expression = call;
+      let parent = expression.parent();
+      while (parent) {
+        for (const pattern of ['module.exports = $VALUE', 'export default $VALUE']) {
+          if (parent.matches(pattern) && expression.parent()?.id() === parent.id()) {
+            return true;
           }
         }
+
+        if (parent.kind() === 'variable_declarator') {
+          const identifier = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(parent.text())?.[1];
+          return Boolean(identifier && exportedIdentifiers.has(identifier));
+        }
+
+        const parentKind = parent.kind();
+        if (
+          parentKind !== 'call_expression' &&
+          parentKind !== 'arguments' &&
+          parentKind !== 'parenthesized_expression' &&
+          parentKind !== 'await_expression'
+        ) {
+          return false;
+        }
+        expression = parent;
+        parent = parent.parent();
       }
+      return false;
+    };
+
+    return calls.some((call) => {
+      if (options.allowDirectExport && isDirectlyExportedExpression(call)) {
+        return true;
+      }
+
+      if (!options.propertyName) return false;
 
       const property = call
         .ancestors()

--- a/libs/with-zephyr/src/engine/ast-grep.ts
+++ b/libs/with-zephyr/src/engine/ast-grep.ts
@@ -216,14 +216,8 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
       return false;
     };
 
-    return calls.some((call) => {
-      if (options.allowDirectExport && isDirectlyExportedExpression(call)) {
-        return true;
-      }
-
-      if (!options.propertyName) return false;
-
-      const property = call
+    const isRegisteredInExportedProperty = (value: SgNode): boolean => {
+      const property = value
         .ancestors()
         .find(
           (ancestor) =>
@@ -235,27 +229,56 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
       if (!property || !isExportedObject(property.parent())) return false;
 
       if (options.propertyName === 'plugins') {
-        const array = call.parent();
+        const array = value.parent();
         return Boolean(
           array?.kind() === 'array' && array.parent()?.id() === property.id()
         );
       }
 
-      const member = call.parent();
-      if (
-        member?.kind() !== 'member_expression' ||
-        !/\.\s*commands\s*$/.test(member.text())
-      ) {
-        return false;
-      }
-      if (member.parent()?.id() === property.id()) return true;
-      const spread = member.parent();
+      if (value.parent()?.id() === property.id()) return true;
+      const spread = value.parent();
       const array = spread?.parent();
       return Boolean(
         spread?.kind() === 'spread_element' &&
         array?.kind() === 'array' &&
         array.parent()?.id() === property.id()
       );
+    };
+
+    return calls.some((call) => {
+      if (options.allowDirectExport && isDirectlyExportedExpression(call)) {
+        return true;
+      }
+
+      if (!options.propertyName) return false;
+
+      if (options.propertyName === 'plugins') {
+        if (isRegisteredInExportedProperty(call)) return true;
+      } else {
+        const member = call.parent();
+        if (
+          member?.kind() === 'member_expression' &&
+          /\.\s*commands\s*$/.test(member.text()) &&
+          isRegisteredInExportedProperty(member)
+        ) {
+          return true;
+        }
+      }
+
+      const declaration = call.parent();
+      if (declaration?.kind() !== 'variable_declarator') return false;
+      const bindingName = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(declaration.text())?.[1];
+      if (!bindingName) return false;
+
+      if (options.propertyName === 'commands') {
+        return root
+          .findAll(`${bindingName}.commands`)
+          .some(isRegisteredInExportedProperty);
+      }
+      return root
+        .findAll(bindingName)
+        .filter((identifier) => identifier.kind() === 'identifier')
+        .some(isRegisteredInExportedProperty);
     });
   } catch {
     return false;

--- a/libs/with-zephyr/src/engine/ast-grep.ts
+++ b/libs/with-zephyr/src/engine/ast-grep.ts
@@ -24,6 +24,11 @@ export interface AstGrepResult {
   stdout: string;
 }
 
+export interface ExportedConfigCallOptions extends AstGrepRunOptions {
+  propertyName: 'commands' | 'plugins';
+  allowDirectExport?: boolean;
+}
+
 interface AstGrepRuntime {
   parse: (language: string, source: string) => { root: () => SgNode };
 }
@@ -148,6 +153,86 @@ export function searchWithAstGrep(options: AstGrepRunOptions): AstGrepResult {
       stdout: '',
       stderr: (error as Error).message,
     };
+  }
+}
+
+export function hasExportedConfigCall(options: ExportedConfigCallOptions): boolean {
+  try {
+    const language = options.language ?? detectLanguage(options.filePath);
+    const source = fs.readFileSync(options.filePath, 'utf8');
+    const { parse } = getAstGrepRuntime();
+    const root = parse(toNapiLanguage(language), source).root();
+    const calls = root.findAll(buildMatcher(options));
+    const exportedIdentifiers = new Set<string>();
+    for (const pattern of ['module.exports = $IDENT', 'export default $IDENT']) {
+      for (const exported of root.findAll(pattern)) {
+        const identifier = exported.getMatch('IDENT');
+        if (identifier?.kind() === 'identifier')
+          exportedIdentifiers.add(identifier.text());
+      }
+    }
+
+    const isExportedObject = (object: SgNode | null): boolean => {
+      const parent = object?.parent();
+      if (!parent) return false;
+      if (
+        parent.matches('module.exports = {$$$PROPS}') ||
+        parent.matches('export default {$$$PROPS}')
+      ) {
+        return true;
+      }
+      if (parent.kind() !== 'variable_declarator') return false;
+      const identifier = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(parent.text())?.[1];
+      return Boolean(identifier && exportedIdentifiers.has(identifier));
+    };
+
+    return calls.some((call) => {
+      if (options.allowDirectExport) {
+        for (const ancestor of call.ancestors()) {
+          for (const pattern of ['module.exports = $VALUE', 'export default $VALUE']) {
+            if (ancestor.matches(pattern) && call.parent()?.id() === ancestor.id()) {
+              return true;
+            }
+          }
+        }
+      }
+
+      const property = call
+        .ancestors()
+        .find(
+          (ancestor) =>
+            ancestor.kind() === 'pair' &&
+            new RegExp(
+              `^\\s*(?:${options.propertyName}|["']${options.propertyName}["']|\\[\\s*["']${options.propertyName}["']\\s*\\])\\s*:`
+            ).test(ancestor.text())
+        );
+      if (!property || !isExportedObject(property.parent())) return false;
+
+      if (options.propertyName === 'plugins') {
+        const array = call.parent();
+        return Boolean(
+          array?.kind() === 'array' && array.parent()?.id() === property.id()
+        );
+      }
+
+      const member = call.parent();
+      if (
+        member?.kind() !== 'member_expression' ||
+        !/\.\s*commands\s*$/.test(member.text())
+      ) {
+        return false;
+      }
+      if (member.parent()?.id() === property.id()) return true;
+      const spread = member.parent();
+      const array = spread?.parent();
+      return Boolean(
+        spread?.kind() === 'spread_element' &&
+        array?.kind() === 'array' &&
+        array.parent()?.id() === property.id()
+      );
+    });
+  } catch {
+    return false;
   }
 }
 

--- a/libs/with-zephyr/src/engine/ast-grep.ts
+++ b/libs/with-zephyr/src/engine/ast-grep.ts
@@ -186,6 +186,26 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
       return Boolean(identifier && exportedIdentifiers.has(identifier));
     };
 
+    const isReturnedFromFunction = (bindingName: string, functionNode: SgNode): boolean =>
+      root
+        .findAll(bindingName)
+        .filter((identifier) => identifier.kind() === 'identifier')
+        .some((identifier) => {
+          let ancestor = identifier.parent();
+          while (ancestor && ancestor.id() !== functionNode.id()) {
+            if (
+              ancestor.kind() === 'arrow_function' ||
+              ancestor.kind() === 'function_expression' ||
+              ancestor.kind() === 'function_declaration'
+            ) {
+              return false;
+            }
+            if (ancestor.kind() === 'return_statement') return true;
+            ancestor = ancestor.parent();
+          }
+          return false;
+        });
+
     const isDirectlyExportedExpression = (call: SgNode): boolean => {
       let expression = call;
       let parent = expression.parent();
@@ -198,7 +218,21 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
 
         if (parent.kind() === 'variable_declarator') {
           const identifier = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(parent.text())?.[1];
-          return Boolean(identifier && exportedIdentifiers.has(identifier));
+          if (!identifier) return false;
+          if (exportedIdentifiers.has(identifier)) return true;
+
+          const functionNode = parent
+            .ancestors()
+            .find(
+              (ancestor) =>
+                ancestor.kind() === 'arrow_function' ||
+                ancestor.kind() === 'function_expression'
+            );
+          return Boolean(
+            functionNode &&
+            isReturnedFromFunction(identifier, functionNode) &&
+            isDirectlyExportedExpression(functionNode)
+          );
         }
 
         const parentKind = parent.kind();

--- a/libs/with-zephyr/src/index.ts
+++ b/libs/with-zephyr/src/index.ts
@@ -31,6 +31,7 @@ import {
   installPackages as installPackagesDirect,
   isPackageInstalled,
   isPackageRequirementSatisfied,
+  isResolvedPackageRequirementSatisfied,
 } from './package-manager.js';
 import { bootstrapNextJsVinext, type PackageRequirement } from './nextjs-vinext.js';
 import { bootstrapMetroCommands } from './metro-bootstrap.js';
@@ -566,6 +567,70 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
       const installSuccess = installDependencies(directory, packageManager);
       if (installSuccess) {
         console.log(chalk.green('✓ Installed dependencies from package.json'));
+
+        const nestedProjects = new Map<string, PackageRequirement[]>();
+        for (const packageRequirement of stagedPackages) {
+          const projectDirectory = path.resolve(
+            packageRequirement.projectDirectory ?? directory
+          );
+          if (projectDirectory === path.resolve(directory)) continue;
+          nestedProjects.set(projectDirectory, [
+            ...(nestedProjects.get(projectDirectory) ?? []),
+            packageRequirement,
+          ]);
+        }
+        for (const [projectDirectory, requirements] of nestedProjects) {
+          const isUnresolved = (packageRequirement: PackageRequirement) => {
+            const minimumVersion =
+              packageRequirement.version?.match(/^\^(\d+\.\d+\.\d+)$/)?.[1];
+            const maximumVersionExclusive =
+              packageRequirement.name === '@module-federation/metro'
+                ? '3.0.0'
+                : undefined;
+            return !isResolvedPackageRequirementSatisfied(
+              packageRequirement.name,
+              projectDirectory,
+              minimumVersion,
+              maximumVersionExclusive
+            );
+          };
+          const unresolved = requirements.filter(isUnresolved);
+          if (unresolved.length === 0) continue;
+
+          const nestedPackageManager = detectPackageManager(projectDirectory, {
+            ignoreUserAgent: true,
+          });
+          const nestedInstallSuccess = installDependencies(
+            projectDirectory,
+            nestedPackageManager
+          );
+          const stillUnresolved = nestedInstallSuccess
+            ? unresolved.filter(isUnresolved)
+            : unresolved;
+          if (nestedInstallSuccess && stillUnresolved.length === 0) {
+            console.log(
+              chalk.green(
+                `✓ Installed dependencies in ${normalizePathForOutput(path.relative(path.resolve(directory), projectDirectory))}`
+              )
+            );
+          } else if (!nestedInstallSuccess) {
+            console.log(
+              chalk.red(
+                `✗ Failed to install dependencies in ${normalizePathForOutput(path.relative(path.resolve(directory), projectDirectory))}`
+              )
+            );
+            errors += stillUnresolved.length;
+            dependencyInstallFailed = true;
+          } else {
+            console.log(
+              chalk.red(
+                `✗ Installed dependencies in ${normalizePathForOutput(path.relative(path.resolve(directory), projectDirectory))}, but ${stillUnresolved.map(({ name }) => name).join(', ')} still cannot be resolved at compatible versions`
+              )
+            );
+            errors += stillUnresolved.length;
+            dependencyInstallFailed = true;
+          }
+        }
       } else {
         console.log(chalk.red('✗ Failed to install dependencies from package.json'));
         errors += stagedPackages.length;

--- a/libs/with-zephyr/src/index.ts
+++ b/libs/with-zephyr/src/index.ts
@@ -30,6 +30,7 @@ import {
   installDependencies,
   installPackages as installPackagesDirect,
   isPackageInstalled,
+  isPackageRequirementSatisfied,
 } from './package-manager.js';
 import { bootstrapNextJsVinext, type PackageRequirement } from './nextjs-vinext.js';
 import { bootstrapMetroCommands } from './metro-bootstrap.js';
@@ -281,18 +282,23 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
         updatedPackageJson: false,
         packageRequirements: [] as PackageRequirement[],
       };
-  const metroProjectDirectories = [
-    ...new Set(
-      configFiles
-        .filter(({ bundlerName }) => bundlerName === 'metro')
-        .map(({ filePath }) => path.resolve(path.dirname(filePath)))
-    ),
-  ];
+  const metroProjects = new Map<string, string[]>();
+  for (const { bundlerName, filePath } of configFiles) {
+    if (bundlerName !== 'metro') continue;
+    const projectDirectory = path.resolve(path.dirname(filePath));
+    metroProjects.set(projectDirectory, [
+      ...(metroProjects.get(projectDirectory) ?? []),
+      path.resolve(filePath),
+    ]);
+  }
   const metroBootstraps =
     !bundlers || bundlers.includes('metro')
-      ? metroProjectDirectories.map((projectDirectory) => ({
+      ? [...metroProjects].map(([projectDirectory, metroConfigFilePaths]) => ({
           projectDirectory,
-          result: bootstrapMetroCommands(projectDirectory, { dryRun }),
+          result: bootstrapMetroCommands(projectDirectory, {
+            dryRun,
+            metroConfigFilePaths,
+          }),
         }))
       : [];
 
@@ -381,23 +387,27 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
 
   // Collect unique plugins that need to be installed
   const requiredPackages = new Map<string, PackageRequirement>();
-  const metroPackageNames = new Set(
-    metroBootstraps.flatMap(({ result }) =>
-      result.packageRequirements.map(({ name }) => name)
-    )
-  );
   const packagesToProcess: ConfigFile[] = [];
   const filteredConfigFiles: ConfigFile[] = [];
+  const addRequiredPackage = (packageRequirement: PackageRequirement) => {
+    const projectDirectory = path.resolve(
+      packageRequirement.projectDirectory ?? directory
+    );
+    requiredPackages.set(`${projectDirectory}\0${packageRequirement.name}`, {
+      ...packageRequirement,
+      projectDirectory,
+    });
+  };
 
   for (const packageRequirement of nextJsBootstrap.packageRequirements) {
-    requiredPackages.set(packageRequirement.name, packageRequirement);
+    addRequiredPackage(packageRequirement);
   }
   for (const packageRequirement of slidevBootstrap.packageRequirements) {
-    requiredPackages.set(packageRequirement.name, packageRequirement);
+    addRequiredPackage(packageRequirement);
   }
   for (const { result } of metroBootstraps) {
     for (const packageRequirement of result.packageRequirements) {
-      requiredPackages.set(packageRequirement.name, packageRequirement);
+      addRequiredPackage(packageRequirement);
     }
   }
 
@@ -429,7 +439,16 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
       continue;
     }
 
-    requiredPackages.set(config.plugin, { name: config.plugin, isDev: true });
+    addRequiredPackage({
+      name: config.plugin,
+      isDev: true,
+      ...(bundlerName === 'metro'
+        ? {
+            version: '^1.4.0',
+            projectDirectory: path.resolve(path.dirname(filePath)),
+          }
+        : {}),
+    });
     packagesToProcess.push({ filePath, bundlerName, config });
   }
 
@@ -437,7 +456,17 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
   const missingPackages: PackageRequirement[] = [];
   if (installPackages) {
     for (const packageRequirement of requiredPackages.values()) {
-      if (!isPackageInstalled(packageRequirement.name, directory)) {
+      const projectDirectory = packageRequirement.projectDirectory ?? directory;
+      const minimumVersion =
+        packageRequirement.version?.match(/^\^(\d+\.\d+\.\d+)$/)?.[1];
+      const satisfied = packageRequirement.version
+        ? isPackageRequirementSatisfied(
+            packageRequirement.name,
+            projectDirectory,
+            minimumVersion
+          )
+        : isPackageInstalled(packageRequirement.name, projectDirectory);
+      if (!satisfied) {
         missingPackages.push(packageRequirement);
       }
     }
@@ -448,7 +477,7 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
     for (const packageRequirement of missingPackages) {
       console.log(
         chalk.yellow(
-          `  - ${packageRequirement.name}${packageRequirement.version ? `@${packageRequirement.version}` : ''}`
+          `  - ${packageRequirement.name}${packageRequirement.version ? `@${packageRequirement.version}` : ''}${packageRequirement.projectDirectory && path.resolve(packageRequirement.projectDirectory) !== path.resolve(directory) ? ` (${normalizePathForOutput(path.relative(path.resolve(directory), packageRequirement.projectDirectory))})` : ''}`
         )
       );
     }
@@ -477,34 +506,57 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
     const packageManager = detectPackageManager(directory);
     console.log(chalk.gray(`Detected package manager: ${packageManager}`));
 
-    const packageJsonPath = path.join(directory, 'package.json');
     const stagedPackages: PackageRequirement[] = [];
     const fallbackPackages: PackageRequirement[] = [];
 
-    if (fs.existsSync(packageJsonPath)) {
-      for (const packageRequirement of missingPackages) {
+    for (const packageRequirement of missingPackages) {
+      const projectDirectory = packageRequirement.projectDirectory ?? directory;
+      const packageJsonPath = path.join(projectDirectory, 'package.json');
+      if (fs.existsSync(packageJsonPath)) {
         const version =
           packageRequirement.version ?? getLatestVersion(packageRequirement.name);
         const added = addToPackageJson(
-          directory,
+          projectDirectory,
           packageRequirement.name,
           version,
           packageRequirement.isDev
         );
         if (added) {
           stagedPackages.push(packageRequirement);
-          console.log(chalk.green(`✓ Added ${packageRequirement.name} to package.json`));
-        } else {
+          console.log(
+            chalk.green(
+              `✓ Added ${packageRequirement.name} to ${normalizePathForOutput(path.relative(path.resolve(directory), packageJsonPath) || 'package.json')}`
+            )
+          );
+        } else if (path.resolve(projectDirectory) === path.resolve(directory)) {
           fallbackPackages.push(packageRequirement);
           console.log(
             chalk.red(
               `✗ Failed to stage ${packageRequirement.name} in package.json, falling back`
             )
           );
+        } else {
+          console.log(
+            chalk.red(
+              `✗ Failed to stage ${packageRequirement.name} in ${normalizePathForOutput(path.relative(path.resolve(directory), packageJsonPath))}`
+            )
+          );
+          errors++;
+          dependencyInstallFailed = true;
         }
+      } else if (path.resolve(projectDirectory) === path.resolve(directory)) {
+        fallbackPackages.push(packageRequirement);
+      } else {
+        console.log(
+          chalk.red(
+            `✗ No package.json found for ${normalizePathForOutput(path.relative(path.resolve(directory), projectDirectory))}`
+          )
+        );
+        errors++;
+        dependencyInstallFailed = true;
       }
-    } else {
-      fallbackPackages.push(...missingPackages);
+    }
+    if (fallbackPackages.length > 0) {
       console.log(
         chalk.yellow('No package.json found; falling back to direct package manager add')
       );
@@ -517,9 +569,7 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
       } else {
         console.log(chalk.red('✗ Failed to install dependencies from package.json'));
         errors += stagedPackages.length;
-        dependencyInstallFailed ||= stagedPackages.some(({ name }) =>
-          metroPackageNames.has(name)
-        );
+        dependencyInstallFailed = true;
       }
     }
 
@@ -551,9 +601,7 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
         } else {
           console.log(chalk.red(`✗ Failed to install ${prodPackages.join(', ')}`));
           errors += prodPackages.length;
-          dependencyInstallFailed ||= fallbackPackages.some(
-            ({ name, isDev }) => !isDev && metroPackageNames.has(name)
-          );
+          dependencyInstallFailed = true;
         }
       }
 
@@ -569,9 +617,7 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
         } else {
           console.log(chalk.red(`✗ Failed to install ${devPackages.join(', ')}`));
           errors += devPackages.length;
-          dependencyInstallFailed ||= fallbackPackages.some(
-            ({ name, isDev }) => isDev && metroPackageNames.has(name)
-          );
+          dependencyInstallFailed = true;
         }
       }
     }
@@ -586,8 +632,8 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
       }
       const command =
         result.integration === 'rnef'
-          ? 'rnef bundle-mf-remote --platform ios --dev false'
-          : 'npx react-native bundle-mf-remote --platform ios --dev false';
+          ? `rnef bundle-mf-remote --platform ${result.platformArgument} --dev false`
+          : `npx react-native bundle-mf-remote --platform ${result.platformArgument} --dev false`;
       console.log(chalk.blue(`Publish the first bundle with: ${command}`));
     }
   }

--- a/libs/with-zephyr/src/index.ts
+++ b/libs/with-zephyr/src/index.ts
@@ -62,6 +62,19 @@ function normalizePathForOutput(filePath: string): string {
   return filePath.replace(/\\/g, '/');
 }
 
+function isRequirementResolved(packageRequirement: PackageRequirement): boolean {
+  const projectDirectory = packageRequirement.projectDirectory ?? process.cwd();
+  const minimumVersion = packageRequirement.version?.match(/^\^(\d+\.\d+\.\d+)$/)?.[1];
+  const maximumVersionExclusive =
+    packageRequirement.name === '@module-federation/metro' ? '3.0.0' : undefined;
+  return isResolvedPackageRequirementSatisfied(
+    packageRequirement.name,
+    projectDirectory,
+    minimumVersion,
+    maximumVersionExclusive
+  );
+}
+
 /** Find all bundler configuration files in the given directory */
 function findConfigFiles(directory: string): ConfigFile[] {
   const configFiles: ConfigFile[] = [];
@@ -394,9 +407,16 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
     const projectDirectory = path.resolve(
       packageRequirement.projectDirectory ?? directory
     );
-    requiredPackages.set(`${projectDirectory}\0${packageRequirement.name}`, {
+    const key = `${projectDirectory}\0${packageRequirement.name}`;
+    const existing = requiredPackages.get(key);
+    requiredPackages.set(key, {
+      ...existing,
       ...packageRequirement,
       projectDirectory,
+      isDev: existing
+        ? existing.isDev && packageRequirement.isDev
+        : packageRequirement.isDev,
+      requireResolved: existing?.requireResolved || packageRequirement.requireResolved,
     });
   };
 
@@ -460,13 +480,19 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
       const projectDirectory = packageRequirement.projectDirectory ?? directory;
       const minimumVersion =
         packageRequirement.version?.match(/^\^(\d+\.\d+\.\d+)$/)?.[1];
-      const satisfied = packageRequirement.version
+      const satisfied = packageRequirement.requireResolved
         ? isPackageRequirementSatisfied(
             packageRequirement.name,
             projectDirectory,
             minimumVersion
-          )
-        : isPackageInstalled(packageRequirement.name, projectDirectory);
+          ) && isRequirementResolved(packageRequirement)
+        : packageRequirement.version
+          ? isPackageRequirementSatisfied(
+              packageRequirement.name,
+              projectDirectory,
+              minimumVersion
+            )
+          : isPackageInstalled(packageRequirement.name, projectDirectory);
       if (!satisfied) {
         missingPackages.push(packageRequirement);
       }
@@ -580,20 +606,8 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
           ]);
         }
         for (const [projectDirectory, requirements] of nestedProjects) {
-          const isUnresolved = (packageRequirement: PackageRequirement) => {
-            const minimumVersion =
-              packageRequirement.version?.match(/^\^(\d+\.\d+\.\d+)$/)?.[1];
-            const maximumVersionExclusive =
-              packageRequirement.name === '@module-federation/metro'
-                ? '3.0.0'
-                : undefined;
-            return !isResolvedPackageRequirementSatisfied(
-              packageRequirement.name,
-              projectDirectory,
-              minimumVersion,
-              maximumVersionExclusive
-            );
-          };
+          const isUnresolved = (packageRequirement: PackageRequirement) =>
+            !isRequirementResolved(packageRequirement);
           const unresolved = requirements.filter(isUnresolved);
           if (unresolved.length === 0) continue;
 
@@ -688,6 +702,23 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
     }
 
     console.log();
+  }
+
+  if (!dryRun && !dependencyInstallFailed) {
+    for (const { projectDirectory, result } of metroBootstraps) {
+      if (result.manualGuidance.length > 0 || result.integration === 'none') continue;
+      const unresolved = result.packageRequirements.filter(
+        (packageRequirement) => !isRequirementResolved(packageRequirement)
+      );
+      if (unresolved.length === 0) continue;
+      console.log(
+        chalk.red(
+          `✗ Cannot publish from ${normalizePathForOutput(path.relative(path.resolve(directory), projectDirectory) || '.')}: ${unresolved.map(({ name }) => name).join(', ')} cannot be resolved at compatible versions`
+        )
+      );
+      errors += unresolved.length;
+      dependencyInstallFailed = true;
+    }
   }
 
   if (!dryRun && !dependencyInstallFailed) {

--- a/libs/with-zephyr/src/index.ts
+++ b/libs/with-zephyr/src/index.ts
@@ -32,6 +32,7 @@ import {
   isPackageInstalled,
 } from './package-manager.js';
 import { bootstrapNextJsVinext, type PackageRequirement } from './nextjs-vinext.js';
+import { bootstrapMetroCommands } from './metro-bootstrap.js';
 import { bootstrapSlidevVite } from './slidev-vite.js';
 import { applyBundlerOperations, hasZephyrCall } from './operations.js';
 import type { BundlerConfig, CodemodOptions, ConfigFile } from './types.js';
@@ -267,6 +268,8 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
     console.log(chalk.yellow(`🔍 Dry run mode - no files will be modified\n`));
   }
 
+  const configFiles = findConfigFiles(directory);
+
   const nextJsBootstrap = bootstrapNextJsVinext(directory, { dryRun });
   const slidevBootstrapRequested =
     !bundlers || bundlers.includes('vite') || bundlers.includes('slidev');
@@ -278,6 +281,20 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
         updatedPackageJson: false,
         packageRequirements: [] as PackageRequirement[],
       };
+  const metroProjectDirectories = [
+    ...new Set(
+      configFiles
+        .filter(({ bundlerName }) => bundlerName === 'metro')
+        .map(({ filePath }) => path.resolve(path.dirname(filePath)))
+    ),
+  ];
+  const metroBootstraps =
+    !bundlers || bundlers.includes('metro')
+      ? metroProjectDirectories.map((projectDirectory) => ({
+          projectDirectory,
+          result: bootstrapMetroCommands(projectDirectory, { dryRun }),
+        }))
+      : [];
 
   if (nextJsBootstrap.isNextJsApp) {
     if (nextJsBootstrap.createdFiles.length > 0) {
@@ -319,7 +336,39 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
     }
   }
 
-  const configFiles = findConfigFiles(directory);
+  for (const { projectDirectory, result } of metroBootstraps) {
+    const displayPath = (fileName: string) =>
+      normalizePathForOutput(
+        path.relative(path.resolve(directory), path.join(projectDirectory, fileName))
+      );
+    for (const createdFile of result.createdFiles) {
+      console.log(
+        chalk.green(
+          `✓ ${dryRun ? 'Would create' : 'Created'} ${displayPath(createdFile)}`
+        )
+      );
+    }
+    for (const updatedFile of result.updatedFiles) {
+      console.log(
+        chalk.green(
+          `✓ ${dryRun ? 'Would update' : 'Updated'} ${displayPath(updatedFile)}`
+        )
+      );
+    }
+    if (result.manualGuidance.length > 0) {
+      console.log(
+        chalk.yellow(
+          `\nMetro publication command registration requires manual setup in ${normalizePathForOutput(path.relative(path.resolve(directory), projectDirectory) || '.')}:`
+        )
+      );
+      for (const line of result.manualGuidance) {
+        console.log(chalk.yellow(line));
+      }
+      console.log();
+    } else if (result.createdFiles.length > 0 || result.updatedFiles.length > 0) {
+      console.log();
+    }
+  }
 
   if (
     configFiles.length === 0 &&
@@ -332,6 +381,11 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
 
   // Collect unique plugins that need to be installed
   const requiredPackages = new Map<string, PackageRequirement>();
+  const metroPackageNames = new Set(
+    metroBootstraps.flatMap(({ result }) =>
+      result.packageRequirements.map(({ name }) => name)
+    )
+  );
   const packagesToProcess: ConfigFile[] = [];
   const filteredConfigFiles: ConfigFile[] = [];
 
@@ -340,6 +394,11 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
   }
   for (const packageRequirement of slidevBootstrap.packageRequirements) {
     requiredPackages.set(packageRequirement.name, packageRequirement);
+  }
+  for (const { result } of metroBootstraps) {
+    for (const packageRequirement of result.packageRequirements) {
+      requiredPackages.set(packageRequirement.name, packageRequirement);
+    }
   }
 
   for (const { filePath, bundlerName, config } of configFiles) {
@@ -387,7 +446,11 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
   if (installPackages && missingPackages.length > 0 && dryRun) {
     console.log(chalk.blue(`\n📦 Packages that would be installed:\n`));
     for (const packageRequirement of missingPackages) {
-      console.log(chalk.yellow(`  - ${packageRequirement.name}`));
+      console.log(
+        chalk.yellow(
+          `  - ${packageRequirement.name}${packageRequirement.version ? `@${packageRequirement.version}` : ''}`
+        )
+      );
     }
     console.log();
   }
@@ -395,6 +458,7 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
   // Process configuration files
   let processed = 0;
   let errors = 0;
+  let dependencyInstallFailed = false;
 
   for (const { filePath, bundlerName, config } of packagesToProcess) {
     const success = transformConfigFile(filePath, bundlerName, config, {
@@ -419,11 +483,12 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
 
     if (fs.existsSync(packageJsonPath)) {
       for (const packageRequirement of missingPackages) {
-        const latestVersion = getLatestVersion(packageRequirement.name);
+        const version =
+          packageRequirement.version ?? getLatestVersion(packageRequirement.name);
         const added = addToPackageJson(
           directory,
           packageRequirement.name,
-          latestVersion,
+          version,
           packageRequirement.isDev
         );
         if (added) {
@@ -451,16 +516,28 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
         console.log(chalk.green('✓ Installed dependencies from package.json'));
       } else {
         console.log(chalk.red('✗ Failed to install dependencies from package.json'));
+        errors += stagedPackages.length;
+        dependencyInstallFailed ||= stagedPackages.some(({ name }) =>
+          metroPackageNames.has(name)
+        );
       }
     }
 
     if (fallbackPackages.length > 0) {
       const prodPackages = fallbackPackages
         .filter((packageRequirement) => !packageRequirement.isDev)
-        .map((packageRequirement) => packageRequirement.name);
+        .map((packageRequirement) =>
+          packageRequirement.version
+            ? `${packageRequirement.name}@${packageRequirement.version}`
+            : packageRequirement.name
+        );
       const devPackages = fallbackPackages
         .filter((packageRequirement) => packageRequirement.isDev)
-        .map((packageRequirement) => packageRequirement.name);
+        .map((packageRequirement) =>
+          packageRequirement.version
+            ? `${packageRequirement.name}@${packageRequirement.version}`
+            : packageRequirement.name
+        );
 
       if (prodPackages.length > 0) {
         const success = installPackagesDirect(
@@ -473,6 +550,10 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
           console.log(chalk.green(`✓ Installed ${prodPackages.join(', ')}`));
         } else {
           console.log(chalk.red(`✗ Failed to install ${prodPackages.join(', ')}`));
+          errors += prodPackages.length;
+          dependencyInstallFailed ||= fallbackPackages.some(
+            ({ name, isDev }) => !isDev && metroPackageNames.has(name)
+          );
         }
       }
 
@@ -487,11 +568,28 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
           console.log(chalk.green(`✓ Installed ${devPackages.join(', ')}`));
         } else {
           console.log(chalk.red(`✗ Failed to install ${devPackages.join(', ')}`));
+          errors += devPackages.length;
+          dependencyInstallFailed ||= fallbackPackages.some(
+            ({ name, isDev }) => isDev && metroPackageNames.has(name)
+          );
         }
       }
     }
 
     console.log();
+  }
+
+  if (!dryRun && !dependencyInstallFailed) {
+    for (const { result } of metroBootstraps) {
+      if (result.manualGuidance.length > 0 || result.integration === 'none') {
+        continue;
+      }
+      const command =
+        result.integration === 'rnef'
+          ? 'rnef bundle-mf-remote --platform ios --dev false'
+          : 'npx react-native bundle-mf-remote --platform ios --dev false';
+      console.log(chalk.blue(`Publish the first bundle with: ${command}`));
+    }
   }
 
   console.log(`\n${chalk.bold('Summary:')}`);
@@ -502,6 +600,10 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
     }`
   );
   console.log(`${chalk.red('✗')} Errors: ${errors}`);
+
+  if (dependencyInstallFailed) {
+    process.exitCode = 1;
+  }
 
   if (dryRun && processed > 0) {
     console.log(chalk.yellow(`\nRun without --dry-run to apply changes.`));

--- a/libs/with-zephyr/src/index.ts
+++ b/libs/with-zephyr/src/index.ts
@@ -691,7 +691,7 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
   }
 
   if (!dryRun && !dependencyInstallFailed) {
-    for (const { result } of metroBootstraps) {
+    for (const { projectDirectory, result } of metroBootstraps) {
       if (result.manualGuidance.length > 0 || result.integration === 'none') {
         continue;
       }
@@ -699,7 +699,15 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
         result.integration === 'rnef'
           ? `rnef bundle-mf-remote --platform ${result.platformArgument} --dev false`
           : `npx react-native bundle-mf-remote --platform ${result.platformArgument} --dev false`;
-      console.log(chalk.blue(`Publish the first bundle with: ${command}`));
+      const relativeProjectDirectory = normalizePathForOutput(
+        path.relative(path.resolve(directory), projectDirectory)
+      );
+      const projectPrefix = relativeProjectDirectory
+        ? `cd "${relativeProjectDirectory}" && `
+        : '';
+      console.log(
+        chalk.blue(`Publish the first bundle with: ${projectPrefix}${command}`)
+      );
     }
   }
 

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -441,12 +441,14 @@ export function bootstrapMetroCommands(
         isDev: isDevRequirement('zephyr-metro-plugin'),
         version: ZEPHYR_METRO_PLUGIN_VERSION,
         projectDirectory: directory,
+        requireResolved: true,
       },
       {
         name: '@module-federation/metro',
         isDev: isDevRequirement('@module-federation/metro'),
         version: MODULE_FEDERATION_METRO_VERSION,
         projectDirectory: directory,
+        requireResolved: true,
       },
     ];
   };

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -124,17 +124,18 @@ function getVersionProblem(
 
 function hasModuleFederationSetup(filePath: string): boolean {
   const content = fs.readFileSync(filePath, 'utf8');
-  const importsWithModuleFederation =
-    /^\s*import\s*\{[^}]*\bwithModuleFederation\b[^}]*\}\s*from\s*["']@module-federation\/metro["']/m.test(
-      content
-    ) ||
-    /^\s*(?:const|let|var)\s*\{[^}]*\bwithModuleFederation\b[^}]*\}\s*=\s*require\(\s*["']@module-federation\/metro["']\s*\)/m.test(
-      content
-    );
-  return (
-    importsWithModuleFederation &&
-    searchWithAstGrep({ filePath, pattern: 'withModuleFederation($$$ARGS)' }).status ===
-      'match'
+  const localName = findImportedHelperName(
+    content,
+    '@module-federation/metro',
+    'withModuleFederation'
+  );
+  return Boolean(
+    localName &&
+    hasExportedConfigCall({
+      filePath,
+      pattern: `${localName}($$$ARGS)`,
+      allowDirectExport: true,
+    })
   );
 }
 
@@ -153,10 +154,18 @@ function discoverConfigFiles(
   };
 }
 
-function findImportedHelperName(content: string, importName: string): string | undefined {
+function findImportedHelperName(
+  content: string,
+  packageName: string,
+  importName: string
+): string | undefined {
+  const escapedPackageName = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const importPatterns = [
-    /import\s*\{([^}]*)\}\s*from\s*["']zephyr-metro-plugin["']/g,
-    /(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\(["']zephyr-metro-plugin["']\)/g,
+    new RegExp(`import\\s*\\{([^}]*)\\}\\s*from\\s*["']${escapedPackageName}["']`, 'g'),
+    new RegExp(
+      `(?:const|let|var)\\s*\\{([^}]*)\\}\\s*=\\s*require\\(\\s*["']${escapedPackageName}["']\\s*\\)`,
+      'g'
+    ),
   ];
 
   for (const pattern of importPatterns) {
@@ -180,7 +189,7 @@ function hasExportedHelperCall(
   importName: string,
   propertyName: 'commands' | 'plugins'
 ): boolean {
-  const localName = findImportedHelperName(content, importName);
+  const localName = findImportedHelperName(content, 'zephyr-metro-plugin', importName);
   return [importName, localName]
     .filter((name): name is string => Boolean(name))
     .some((name) => {
@@ -195,7 +204,7 @@ function hasExportedHelperCall(
 }
 
 function addImport(content: string, importName: string, esm: boolean): string {
-  if (findImportedHelperName(content, importName)) {
+  if (findImportedHelperName(content, 'zephyr-metro-plugin', importName)) {
     return content;
   }
 
@@ -217,7 +226,8 @@ function updateCommonJsConfig(
   if (hasExportedHelperCall(filePath, content, importName, propertyName)) {
     return 'already-configured';
   }
-  const localName = findImportedHelperName(content, importName) ?? importName;
+  const localName =
+    findImportedHelperName(content, 'zephyr-metro-plugin', importName) ?? importName;
   if (
     (content.match(/module\.exports\s*=/g)?.length ?? 0) !== 1 ||
     searchWithAstGrep({
@@ -257,7 +267,8 @@ function updateEsmConfig(
   if (hasExportedHelperCall(filePath, content, importName, propertyName)) {
     return 'already-configured';
   }
-  const localName = findImportedHelperName(content, importName) ?? importName;
+  const localName =
+    findImportedHelperName(content, 'zephyr-metro-plugin', importName) ?? importName;
 
   const result = rewriteWithAstGrep({
     filePath,
@@ -421,17 +432,19 @@ export function bootstrapMetroCommands(
   }
 
   result.integration = integration;
+  const isDevRequirement = (packageName: string) =>
+    !Object.prototype.hasOwnProperty.call(packageJson['dependencies'] ?? {}, packageName);
   const setPackageRequirements = () => {
     result.packageRequirements = [
       {
         name: 'zephyr-metro-plugin',
-        isDev: true,
+        isDev: isDevRequirement('zephyr-metro-plugin'),
         version: ZEPHYR_METRO_PLUGIN_VERSION,
         projectDirectory: directory,
       },
       {
         name: '@module-federation/metro',
-        isDev: true,
+        isDev: isDevRequirement('@module-federation/metro'),
         version: MODULE_FEDERATION_METRO_VERSION,
         projectDirectory: directory,
       },

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -154,6 +154,26 @@ function getUniqueBindingName(content: string, bindingName: string): string {
   return candidate;
 }
 
+function getMetroResolutionDirectories(directory: string): string[] {
+  const reactNativeMetroConfigDirectory = getResolvedPackageDirectory(
+    '@react-native/metro-config',
+    directory
+  );
+  if (!reactNativeMetroConfigDirectory) return [];
+
+  const metroConfigDirectory = getResolvedPackageDirectory(
+    'metro-config',
+    reactNativeMetroConfigDirectory
+  );
+  const metroDirectory = getResolvedPackageDirectory(
+    'metro',
+    metroConfigDirectory ?? reactNativeMetroConfigDirectory
+  );
+  return [reactNativeMetroConfigDirectory, metroConfigDirectory, metroDirectory].filter(
+    (value): value is string => Boolean(value)
+  );
+}
+
 function hasModuleFederationSetup(filePath: string): boolean {
   const content = fs.readFileSync(filePath, 'utf8');
   const localName = findImportedHelperExpression(
@@ -429,11 +449,7 @@ export function bootstrapMetroCommands(
     return result;
   }
 
-  const metroConfigDirectory = getResolvedPackageDirectory(
-    '@react-native/metro-config',
-    directory
-  );
-  const metroResolutionDirectories = metroConfigDirectory ? [metroConfigDirectory] : [];
+  const metroResolutionDirectories = getMetroResolutionDirectories(directory);
   const versionProblems = [
     getVersionProblem(directory, '@module-federation/metro', '2.9.0', {
       allowMissing: true,
@@ -441,6 +457,7 @@ export function bootstrapMetroCommands(
     }),
     getVersionProblem(directory, '@babel/types', '7.25.0', {
       maximumVersionExclusive: '8.0.0',
+      resolutionDirectories: metroResolutionDirectories,
     }),
     getVersionProblem(directory, 'react', '19.0.0'),
     getVersionProblem(directory, 'react-native', '0.79.0'),

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -327,6 +327,9 @@ function updateCommonJsConfig(
   dryRun: boolean
 ): ConfigUpdateResult {
   const content = fs.readFileSync(filePath, 'utf8');
+  if ((content.match(/module\.exports\s*=/g)?.length ?? 0) !== 1) {
+    return 'unsupported';
+  }
   if (hasExportedHelperCall(filePath, content, importName, propertyName)) {
     return 'already-configured';
   }
@@ -335,7 +338,6 @@ function updateCommonJsConfig(
     importName;
   bindingName = getUniqueBindingName(content, bindingName);
   if (
-    (content.match(/module\.exports\s*=/g)?.length ?? 0) !== 1 ||
     searchWithAstGrep({
       filePath,
       pattern: 'module.exports = {$$$PROPS}',

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { rewriteWithAstGrep, searchWithAstGrep } from './engine/ast-grep.js';
+import {
+  hasExportedConfigCall,
+  rewriteWithAstGrep,
+  searchWithAstGrep,
+} from './engine/ast-grep.js';
 import type { PackageRequirement } from './nextjs-vinext.js';
 import {
   getDeclaredPackageVersion,
@@ -41,6 +45,13 @@ const METRO_CONFIG_FILES = [
 ];
 const MODULE_FEDERATION_METRO_VERSION = '^2.9.0';
 const ZEPHYR_METRO_PLUGIN_VERSION = '^1.4.0';
+const METRO_PEER_PACKAGES = [
+  'metro',
+  'metro-config',
+  'metro-file-map',
+  'metro-resolver',
+  'metro-source-map',
+];
 
 type ConfigUpdateResult = 'updated' | 'already-configured' | 'unsupported';
 
@@ -163,18 +174,23 @@ function findImportedHelperName(content: string, importName: string): string | u
   return undefined;
 }
 
-function hasHelperCall(filePath: string, content: string, importName: string): boolean {
+function hasExportedHelperCall(
+  filePath: string,
+  content: string,
+  importName: string,
+  propertyName: 'commands' | 'plugins'
+): boolean {
   const localName = findImportedHelperName(content, importName);
   return [importName, localName]
     .filter((name): name is string => Boolean(name))
     .some((name) => {
-      if (name.startsWith('$')) {
-        const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        return new RegExp(`(?:^|[^$\\w])${escapedName}\\s*\\(`, 'm').test(content);
-      }
-      return (
-        searchWithAstGrep({ filePath, pattern: `${name}($$$ARGS)` }).status === 'match'
-      );
+      if (name.startsWith('$')) return false;
+      return hasExportedConfigCall({
+        filePath,
+        pattern: `${name}($$$ARGS)`,
+        propertyName,
+        allowDirectExport: propertyName === 'commands',
+      });
     });
 }
 
@@ -198,7 +214,7 @@ function updateCommonJsConfig(
   dryRun: boolean
 ): ConfigUpdateResult {
   const content = fs.readFileSync(filePath, 'utf8');
-  if (hasHelperCall(filePath, content, importName)) {
+  if (hasExportedHelperCall(filePath, content, importName, propertyName)) {
     return 'already-configured';
   }
   const localName = findImportedHelperName(content, importName) ?? importName;
@@ -238,7 +254,7 @@ function updateEsmConfig(
   dryRun: boolean
 ): ConfigUpdateResult {
   const content = fs.readFileSync(filePath, 'utf8');
-  if (hasHelperCall(filePath, content, importName)) {
+  if (hasExportedHelperCall(filePath, content, importName, propertyName)) {
     return 'already-configured';
   }
   const localName = findImportedHelperName(content, importName) ?? importName;
@@ -345,8 +361,16 @@ export function bootstrapMetroCommands(
       allowMissing: true,
       maximumVersionExclusive: '3.0.0',
     }),
+    getVersionProblem(directory, '@babel/types', '7.25.0', {
+      maximumVersionExclusive: '8.0.0',
+    }),
+    getVersionProblem(directory, 'react', '19.0.0'),
     getVersionProblem(directory, 'react-native', '0.79.0'),
-    getVersionProblem(directory, 'metro', '0.82.0'),
+    ...METRO_PEER_PACKAGES.map((packageName) =>
+      getVersionProblem(directory, packageName, '0.82.1', {
+        maximumVersionExclusive: '0.83.0',
+      })
+    ),
   ].filter((problem): problem is string => Boolean(problem));
   if (versionProblems.length > 0) {
     result.integration = 'ambiguous';

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -211,7 +211,16 @@ function addImport(content: string, importName: string, esm: boolean): string {
   const declaration = esm
     ? `import { ${importName} } from "zephyr-metro-plugin";\n`
     : `const { ${importName} } = require("zephyr-metro-plugin");\n`;
-  return `${declaration}${content}`;
+  let insertionIndex = content.startsWith('#!') ? content.indexOf('\n') + 1 : 0;
+  if (insertionIndex === 0 && content.startsWith('#!')) {
+    return `${content}\n${declaration}`;
+  }
+  const directivePrologue =
+    /^(?:(?:[ \t]*(?:"[^"\r\n]*"|'[^'\r\n]*')[ \t]*;?[ \t]*(?:\r?\n|$))|(?:[ \t]*\/\/[^\r\n]*(?:\r?\n|$))|(?:[ \t]*\/\*[\s\S]*?\*\/[ \t]*(?:\r?\n|$))|(?:[ \t]*\r?\n))+/.exec(
+      content.slice(insertionIndex)
+    );
+  insertionIndex += directivePrologue?.[0].length ?? 0;
+  return `${content.slice(0, insertionIndex)}${declaration}${content.slice(insertionIndex)}`;
 }
 
 function updateCommonJsConfig(

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -176,6 +176,9 @@ function getMetroResolutionDirectories(directory: string): string[] {
 
 function hasModuleFederationSetup(filePath: string): boolean {
   const content = fs.readFileSync(filePath, 'utf8');
+  if ((content.match(/module\.exports\s*=/g)?.length ?? 0) > 1) {
+    return false;
+  }
   const localName = findImportedHelperExpression(
     filePath,
     content,

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -2,11 +2,18 @@ import fs from 'fs';
 import path from 'path';
 import { rewriteWithAstGrep, searchWithAstGrep } from './engine/ast-grep.js';
 import type { PackageRequirement } from './nextjs-vinext.js';
+import {
+  getDeclaredPackageVersion,
+  getResolvedPackageVersion,
+  isSafelyConstrainedVersion,
+  isVersionCompatible,
+} from './package-manager.js';
 
 type MetroIntegration = 'react-native-cli' | 'rnef' | 'ambiguous' | 'none';
 
 export interface MetroBootstrapResult {
   integration: MetroIntegration;
+  platformArgument: string;
   createdFiles: string[];
   updatedFiles: string[];
   packageRequirements: PackageRequirement[];
@@ -26,13 +33,14 @@ const REACT_NATIVE_CONFIG_FILES = [
   'react-native.config.mjs',
 ];
 const RNEF_CONFIG_FILES = ['rnef.config.js', 'rnef.config.ts', 'rnef.config.mjs'];
-const MODULE_FEDERATION_METRO_VERSION = '^2.9.0';
-
-const MANUAL_GUIDANCE = [
-  'No React Native command config was changed because the integration could not be updated safely.',
-  'React Native CLI: export commands: [...(config.commands ?? []), ...zephyrMetroReactNativeCli().commands] from react-native.config.js and import zephyrMetroReactNativeCli from zephyr-metro-plugin.',
-  'RNEF: add zephyrMetroRNEFPlugin() to the exported plugins array in rnef.config.* and import zephyrMetroRNEFPlugin from zephyr-metro-plugin.',
+const METRO_CONFIG_FILES = [
+  'metro.config.js',
+  'metro.config.ts',
+  'metro.config.mjs',
+  'metro.config.cjs',
 ];
+const MODULE_FEDERATION_METRO_VERSION = '^2.9.0';
+const ZEPHYR_METRO_PLUGIN_VERSION = '^1.4.0';
 
 type ConfigUpdateResult = 'updated' | 'already-configured' | 'unsupported';
 
@@ -52,19 +60,71 @@ function hasAnyPackage(packageJson: Record<string, any>, names: string[]): boole
   return names.some((name) => Boolean(packages[name]));
 }
 
-function getPackageVersion(
-  packageJson: Record<string, any>,
-  packageName: string
-): string | undefined {
-  return (
-    packageJson['dependencies']?.[packageName] ??
-    packageJson['devDependencies']?.[packageName]
-  );
+function getPlatformArgument(packageJson: Record<string, any>): string {
+  const hasAndroid = hasAnyPackage(packageJson, [
+    '@react-native-community/cli-platform-android',
+  ]);
+  const hasIos = hasAnyPackage(packageJson, ['@react-native-community/cli-platform-ios']);
+  return hasAndroid !== hasIos ? (hasAndroid ? 'android' : 'ios') : '<platform>';
 }
 
-function supportsMetroCommands(version: string): boolean {
-  const match = version.match(/(\d+)\.(\d+)/);
-  return Boolean(match && Number(match[1]) === 2 && Number(match[2]) >= 9);
+function getManualGuidance(packageJson: Record<string, any>): string[] {
+  return [
+    'No React Native command config was changed because the integration could not be updated safely.',
+    'React Native CLI: export commands: [...(config.commands ?? []), ...zephyrMetroReactNativeCli().commands] from the active react-native.config.* file and import zephyrMetroReactNativeCli from zephyr-metro-plugin.',
+    'RNEF: add zephyrMetroRNEFPlugin() to the exported plugins array in the active rnef.config.* file and import zephyrMetroRNEFPlugin from zephyr-metro-plugin.',
+    `Publish with --platform ${getPlatformArgument(packageJson)} after registration.`,
+  ];
+}
+
+function getVersionProblem(
+  directory: string,
+  packageName: string,
+  minimumVersion: string,
+  options: { allowMissing?: boolean; maximumVersionExclusive?: string } = {}
+): string | undefined {
+  const expectedVersion = options.maximumVersionExclusive
+    ? `${minimumVersion} or newer but below ${options.maximumVersionExclusive}`
+    : `${minimumVersion} or newer`;
+  const resolvedVersion = getResolvedPackageVersion(packageName, directory);
+  if (resolvedVersion) {
+    return isVersionCompatible(
+      resolvedVersion,
+      minimumVersion,
+      options.maximumVersionExclusive
+    )
+      ? undefined
+      : `${packageName} ${resolvedVersion} is installed, but ${expectedVersion} is required.`;
+  }
+
+  const declaration = getDeclaredPackageVersion(packageName, directory);
+  if (!declaration) {
+    if (options.allowMissing) return undefined;
+    return `${packageName} could not be resolved and has no direct version declaration.`;
+  }
+  return isSafelyConstrainedVersion(
+    declaration,
+    minimumVersion,
+    options.maximumVersionExclusive
+  )
+    ? undefined
+    : `${packageName} declaration "${declaration}" could not be verified as ${expectedVersion}.`;
+}
+
+function hasModuleFederationSetup(filePath: string): boolean {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const importsWithModuleFederation =
+    /^\s*import\s*\{[^}]*\bwithModuleFederation\b[^}]*\}\s*from\s*["']@module-federation\/metro["']/m.test(
+      content
+    ) ||
+    /^\s*(?:const|let|var)\s*\{[^}]*\bwithModuleFederation\b[^}]*\}\s*=\s*require\(\s*["']@module-federation\/metro["']\s*\)/m.test(
+      content
+    );
+  return (
+    importsWithModuleFederation &&
+    searchWithAstGrep({ filePath, pattern: 'withModuleFederation($$$ARGS)' }).status ===
+      'match'
+  );
 }
 
 function discoverConfigFiles(
@@ -238,11 +298,12 @@ function updateConfig(
 
 export function bootstrapMetroCommands(
   directory: string,
-  options: { dryRun?: boolean } = {}
+  options: { dryRun?: boolean; metroConfigFilePaths?: string[] } = {}
 ): MetroBootstrapResult {
   const dryRun = options.dryRun ?? false;
   const result: MetroBootstrapResult = {
     integration: 'none',
+    platformArgument: '<platform>',
     createdFiles: [],
     updatedFiles: [],
     packageRequirements: [],
@@ -251,20 +312,45 @@ export function bootstrapMetroCommands(
   const packageJson = readPackageJson(directory);
   if (!packageJson) {
     result.integration = 'ambiguous';
-    result.manualGuidance = MANUAL_GUIDANCE;
+    result.manualGuidance = [
+      'No package.json was found for this Metro project, so publication commands were not registered.',
+    ];
+    return result;
+  }
+  result.platformArgument = getPlatformArgument(packageJson);
+
+  const metroConfigFilePaths =
+    options.metroConfigFilePaths ??
+    METRO_CONFIG_FILES.map((fileName) => path.join(directory, fileName)).filter(
+      (filePath) => fs.existsSync(filePath)
+    );
+  if (
+    metroConfigFilePaths.length !== 1 ||
+    !hasModuleFederationSetup(metroConfigFilePaths[0]!)
+  ) {
+    const configDescription =
+      metroConfigFilePaths.length === 1
+        ? path.basename(metroConfigFilePaths[0]!)
+        : 'The active Metro config';
+    result.integration = 'ambiguous';
+    result.manualGuidance = [
+      `${configDescription} is not verifiably configured with @module-federation/metro using withModuleFederation(). Companion command config was left unchanged; configure Module Federation first, then rerun with-zephyr.`,
+      ...getManualGuidance(packageJson),
+    ];
     return result;
   }
 
-  const installedMetroVersion = getPackageVersion(
-    packageJson,
-    '@module-federation/metro'
-  );
-  if (installedMetroVersion && !supportsMetroCommands(installedMetroVersion)) {
+  const versionProblems = [
+    getVersionProblem(directory, '@module-federation/metro', '2.9.0', {
+      allowMissing: true,
+      maximumVersionExclusive: '3.0.0',
+    }),
+    getVersionProblem(directory, 'react-native', '0.79.0'),
+    getVersionProblem(directory, 'metro', '0.82.0'),
+  ].filter((problem): problem is string => Boolean(problem));
+  if (versionProblems.length > 0) {
     result.integration = 'ambiguous';
-    result.manualGuidance = [
-      `Installed @module-federation/metro version ${installedMetroVersion} is not supported by the publication adapter. Use ${MODULE_FEDERATION_METRO_VERSION}.`,
-      ...MANUAL_GUIDANCE,
-    ];
+    result.manualGuidance = [...versionProblems, ...getManualGuidance(packageJson)];
     return result;
   }
 
@@ -294,7 +380,7 @@ export function bootstrapMetroCommands(
     hasReactNativeConfigWithRnefPackage
   ) {
     result.integration = 'ambiguous';
-    result.manualGuidance = MANUAL_GUIDANCE;
+    result.manualGuidance = getManualGuidance(packageJson);
     return result;
   }
 
@@ -306,18 +392,24 @@ export function bootstrapMetroCommands(
         : 'ambiguous';
   if (integration === 'ambiguous') {
     result.integration = integration;
-    result.manualGuidance = MANUAL_GUIDANCE;
+    result.manualGuidance = getManualGuidance(packageJson);
     return result;
   }
 
   result.integration = integration;
   const setPackageRequirements = () => {
     result.packageRequirements = [
-      { name: 'zephyr-metro-plugin', isDev: true },
+      {
+        name: 'zephyr-metro-plugin',
+        isDev: true,
+        version: ZEPHYR_METRO_PLUGIN_VERSION,
+        projectDirectory: directory,
+      },
       {
         name: '@module-federation/metro',
         isDev: true,
         version: MODULE_FEDERATION_METRO_VERSION,
+        projectDirectory: directory,
       },
     ];
   };
@@ -356,7 +448,7 @@ export function bootstrapMetroCommands(
     if (updateResult === 'unsupported') {
       result.manualGuidance = [
         `${reactNativeConfigName} does not directly export an object and was left unchanged.`,
-        ...MANUAL_GUIDANCE,
+        ...getManualGuidance(packageJson),
       ];
     } else {
       setPackageRequirements();
@@ -395,7 +487,7 @@ export function bootstrapMetroCommands(
   if (updateResult === 'unsupported') {
     result.manualGuidance = [
       `${rnefConfigName} does not directly export an object and was left unchanged.`,
-      ...MANUAL_GUIDANCE,
+      ...getManualGuidance(packageJson),
     ];
   } else {
     setPackageRequirements();

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -8,6 +8,7 @@ import {
 import type { PackageRequirement } from './nextjs-vinext.js';
 import {
   getDeclaredPackageVersion,
+  getResolvedPackageDirectory,
   getResolvedPackageVersion,
   isSafelyConstrainedVersion,
   isVersionCompatible,
@@ -92,12 +93,34 @@ function getVersionProblem(
   directory: string,
   packageName: string,
   minimumVersion: string,
-  options: { allowMissing?: boolean; maximumVersionExclusive?: string } = {}
+  options: {
+    allowMissing?: boolean;
+    maximumVersionExclusive?: string;
+    resolutionDirectories?: string[];
+  } = {}
 ): string | undefined {
   const expectedVersion = options.maximumVersionExclusive
     ? `${minimumVersion} or newer but below ${options.maximumVersionExclusive}`
     : `${minimumVersion} or newer`;
-  const resolvedVersion = getResolvedPackageVersion(packageName, directory);
+  const declaration = getDeclaredPackageVersion(packageName, directory);
+  const usesWorkspaceProtocol = /^(?:catalog:|workspace:)/.test(declaration ?? '');
+  if (
+    declaration &&
+    !usesWorkspaceProtocol &&
+    !isSafelyConstrainedVersion(
+      declaration,
+      minimumVersion,
+      options.maximumVersionExclusive
+    )
+  ) {
+    return `${packageName} declaration "${declaration}" could not be verified as ${expectedVersion}.`;
+  }
+
+  const resolvedVersion = [directory, ...(options.resolutionDirectories ?? [])]
+    .map((resolutionDirectory) =>
+      getResolvedPackageVersion(packageName, resolutionDirectory)
+    )
+    .find((version): version is string => Boolean(version));
   if (resolvedVersion) {
     return isVersionCompatible(
       resolvedVersion,
@@ -108,7 +131,6 @@ function getVersionProblem(
       : `${packageName} ${resolvedVersion} is installed, but ${expectedVersion} is required.`;
   }
 
-  const declaration = getDeclaredPackageVersion(packageName, directory);
   if (!declaration) {
     if (options.allowMissing) return undefined;
     return `${packageName} could not be resolved and has no direct version declaration.`;
@@ -120,6 +142,16 @@ function getVersionProblem(
   )
     ? undefined
     : `${packageName} declaration "${declaration}" could not be verified as ${expectedVersion}.`;
+}
+
+function getUniqueBindingName(content: string, bindingName: string): string {
+  let candidate = bindingName;
+  let suffix = 2;
+  while (new RegExp(`\\b${candidate}\\b`).test(content)) {
+    candidate = `${bindingName}${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
 }
 
 function hasModuleFederationSetup(filePath: string): boolean {
@@ -233,7 +265,7 @@ function addImport(content: string, importName: string, esm: boolean): string {
     return `${content}\n${declaration}`;
   }
   const directivePrologue =
-    /^(?:(?:[ \t]*(?:"[^"\r\n]*"|'[^'\r\n]*')[ \t]*;?[ \t]*(?:\r?\n|$))|(?:[ \t]*\/\/[^\r\n]*(?:\r?\n|$))|(?:[ \t]*\/\*[\s\S]*?\*\/[ \t]*(?:\r?\n|$))|(?:[ \t]*\r?\n))+/.exec(
+    /^(?:(?:[ \t]*(?:"[^"\r\n]*"|'[^'\r\n]*')[ \t]*;?[ \t]*(?:(?:\/\/[^\r\n]*)|(?:\/\*[\s\S]*?\*\/[ \t]*))?(?:\r?\n|$))|(?:[ \t]*\/\/[^\r\n]*(?:\r?\n|$))|(?:[ \t]*\/\*[\s\S]*?\*\/[ \t]*(?:\r?\n|$))|(?:[ \t]*\r?\n))+/.exec(
       content.slice(insertionIndex)
     );
   insertionIndex += directivePrologue?.[0].length ?? 0;
@@ -255,6 +287,7 @@ function updateCommonJsConfig(
   const localName =
     findImportedHelperExpression(content, 'zephyr-metro-plugin', importName) ??
     importName;
+  bindingName = getUniqueBindingName(content, bindingName);
   if (
     (content.match(/module\.exports\s*=/g)?.length ?? 0) !== 1 ||
     searchWithAstGrep({
@@ -297,6 +330,7 @@ function updateEsmConfig(
   const localName =
     findImportedHelperExpression(content, 'zephyr-metro-plugin', importName) ??
     importName;
+  bindingName = getUniqueBindingName(content, bindingName);
 
   const result = rewriteWithAstGrep({
     filePath,
@@ -395,6 +429,11 @@ export function bootstrapMetroCommands(
     return result;
   }
 
+  const metroConfigDirectory = getResolvedPackageDirectory(
+    '@react-native/metro-config',
+    directory
+  );
+  const metroResolutionDirectories = metroConfigDirectory ? [metroConfigDirectory] : [];
   const versionProblems = [
     getVersionProblem(directory, '@module-federation/metro', '2.9.0', {
       allowMissing: true,
@@ -408,6 +447,7 @@ export function bootstrapMetroCommands(
     ...METRO_PEER_PACKAGES.map((packageName) =>
       getVersionProblem(directory, packageName, '0.82.1', {
         maximumVersionExclusive: '0.83.0',
+        resolutionDirectories: metroResolutionDirectories,
       })
     ),
   ].filter((problem): problem is string => Boolean(problem));

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -177,6 +177,7 @@ function getMetroResolutionDirectories(directory: string): string[] {
 function hasModuleFederationSetup(filePath: string): boolean {
   const content = fs.readFileSync(filePath, 'utf8');
   const localName = findImportedHelperExpression(
+    filePath,
     content,
     '@module-federation/metro',
     'withModuleFederation'
@@ -207,6 +208,7 @@ function discoverConfigFiles(
 }
 
 function findImportedHelperExpression(
+  filePath: string,
   content: string,
   packageName: string,
   importName: string
@@ -222,6 +224,12 @@ function findImportedHelperExpression(
 
   for (const pattern of importPatterns) {
     for (const match of content.matchAll(pattern)) {
+      if (
+        !match[0] ||
+        searchWithAstGrep({ filePath, pattern: match[0] }).status !== 'match'
+      ) {
+        continue;
+      }
       const specifiers = match[1]?.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
       for (const specifier of specifiers?.split(',') ?? []) {
         const parts = specifier.trim().split(/\s+(?:as\s+)?|\s*:\s*/);
@@ -234,15 +242,25 @@ function findImportedHelperExpression(
 
   const namespacePatterns = [
     new RegExp(
-      `import\\s*\\*\\s*as\\s*([A-Za-z_$][\\w$]*)\\s*from\\s*["']${escapedPackageName}["']`
+      `import\\s*\\*\\s*as\\s*([A-Za-z_$][\\w$]*)\\s*from\\s*["']${escapedPackageName}["']`,
+      'g'
     ),
     new RegExp(
-      `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*require\\(\\s*["']${escapedPackageName}["']\\s*\\)`
+      `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*require\\(\\s*["']${escapedPackageName}["']\\s*\\)`,
+      'g'
     ),
   ];
   for (const pattern of namespacePatterns) {
-    const namespace = pattern.exec(content)?.[1];
-    if (namespace) return `${namespace}.${importName}`;
+    for (const match of content.matchAll(pattern)) {
+      const namespace = match[1];
+      if (
+        namespace &&
+        match[0] &&
+        searchWithAstGrep({ filePath, pattern: match[0] }).status === 'match'
+      ) {
+        return `${namespace}.${importName}`;
+      }
+    }
   }
 
   return undefined;
@@ -255,6 +273,7 @@ function hasExportedHelperCall(
   propertyName: 'commands' | 'plugins'
 ): boolean {
   const localName = findImportedHelperExpression(
+    filePath,
     content,
     'zephyr-metro-plugin',
     importName
@@ -272,8 +291,15 @@ function hasExportedHelperCall(
     });
 }
 
-function addImport(content: string, importName: string, esm: boolean): string {
-  if (findImportedHelperExpression(content, 'zephyr-metro-plugin', importName)) {
+function addImport(
+  filePath: string,
+  content: string,
+  importName: string,
+  esm: boolean
+): string {
+  if (
+    findImportedHelperExpression(filePath, content, 'zephyr-metro-plugin', importName)
+  ) {
     return content;
   }
 
@@ -305,7 +331,7 @@ function updateCommonJsConfig(
     return 'already-configured';
   }
   const localName =
-    findImportedHelperExpression(content, 'zephyr-metro-plugin', importName) ??
+    findImportedHelperExpression(filePath, content, 'zephyr-metro-plugin', importName) ??
     importName;
   bindingName = getUniqueBindingName(content, bindingName);
   if (
@@ -318,7 +344,7 @@ function updateCommonJsConfig(
     return 'unsupported';
   }
 
-  const nextContent = `${addImport(content, importName, false).trimEnd()}
+  const nextContent = `${addImport(filePath, content, importName, false).trimEnd()}
 
 const ${bindingName} = module.exports;
 module.exports = {
@@ -348,7 +374,7 @@ function updateEsmConfig(
     return 'already-configured';
   }
   const localName =
-    findImportedHelperExpression(content, 'zephyr-metro-plugin', importName) ??
+    findImportedHelperExpression(filePath, content, 'zephyr-metro-plugin', importName) ??
     importName;
   bindingName = getUniqueBindingName(content, bindingName);
 
@@ -371,7 +397,7 @@ export default {
 
   if (!dryRun) {
     const updatedContent = fs.readFileSync(filePath, 'utf8');
-    fs.writeFileSync(filePath, addImport(updatedContent, importName, true));
+    fs.writeFileSync(filePath, addImport(filePath, updatedContent, importName, true));
   }
   return 'updated';
 }

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -1,0 +1,404 @@
+import fs from 'fs';
+import path from 'path';
+import { rewriteWithAstGrep, searchWithAstGrep } from './engine/ast-grep.js';
+import type { PackageRequirement } from './nextjs-vinext.js';
+
+type MetroIntegration = 'react-native-cli' | 'rnef' | 'ambiguous' | 'none';
+
+export interface MetroBootstrapResult {
+  integration: MetroIntegration;
+  createdFiles: string[];
+  updatedFiles: string[];
+  packageRequirements: PackageRequirement[];
+  manualGuidance: string[];
+}
+
+const REACT_NATIVE_CLI_PACKAGES = [
+  '@react-native-community/cli',
+  '@react-native-community/cli-platform-android',
+  '@react-native-community/cli-platform-ios',
+];
+const RNEF_PACKAGES = ['@rnef/cli', '@rnef/config'];
+const REACT_NATIVE_CONFIG_FILES = [
+  'react-native.config.js',
+  'react-native.config.cjs',
+  'react-native.config.ts',
+  'react-native.config.mjs',
+];
+const RNEF_CONFIG_FILES = ['rnef.config.js', 'rnef.config.ts', 'rnef.config.mjs'];
+const MODULE_FEDERATION_METRO_VERSION = '^2.9.0';
+
+const MANUAL_GUIDANCE = [
+  'No React Native command config was changed because the integration could not be updated safely.',
+  'React Native CLI: export commands: [...(config.commands ?? []), ...zephyrMetroReactNativeCli().commands] from react-native.config.js and import zephyrMetroReactNativeCli from zephyr-metro-plugin.',
+  'RNEF: add zephyrMetroRNEFPlugin() to the exported plugins array in rnef.config.* and import zephyrMetroRNEFPlugin from zephyr-metro-plugin.',
+];
+
+type ConfigUpdateResult = 'updated' | 'already-configured' | 'unsupported';
+
+function readPackageJson(directory: string): Record<string, any> | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(directory, 'package.json'), 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function hasAnyPackage(packageJson: Record<string, any>, names: string[]): boolean {
+  const packages = {
+    ...packageJson['dependencies'],
+    ...packageJson['devDependencies'],
+  };
+  return names.some((name) => Boolean(packages[name]));
+}
+
+function getPackageVersion(
+  packageJson: Record<string, any>,
+  packageName: string
+): string | undefined {
+  return (
+    packageJson['dependencies']?.[packageName] ??
+    packageJson['devDependencies']?.[packageName]
+  );
+}
+
+function supportsMetroCommands(version: string): boolean {
+  const match = version.match(/(\d+)\.(\d+)/);
+  return Boolean(match && Number(match[1]) === 2 && Number(match[2]) >= 9);
+}
+
+function discoverConfigFiles(
+  directory: string,
+  prefix: string,
+  supportedFiles: string[]
+): { supported: string[]; unsupported: string[] } {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const candidates = entries
+    .filter((entry) => entry.isFile() && entry.name.startsWith(prefix))
+    .map((entry) => entry.name);
+  return {
+    supported: supportedFiles.filter((fileName) => candidates.includes(fileName)),
+    unsupported: candidates.filter((fileName) => !supportedFiles.includes(fileName)),
+  };
+}
+
+function findImportedHelperName(content: string, importName: string): string | undefined {
+  const importPatterns = [
+    /import\s*\{([^}]*)\}\s*from\s*["']zephyr-metro-plugin["']/g,
+    /(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\(["']zephyr-metro-plugin["']\)/g,
+  ];
+
+  for (const pattern of importPatterns) {
+    for (const match of content.matchAll(pattern)) {
+      const specifiers = match[1]?.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
+      for (const specifier of specifiers?.split(',') ?? []) {
+        const parts = specifier.trim().split(/\s+(?:as\s+)?|\s*:\s*/);
+        if (parts[0] === importName) {
+          return parts[1] ?? importName;
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function hasHelperCall(filePath: string, content: string, importName: string): boolean {
+  const localName = findImportedHelperName(content, importName);
+  return [importName, localName]
+    .filter((name): name is string => Boolean(name))
+    .some((name) => {
+      if (name.startsWith('$')) {
+        const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return new RegExp(`(?:^|[^$\\w])${escapedName}\\s*\\(`, 'm').test(content);
+      }
+      return (
+        searchWithAstGrep({ filePath, pattern: `${name}($$$ARGS)` }).status === 'match'
+      );
+    });
+}
+
+function addImport(content: string, importName: string, esm: boolean): string {
+  if (findImportedHelperName(content, importName)) {
+    return content;
+  }
+
+  const declaration = esm
+    ? `import { ${importName} } from "zephyr-metro-plugin";\n`
+    : `const { ${importName} } = require("zephyr-metro-plugin");\n`;
+  return `${declaration}${content}`;
+}
+
+function updateCommonJsConfig(
+  filePath: string,
+  importName: string,
+  bindingName: string,
+  propertyName: 'commands' | 'plugins',
+  integrationExpression: string,
+  dryRun: boolean
+): ConfigUpdateResult {
+  const content = fs.readFileSync(filePath, 'utf8');
+  if (hasHelperCall(filePath, content, importName)) {
+    return 'already-configured';
+  }
+  const localName = findImportedHelperName(content, importName) ?? importName;
+  if (
+    (content.match(/module\.exports\s*=/g)?.length ?? 0) !== 1 ||
+    searchWithAstGrep({
+      filePath,
+      pattern: 'module.exports = {$$$PROPS}',
+    }).status !== 'match'
+  ) {
+    return 'unsupported';
+  }
+
+  const nextContent = `${addImport(content, importName, false).trimEnd()}
+
+const ${bindingName} = module.exports;
+module.exports = {
+  ...${bindingName},
+  ${propertyName}: [
+    ...(${bindingName}.${propertyName} ?? []),
+    ${integrationExpression.replace(importName, localName)},
+  ],
+};
+`;
+  if (!dryRun) {
+    fs.writeFileSync(filePath, nextContent);
+  }
+  return 'updated';
+}
+
+function updateEsmConfig(
+  filePath: string,
+  importName: string,
+  bindingName: string,
+  propertyName: 'commands' | 'plugins',
+  integrationExpression: string,
+  dryRun: boolean
+): ConfigUpdateResult {
+  const content = fs.readFileSync(filePath, 'utf8');
+  if (hasHelperCall(filePath, content, importName)) {
+    return 'already-configured';
+  }
+  const localName = findImportedHelperName(content, importName) ?? importName;
+
+  const result = rewriteWithAstGrep({
+    filePath,
+    pattern: 'export default {$$$PROPS}',
+    rewrite: `const ${bindingName} = {$$$PROPS};
+export default {
+  ...${bindingName},
+  ${propertyName}: [
+    ...(${bindingName}.${propertyName} ?? []),
+    ${integrationExpression.replace(importName, localName)},
+  ],
+}`,
+    updateAll: !dryRun,
+  });
+  if (result.status !== 'match') {
+    return 'unsupported';
+  }
+
+  if (!dryRun) {
+    const updatedContent = fs.readFileSync(filePath, 'utf8');
+    fs.writeFileSync(filePath, addImport(updatedContent, importName, true));
+  }
+  return 'updated';
+}
+
+function updateConfig(
+  filePath: string,
+  importName: string,
+  bindingName: string,
+  propertyName: 'commands' | 'plugins',
+  integrationExpression: string,
+  dryRun: boolean
+): ConfigUpdateResult {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const esm = /(^|\n)\s*(import\s|export\s)/.test(content);
+  return esm
+    ? updateEsmConfig(
+        filePath,
+        importName,
+        bindingName,
+        propertyName,
+        integrationExpression,
+        dryRun
+      )
+    : updateCommonJsConfig(
+        filePath,
+        importName,
+        bindingName,
+        propertyName,
+        integrationExpression,
+        dryRun
+      );
+}
+
+export function bootstrapMetroCommands(
+  directory: string,
+  options: { dryRun?: boolean } = {}
+): MetroBootstrapResult {
+  const dryRun = options.dryRun ?? false;
+  const result: MetroBootstrapResult = {
+    integration: 'none',
+    createdFiles: [],
+    updatedFiles: [],
+    packageRequirements: [],
+    manualGuidance: [],
+  };
+  const packageJson = readPackageJson(directory);
+  if (!packageJson) {
+    result.integration = 'ambiguous';
+    result.manualGuidance = MANUAL_GUIDANCE;
+    return result;
+  }
+
+  const installedMetroVersion = getPackageVersion(
+    packageJson,
+    '@module-federation/metro'
+  );
+  if (installedMetroVersion && !supportsMetroCommands(installedMetroVersion)) {
+    result.integration = 'ambiguous';
+    result.manualGuidance = [
+      `Installed @module-federation/metro version ${installedMetroVersion} is not supported by the publication adapter. Use ${MODULE_FEDERATION_METRO_VERSION}.`,
+      ...MANUAL_GUIDANCE,
+    ];
+    return result;
+  }
+
+  const reactNativeConfigs = discoverConfigFiles(
+    directory,
+    'react-native.config',
+    REACT_NATIVE_CONFIG_FILES
+  );
+  const rnefConfigs = discoverConfigFiles(directory, 'rnef.config', RNEF_CONFIG_FILES);
+  const hasReactNativeCliPackage = hasAnyPackage(packageJson, REACT_NATIVE_CLI_PACKAGES);
+  const hasRnefPackage = hasAnyPackage(packageJson, RNEF_PACKAGES);
+  const hasInvalidCandidates =
+    reactNativeConfigs.unsupported.length > 0 ||
+    rnefConfigs.unsupported.length > 0 ||
+    reactNativeConfigs.supported.length > 1 ||
+    rnefConfigs.supported.length > 1;
+  const hasConflictingConfigs =
+    reactNativeConfigs.supported.length === 1 && rnefConfigs.supported.length === 1;
+  const hasReactNativeConfigWithRnefPackage =
+    reactNativeConfigs.supported.length === 1 &&
+    rnefConfigs.supported.length === 0 &&
+    hasRnefPackage;
+
+  if (
+    hasInvalidCandidates ||
+    hasConflictingConfigs ||
+    hasReactNativeConfigWithRnefPackage
+  ) {
+    result.integration = 'ambiguous';
+    result.manualGuidance = MANUAL_GUIDANCE;
+    return result;
+  }
+
+  const integration =
+    rnefConfigs.supported.length === 1 || hasRnefPackage
+      ? 'rnef'
+      : reactNativeConfigs.supported.length === 1 || hasReactNativeCliPackage
+        ? 'react-native-cli'
+        : 'ambiguous';
+  if (integration === 'ambiguous') {
+    result.integration = integration;
+    result.manualGuidance = MANUAL_GUIDANCE;
+    return result;
+  }
+
+  result.integration = integration;
+  const setPackageRequirements = () => {
+    result.packageRequirements = [
+      { name: 'zephyr-metro-plugin', isDev: true },
+      {
+        name: '@module-federation/metro',
+        isDev: true,
+        version: MODULE_FEDERATION_METRO_VERSION,
+      },
+    ];
+  };
+
+  if (integration === 'react-native-cli') {
+    const reactNativeConfigName = reactNativeConfigs.supported[0];
+    const reactNativeConfigPath = path.join(
+      directory,
+      reactNativeConfigName ?? 'react-native.config.js'
+    );
+    result.integration = 'react-native-cli';
+    if (!reactNativeConfigName) {
+      const esm = packageJson['type'] === 'module';
+      const content = esm
+        ? `import { zephyrMetroReactNativeCli } from "zephyr-metro-plugin";\n\nexport default zephyrMetroReactNativeCli();\n`
+        : `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\n\nmodule.exports = zephyrMetroReactNativeCli();\n`;
+      if (!dryRun) {
+        fs.writeFileSync(reactNativeConfigPath, content);
+      }
+      result.createdFiles.push('react-native.config.js');
+      setPackageRequirements();
+      return result;
+    }
+
+    const updateResult = updateConfig(
+      reactNativeConfigPath,
+      'zephyrMetroReactNativeCli',
+      '__zephyrReactNativeConfig',
+      'commands',
+      '...zephyrMetroReactNativeCli().commands',
+      dryRun
+    );
+    if (updateResult === 'updated') {
+      result.updatedFiles.push(reactNativeConfigName);
+    }
+    if (updateResult === 'unsupported') {
+      result.manualGuidance = [
+        `${reactNativeConfigName} does not directly export an object and was left unchanged.`,
+        ...MANUAL_GUIDANCE,
+      ];
+    } else {
+      setPackageRequirements();
+    }
+    return result;
+  }
+
+  const rnefConfigName =
+    rnefConfigs.supported[0] ??
+    (packageJson['type'] === 'module' ? 'rnef.config.mjs' : 'rnef.config.js');
+  const rnefConfigPath = path.join(directory, rnefConfigName);
+  if (rnefConfigs.supported.length === 0) {
+    const esm = rnefConfigName.endsWith('.mjs');
+    const content = esm
+      ? `import { zephyrMetroRNEFPlugin } from "zephyr-metro-plugin";\n\nexport default {\n  plugins: [zephyrMetroRNEFPlugin()],\n};\n`
+      : `const { zephyrMetroRNEFPlugin } = require("zephyr-metro-plugin");\n\nmodule.exports = {\n  plugins: [zephyrMetroRNEFPlugin()],\n};\n`;
+    if (!dryRun) {
+      fs.writeFileSync(rnefConfigPath, content);
+    }
+    result.createdFiles.push(rnefConfigName);
+    setPackageRequirements();
+    return result;
+  }
+
+  const updateResult = updateConfig(
+    rnefConfigPath,
+    'zephyrMetroRNEFPlugin',
+    '__zephyrRnefConfig',
+    'plugins',
+    'zephyrMetroRNEFPlugin()',
+    dryRun
+  );
+  if (updateResult === 'updated') {
+    result.updatedFiles.push(rnefConfigName);
+  }
+  if (updateResult === 'unsupported') {
+    result.manualGuidance = [
+      `${rnefConfigName} does not directly export an object and was left unchanged.`,
+      ...MANUAL_GUIDANCE,
+    ];
+  } else {
+    setPackageRequirements();
+  }
+  return result;
+}

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -124,7 +124,7 @@ function getVersionProblem(
 
 function hasModuleFederationSetup(filePath: string): boolean {
   const content = fs.readFileSync(filePath, 'utf8');
-  const localName = findImportedHelperName(
+  const localName = findImportedHelperExpression(
     content,
     '@module-federation/metro',
     'withModuleFederation'
@@ -154,7 +154,7 @@ function discoverConfigFiles(
   };
 }
 
-function findImportedHelperName(
+function findImportedHelperExpression(
   content: string,
   packageName: string,
   importName: string
@@ -180,6 +180,19 @@ function findImportedHelperName(
     }
   }
 
+  const namespacePatterns = [
+    new RegExp(
+      `import\\s*\\*\\s*as\\s*([A-Za-z_$][\\w$]*)\\s*from\\s*["']${escapedPackageName}["']`
+    ),
+    new RegExp(
+      `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*require\\(\\s*["']${escapedPackageName}["']\\s*\\)`
+    ),
+  ];
+  for (const pattern of namespacePatterns) {
+    const namespace = pattern.exec(content)?.[1];
+    if (namespace) return `${namespace}.${importName}`;
+  }
+
   return undefined;
 }
 
@@ -189,7 +202,11 @@ function hasExportedHelperCall(
   importName: string,
   propertyName: 'commands' | 'plugins'
 ): boolean {
-  const localName = findImportedHelperName(content, 'zephyr-metro-plugin', importName);
+  const localName = findImportedHelperExpression(
+    content,
+    'zephyr-metro-plugin',
+    importName
+  );
   return [importName, localName]
     .filter((name): name is string => Boolean(name))
     .some((name) => {
@@ -204,7 +221,7 @@ function hasExportedHelperCall(
 }
 
 function addImport(content: string, importName: string, esm: boolean): string {
-  if (findImportedHelperName(content, 'zephyr-metro-plugin', importName)) {
+  if (findImportedHelperExpression(content, 'zephyr-metro-plugin', importName)) {
     return content;
   }
 
@@ -236,7 +253,8 @@ function updateCommonJsConfig(
     return 'already-configured';
   }
   const localName =
-    findImportedHelperName(content, 'zephyr-metro-plugin', importName) ?? importName;
+    findImportedHelperExpression(content, 'zephyr-metro-plugin', importName) ??
+    importName;
   if (
     (content.match(/module\.exports\s*=/g)?.length ?? 0) !== 1 ||
     searchWithAstGrep({
@@ -277,7 +295,8 @@ function updateEsmConfig(
     return 'already-configured';
   }
   const localName =
-    findImportedHelperName(content, 'zephyr-metro-plugin', importName) ?? importName;
+    findImportedHelperExpression(content, 'zephyr-metro-plugin', importName) ??
+    importName;
 
   const result = rewriteWithAstGrep({
     filePath,

--- a/libs/with-zephyr/src/nextjs-vinext.ts
+++ b/libs/with-zephyr/src/nextjs-vinext.ts
@@ -4,6 +4,7 @@ import path from 'path';
 export interface PackageRequirement {
   name: string;
   isDev: boolean;
+  version?: string;
 }
 
 export interface NextJsVinextBootstrapResult {

--- a/libs/with-zephyr/src/nextjs-vinext.ts
+++ b/libs/with-zephyr/src/nextjs-vinext.ts
@@ -6,6 +6,7 @@ export interface PackageRequirement {
   isDev: boolean;
   version?: string;
   projectDirectory?: string;
+  requireResolved?: boolean;
 }
 
 export interface NextJsVinextBootstrapResult {

--- a/libs/with-zephyr/src/nextjs-vinext.ts
+++ b/libs/with-zephyr/src/nextjs-vinext.ts
@@ -5,6 +5,7 @@ export interface PackageRequirement {
   name: string;
   isDev: boolean;
   version?: string;
+  projectDirectory?: string;
 }
 
 export interface NextJsVinextBootstrapResult {

--- a/libs/with-zephyr/src/package-manager.ts
+++ b/libs/with-zephyr/src/package-manager.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
+import { createRequire } from 'module';
 import path from 'path';
 import type { PackageManager } from './types.js';
 
@@ -101,6 +102,158 @@ export function isPackageInstalled(
   } catch {
     return false;
   }
+}
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function parseVersion(value: string): ParsedVersion | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value.trim());
+  if (!match) return undefined;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareVersions(left: ParsedVersion, right: ParsedVersion): number {
+  return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+}
+
+export function isVersionAtLeast(version: string, minimumVersion: string): boolean {
+  const parsedVersion = parseVersion(version);
+  const parsedMinimum = parseVersion(minimumVersion);
+  return Boolean(
+    parsedVersion && parsedMinimum && compareVersions(parsedVersion, parsedMinimum) >= 0
+  );
+}
+
+export function isVersionCompatible(
+  version: string,
+  minimumVersion: string,
+  maximumVersionExclusive?: string
+): boolean {
+  if (!isVersionAtLeast(version, minimumVersion)) return false;
+  if (!maximumVersionExclusive) return true;
+  const parsedVersion = parseVersion(version);
+  const parsedMaximum = parseVersion(maximumVersionExclusive);
+  return Boolean(
+    parsedVersion && parsedMaximum && compareVersions(parsedVersion, parsedMaximum) < 0
+  );
+}
+
+export function isSafelyConstrainedVersion(
+  declaration: string,
+  minimumVersion: string,
+  maximumVersionExclusive?: string
+): boolean {
+  const value = declaration.trim();
+  const exactOrPrefixed = /^([~^]?)(\d+\.\d+\.\d+)$/.exec(value);
+  if (exactOrPrefixed) {
+    const prefix = exactOrPrefixed[1];
+    const version = exactOrPrefixed[2]!;
+    if (!isVersionCompatible(version, minimumVersion, maximumVersionExclusive)) {
+      return false;
+    }
+    if (!maximumVersionExclusive || prefix !== '^') return true;
+    const parsedVersion = parseVersion(version)!;
+    const parsedMaximum = parseVersion(maximumVersionExclusive)!;
+    return parsedVersion.major + 1 <= parsedMaximum.major;
+  }
+
+  const comparatorRange = /^>=(\d+\.\d+\.\d+)(?:\s+(<|<=)(\d+\.\d+\.\d+))?$/.exec(value);
+  if (!comparatorRange || !isVersionAtLeast(comparatorRange[1]!, minimumVersion)) {
+    return false;
+  }
+  if (!maximumVersionExclusive) return true;
+  if (!comparatorRange[2] || !comparatorRange[3]) return false;
+  const upper = parseVersion(comparatorRange[3])!;
+  const maximum = parseVersion(maximumVersionExclusive)!;
+  const comparison = compareVersions(upper, maximum);
+  return comparison < 0 || (comparison === 0 && comparatorRange[2] === '<');
+}
+
+export function getDeclaredPackageVersion(
+  packageName: string,
+  directory: string
+): string | undefined {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(directory, 'package.json'), 'utf8')
+    );
+    return (
+      packageJson.dependencies?.[packageName] ??
+      packageJson.devDependencies?.[packageName]
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export function getResolvedPackageVersion(
+  packageName: string,
+  directory: string
+): string | undefined {
+  try {
+    let currentDirectory = path.resolve(directory);
+    while (true) {
+      const candidate = path.join(
+        currentDirectory,
+        'node_modules',
+        ...packageName.split('/'),
+        'package.json'
+      );
+      if (fs.existsSync(candidate)) {
+        const packageJson = JSON.parse(fs.readFileSync(candidate, 'utf8'));
+        return typeof packageJson.version === 'string' ? packageJson.version : undefined;
+      }
+      const parentDirectory = path.dirname(currentDirectory);
+      if (parentDirectory === currentDirectory) break;
+      currentDirectory = parentDirectory;
+    }
+
+    const runtimeRequire = createRequire(path.join(directory, 'package.json'));
+    const packageJsonPath = runtimeRequire.resolve(`${packageName}/package.json`);
+    currentDirectory = path.resolve(directory);
+    let belongsToProject = false;
+    while (true) {
+      if (
+        fs.existsSync(path.join(currentDirectory, 'package.json')) &&
+        packageJsonPath.startsWith(`${currentDirectory}${path.sep}`)
+      ) {
+        belongsToProject = true;
+        break;
+      }
+      const parentDirectory = path.dirname(currentDirectory);
+      if (parentDirectory === currentDirectory) break;
+      currentDirectory = parentDirectory;
+    }
+    if (!belongsToProject) return undefined;
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    return typeof packageJson.version === 'string' ? packageJson.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isPackageRequirementSatisfied(
+  packageName: string,
+  directory: string,
+  minimumVersion?: string
+): boolean {
+  const declaration = getDeclaredPackageVersion(packageName, directory);
+  if (!minimumVersion) {
+    return declaration !== undefined;
+  }
+  const resolvedVersion = getResolvedPackageVersion(packageName, directory);
+  if (resolvedVersion) {
+    return isVersionAtLeast(resolvedVersion, minimumVersion);
+  }
+  return Boolean(declaration && isSafelyConstrainedVersion(declaration, minimumVersion));
 }
 
 /** Build an add command for one or more packages */

--- a/libs/with-zephyr/src/package-manager.ts
+++ b/libs/with-zephyr/src/package-manager.ts
@@ -5,10 +5,13 @@ import path from 'path';
 import type { PackageManager } from './types.js';
 
 /** Detect the package manager being used in the project */
-export function detectPackageManager(directory: string = process.cwd()): PackageManager {
+export function detectPackageManager(
+  directory: string = process.cwd(),
+  options: { ignoreUserAgent?: boolean } = {}
+): PackageManager {
   // Priority 1: Check which CLI is actually running (npm_config_user_agent)
   // This is most accurate when someone runs `pnpm dlx with-zephyr` or `npx with-zephyr`
-  if (process.env['npm_config_user_agent']) {
+  if (!options.ignoreUserAgent && process.env['npm_config_user_agent']) {
     const userAgent = process.env['npm_config_user_agent'].toLowerCase();
     if (userAgent.includes('pnpm')) return 'pnpm';
     if (userAgent.includes('yarn')) return 'yarn';
@@ -20,6 +23,7 @@ export function detectPackageManager(directory: string = process.cwd()): Package
   const lockFiles: Record<string, PackageManager> = {
     'pnpm-lock.yaml': 'pnpm',
     'yarn.lock': 'yarn',
+    'bun.lock': 'bun',
     'bun.lockb': 'bun',
     'package-lock.json': 'npm',
   };
@@ -162,7 +166,13 @@ export function isSafelyConstrainedVersion(
     if (!maximumVersionExclusive || prefix !== '^') return true;
     const parsedVersion = parseVersion(version)!;
     const parsedMaximum = parseVersion(maximumVersionExclusive)!;
-    return parsedVersion.major + 1 <= parsedMaximum.major;
+    const caretUpperBound =
+      parsedVersion.major > 0
+        ? { major: parsedVersion.major + 1, minor: 0, patch: 0 }
+        : parsedVersion.minor > 0
+          ? { major: 0, minor: parsedVersion.minor + 1, patch: 0 }
+          : { major: 0, minor: 0, patch: parsedVersion.patch + 1 };
+    return compareVersions(caretUpperBound, parsedMaximum) <= 0;
   }
 
   const comparatorRange = /^>=(\d+\.\d+\.\d+)(?:\s+(<|<=)(\d+\.\d+\.\d+))?$/.exec(value);
@@ -249,11 +259,25 @@ export function isPackageRequirementSatisfied(
   if (!minimumVersion) {
     return declaration !== undefined;
   }
+  if (!declaration) return false;
+  if (isSafelyConstrainedVersion(declaration, minimumVersion)) return true;
+  if (isSafelyConstrainedVersion(declaration, '0.0.0')) return false;
   const resolvedVersion = getResolvedPackageVersion(packageName, directory);
-  if (resolvedVersion) {
-    return isVersionAtLeast(resolvedVersion, minimumVersion);
-  }
-  return Boolean(declaration && isSafelyConstrainedVersion(declaration, minimumVersion));
+  return Boolean(resolvedVersion && isVersionAtLeast(resolvedVersion, minimumVersion));
+}
+
+export function isResolvedPackageRequirementSatisfied(
+  packageName: string,
+  directory: string,
+  minimumVersion?: string,
+  maximumVersionExclusive?: string
+): boolean {
+  const resolvedVersion = getResolvedPackageVersion(packageName, directory);
+  return Boolean(
+    resolvedVersion &&
+    (!minimumVersion ||
+      isVersionCompatible(resolvedVersion, minimumVersion, maximumVersionExclusive))
+  );
 }
 
 /** Build an add command for one or more packages */

--- a/libs/with-zephyr/src/package-manager.ts
+++ b/libs/with-zephyr/src/package-manager.ts
@@ -416,10 +416,12 @@ export function addToPackageJson(
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
     const depType = isDev ? 'devDependencies' : 'dependencies';
+    const oppositeDepType = isDev ? 'dependencies' : 'devDependencies';
     if (!packageJson[depType]) {
       packageJson[depType] = {};
     }
 
+    delete packageJson[oppositeDepType]?.[packageName];
     packageJson[depType][packageName] = /^[~^<>=*]|\s|\|\|/.test(version)
       ? version
       : `^${version}`;

--- a/libs/with-zephyr/src/package-manager.ts
+++ b/libs/with-zephyr/src/package-manager.ts
@@ -243,7 +243,9 @@ export function addToPackageJson(
       packageJson[depType] = {};
     }
 
-    packageJson[depType][packageName] = `^${version}`;
+    packageJson[depType][packageName] = /^[~^<>=*]|\s|\|\|/.test(version)
+      ? version
+      : `^${version}`;
 
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
     return true;

--- a/libs/with-zephyr/src/package-manager.ts
+++ b/libs/with-zephyr/src/package-manager.ts
@@ -204,7 +204,7 @@ export function getDeclaredPackageVersion(
   }
 }
 
-export function getResolvedPackageVersion(
+export function getResolvedPackageDirectory(
   packageName: string,
   directory: string
 ): string | undefined {
@@ -218,8 +218,7 @@ export function getResolvedPackageVersion(
         'package.json'
       );
       if (fs.existsSync(candidate)) {
-        const packageJson = JSON.parse(fs.readFileSync(candidate, 'utf8'));
-        return typeof packageJson.version === 'string' ? packageJson.version : undefined;
+        return fs.realpathSync(path.dirname(candidate));
       }
       const parentDirectory = path.dirname(currentDirectory);
       if (parentDirectory === currentDirectory) break;
@@ -229,21 +228,33 @@ export function getResolvedPackageVersion(
     const runtimeRequire = createRequire(path.join(directory, 'package.json'));
     const packageJsonPath = runtimeRequire.resolve(`${packageName}/package.json`);
     currentDirectory = path.resolve(directory);
-    let belongsToProject = false;
     while (true) {
       if (
         fs.existsSync(path.join(currentDirectory, 'package.json')) &&
         packageJsonPath.startsWith(`${currentDirectory}${path.sep}`)
       ) {
-        belongsToProject = true;
-        break;
+        return path.dirname(packageJsonPath);
       }
       const parentDirectory = path.dirname(currentDirectory);
       if (parentDirectory === currentDirectory) break;
       currentDirectory = parentDirectory;
     }
-    if (!belongsToProject) return undefined;
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getResolvedPackageVersion(
+  packageName: string,
+  directory: string
+): string | undefined {
+  try {
+    const packageDirectory = getResolvedPackageDirectory(packageName, directory);
+    if (!packageDirectory) return undefined;
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(packageDirectory, 'package.json'), 'utf8')
+    );
     return typeof packageJson.version === 'string' ? packageJson.version : undefined;
   } catch {
     return undefined;

--- a/libs/with-zephyr/src/tests/codemod.test.ts
+++ b/libs/with-zephyr/src/tests/codemod.test.ts
@@ -517,6 +517,12 @@ describe('Zephyr Codemod CLI', () => {
 
       expect(output).toContain('Created apps/host/react-native.config.js');
       expect(output).toContain('Created apps/remote/react-native.config.js');
+      expect(output).toContain(
+        'Publish the first bundle with: cd "apps/host" && npx react-native bundle-mf-remote --platform <platform> --dev false'
+      );
+      expect(output).toContain(
+        'Publish the first bundle with: cd "apps/remote" && npx react-native bundle-mf-remote --platform <platform> --dev false'
+      );
       expect(fs.existsSync('apps/host/react-native.config.js')).toBe(true);
       expect(fs.existsSync('apps/remote/react-native.config.js')).toBe(true);
       for (const project of ['apps/host', 'apps/remote']) {

--- a/libs/with-zephyr/src/tests/codemod.test.ts
+++ b/libs/with-zephyr/src/tests/codemod.test.ts
@@ -56,6 +56,24 @@ describe('Zephyr Codemod CLI', () => {
     'metro-source-map': '^0.82.1',
   };
 
+  const writeResolvedMetroCompanions = (directory = tempDir) => {
+    for (const [packageName, version] of [
+      ['zephyr-metro-plugin', '1.4.2'],
+      ['@module-federation/metro', '2.9.1'],
+    ]) {
+      const packageDirectory = path.join(
+        directory,
+        'node_modules',
+        ...packageName.split('/')
+      );
+      fs.mkdirSync(packageDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, 'package.json'),
+        JSON.stringify({ name: packageName, version })
+      );
+    }
+  };
+
   describe('CLI Options', () => {
     it('should show help when --help is provided', () => {
       const output = runCodemod('--help');
@@ -448,6 +466,7 @@ describe('Zephyr Codemod CLI', () => {
     });
 
     it('should bootstrap React Native CLI publication commands', () => {
+      writeResolvedMetroCompanions();
       fs.writeFileSync(
         'package.json',
         JSON.stringify({
@@ -708,8 +727,90 @@ describe('Zephyr Codemod CLI', () => {
       });
 
       expect(output).toContain('Failed to install dependencies from package.json');
-      expect(output).toContain('✗ Errors: 1');
+      expect(output).toContain('✗ Errors: 2');
       expect(output).not.toContain('Publish the first bundle with:');
+    });
+
+    it('should not advertise publication when declared companions remain unresolved', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          packageManager: 'pnpm@11.0.0',
+          dependencies: { 'react-native': '^0.79.0' },
+          devDependencies: {
+            '@module-federation/metro': '^2.9.0',
+            '@react-native-community/cli': '^19.0.0',
+            ...compatibleMetroPeers,
+            'zephyr-metro-plugin': '^1.4.0',
+          },
+        })
+      );
+      fs.writeFileSync(
+        'metro.config.js',
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+      );
+      const fakeBin = path.join(tempDir, 'fake-bin');
+      fs.mkdirSync(fakeBin);
+      const fakePnpm = path.join(fakeBin, 'pnpm');
+      fs.writeFileSync(fakePnpm, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(fakePnpm, 0o755);
+      fs.writeFileSync(path.join(fakeBin, 'pnpm.cmd'), '@exit /b 0\r\n');
+
+      const output = runCodemod('', true, {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        npm_config_user_agent: 'pnpm/11.0.0',
+      });
+
+      expect(output).toContain(
+        'zephyr-metro-plugin, @module-federation/metro cannot be resolved at compatible versions'
+      );
+      expect(output).toContain('✗ Errors: 2');
+      expect(output).not.toContain('Publish the first bundle with:');
+    });
+
+    it('should preserve a production Metro plugin requirement when merging', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          packageManager: 'pnpm@11.0.0',
+          dependencies: {
+            'react-native': '^0.79.0',
+            'zephyr-metro-plugin': '^1.3.0',
+          },
+          devDependencies: {
+            '@module-federation/metro': '^2.9.0',
+            '@react-native-community/cli': '^19.0.0',
+            ...compatibleMetroPeers,
+          },
+        })
+      );
+      fs.writeFileSync(
+        'metro.config.js',
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+      );
+      const fakeBin = path.join(tempDir, 'fake-bin');
+      fs.mkdirSync(fakeBin);
+      const fakeScript = path.join(fakeBin, 'fake-pnpm.js');
+      fs.writeFileSync(
+        fakeScript,
+        `const fs = require("node:fs"); const path = require("node:path"); for (const [name, version] of [["zephyr-metro-plugin", "1.4.2"], ["@module-federation/metro", "2.9.1"]]) { const dir = path.join(process.cwd(), "node_modules", ...name.split("/")); fs.mkdirSync(dir, { recursive: true }); fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, version })); }\n`
+      );
+      const fakePnpm = path.join(fakeBin, 'pnpm');
+      fs.writeFileSync(fakePnpm, `#!/bin/sh\n"${process.execPath}" "${fakeScript}"\n`);
+      fs.chmodSync(fakePnpm, 0o755);
+      fs.writeFileSync(
+        path.join(fakeBin, 'pnpm.cmd'),
+        `@"${process.execPath}" "${fakeScript}"\r\n`
+      );
+
+      runCodemod('', false, {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        npm_config_user_agent: 'pnpm/11.0.0',
+      });
+      const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+      expect(packageJson.dependencies['zephyr-metro-plugin']).toBe('^1.4.0');
+      expect(packageJson.devDependencies['zephyr-metro-plugin']).toBeUndefined();
     });
 
     it('should fail when a successful nested install leaves requirements unresolved', () => {
@@ -818,6 +919,7 @@ describe('Zephyr Codemod CLI', () => {
     });
 
     it('should print Android for Android-only CLI projects', () => {
+      writeResolvedMetroCompanions();
       fs.writeFileSync(
         'package.json',
         JSON.stringify({

--- a/libs/with-zephyr/src/tests/codemod.test.ts
+++ b/libs/with-zephyr/src/tests/codemod.test.ts
@@ -394,6 +394,10 @@ describe('Zephyr Codemod CLI', () => {
     });
 
     it('should transform metro config with async wrapper', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({ devDependencies: { 'zephyr-metro-plugin': '^1.4.0' } })
+      );
       const originalContent = `
         const { getDefaultConfig } = require('@react-native/metro-config');
         module.exports = getDefaultConfig(__dirname);
@@ -413,6 +417,10 @@ describe('Zephyr Codemod CLI', () => {
     });
 
     it('should transform metro ESM config with async wrapper', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({ devDependencies: { 'zephyr-metro-plugin': '^1.4.0' } })
+      );
       const originalContent = `
         export default {
           resolver: { sourceExts: ['js', 'ts'] }
@@ -434,16 +442,18 @@ describe('Zephyr Codemod CLI', () => {
       fs.writeFileSync(
         'package.json',
         JSON.stringify({
+          dependencies: { 'react-native': '^0.79.0' },
           devDependencies: {
             '@react-native-community/cli': '^19.0.0',
             '@module-federation/metro': '^2.9.0',
-            'zephyr-metro-plugin': '^1.3.0',
+            metro: '^0.82.0',
+            'zephyr-metro-plugin': '^1.4.0',
           },
         })
       );
       fs.writeFileSync(
         'metro.config.js',
-        "module.exports = require('@react-native/metro-config').getDefaultConfig(__dirname);"
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
       );
 
       const output = runCodemod();
@@ -451,44 +461,62 @@ describe('Zephyr Codemod CLI', () => {
 
       expect(output).toContain('Created react-native.config.js');
       expect(output).toContain(
-        'Publish the first bundle with: npx react-native bundle-mf-remote --platform ios --dev false'
+        'Publish the first bundle with: npx react-native bundle-mf-remote --platform <platform> --dev false'
       );
       expect(cliConfig).toContain('module.exports = zephyrMetroReactNativeCli()');
     });
 
     it('should bootstrap every unique nested Metro project', () => {
-      fs.writeFileSync(
-        'package.json',
-        JSON.stringify({
-          devDependencies: {
-            '@module-federation/metro': '^2.9.0',
-            'zephyr-metro-plugin': '^1.3.0',
-          },
-        })
-      );
+      fs.writeFileSync('package.json', JSON.stringify({ private: true }));
+      const fakeBin = path.join(tempDir, 'fake-bin');
+      fs.mkdirSync(fakeBin);
+      const fakePnpm = path.join(fakeBin, 'pnpm');
+      fs.writeFileSync(fakePnpm, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(fakePnpm, 0o755);
+      fs.writeFileSync(path.join(fakeBin, 'pnpm.cmd'), '@exit /b 0\r\n');
       for (const project of ['apps/host', 'apps/remote']) {
         fs.mkdirSync(project, { recursive: true });
         fs.writeFileSync(
           path.join(project, 'package.json'),
           JSON.stringify({
-            devDependencies: { '@react-native-community/cli': '^19.0.0' },
+            dependencies: { 'react-native': '^0.79.0' },
+            devDependencies: {
+              '@react-native-community/cli': '^19.0.0',
+              metro: '^0.82.0',
+            },
           })
         );
         fs.writeFileSync(
           path.join(project, 'metro.config.js'),
-          'module.exports = { resolver: {} };\n'
+          `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
         );
       }
 
-      const output = runCodemod();
+      const output = runCodemod('', false, {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        npm_config_user_agent: 'pnpm/11.0.0',
+      });
 
       expect(output).toContain('Created apps/host/react-native.config.js');
       expect(output).toContain('Created apps/remote/react-native.config.js');
       expect(fs.existsSync('apps/host/react-native.config.js')).toBe(true);
       expect(fs.existsSync('apps/remote/react-native.config.js')).toBe(true);
+      for (const project of ['apps/host', 'apps/remote']) {
+        const packageJson = JSON.parse(
+          fs.readFileSync(path.join(project, 'package.json'), 'utf8')
+        );
+        expect(packageJson.devDependencies['zephyr-metro-plugin']).toBe('^1.4.0');
+        expect(packageJson.devDependencies['@module-federation/metro']).toBe('^2.9.0');
+      }
+      const rootPackageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+      expect(rootPackageJson.devDependencies).toBeUndefined();
     });
 
     it('should transform nuxt config by appending zephyr-nuxt-module', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({ devDependencies: { 'zephyr-nuxt-module': '^1.3.0' } })
+      );
       const originalContent = `
         export default defineNuxtConfig({
           modules: ['nitro-cloudflare-dev']
@@ -607,32 +635,40 @@ describe('Zephyr Codemod CLI', () => {
       fs.writeFileSync(
         'package.json',
         JSON.stringify({
+          dependencies: { 'react-native': '^0.79.0' },
           devDependencies: {
             '@react-native-community/cli': '^19.0.0',
             'zephyr-metro-plugin': '^1.3.0',
+            metro: '^0.82.0',
           },
         })
       );
-      fs.writeFileSync('metro.config.js', 'module.exports = { resolver: {} };\n');
+      fs.writeFileSync(
+        'metro.config.js',
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+      );
 
       const output = runCodemod('--dry-run');
 
       expect(output).toContain('@module-federation/metro@^2.9.0');
+      expect(output).toContain('zephyr-metro-plugin@^1.4.0');
     });
 
     it('should count dependency installation failures in the summary', () => {
       fs.writeFileSync(
         'package.json',
         JSON.stringify({
+          dependencies: { 'react-native': '^0.79.0' },
           devDependencies: {
             '@react-native-community/cli': '^19.0.0',
-            'zephyr-metro-plugin': '^1.3.0',
+            metro: '^0.82.0',
+            'zephyr-metro-plugin': '^1.4.0',
           },
         })
       );
       fs.writeFileSync(
         'metro.config.js',
-        `const { withZephyr } = require("zephyr-metro-plugin");\nmodule.exports = withZephyr()({ resolver: {} });\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nconst { withZephyr } = require("zephyr-metro-plugin");\nmodule.exports = withZephyr()(withModuleFederation({ name: "app" })({}));\n`
       );
       const fakeBin = path.join(tempDir, 'fake-bin');
       fs.mkdirSync(fakeBin);
@@ -649,6 +685,32 @@ describe('Zephyr Codemod CLI', () => {
       expect(output).toContain('Failed to install dependencies from package.json');
       expect(output).toContain('✗ Errors: 1');
       expect(output).not.toContain('Publish the first bundle with:');
+    });
+
+    it('should print Android for Android-only CLI projects', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          dependencies: { 'react-native': '^0.79.0' },
+          devDependencies: {
+            '@module-federation/metro': '^2.9.0',
+            '@react-native-community/cli': '^19.0.0',
+            '@react-native-community/cli-platform-android': '^19.0.0',
+            metro: '^0.82.0',
+            'zephyr-metro-plugin': '^1.4.0',
+          },
+        })
+      );
+      fs.writeFileSync(
+        'metro.config.js',
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+      );
+
+      const output = runCodemod();
+
+      expect(output).toContain(
+        'npx react-native bundle-mf-remote --platform android --dev false'
+      );
     });
   });
 

--- a/libs/with-zephyr/src/tests/codemod.test.ts
+++ b/libs/with-zephyr/src/tests/codemod.test.ts
@@ -23,10 +23,10 @@ describe('Zephyr Codemod CLI', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  const runCodemod = (args = '', expectError = false) => {
+  const runCodemod = (args = '', expectError = false, env: NodeJS.ProcessEnv = {}) => {
     const cliPath = path.join(packageRoot, 'dist', 'index.js');
     try {
-      const result = execSync(`node "${cliPath}" ${args} 2>&1`, {
+      const result = execSync(`"${process.execPath}" "${cliPath}" ${args} 2>&1`, {
         // Redirect stderr to stdout
         encoding: 'utf8',
         cwd: tempDir,
@@ -34,6 +34,7 @@ describe('Zephyr Codemod CLI', () => {
           ...process.env,
           NO_COLOR: '1',
           FORCE_COLOR: undefined, // Remove FORCE_COLOR override
+          ...env,
         }, // Disable colors for tests
       });
       return result;
@@ -429,6 +430,64 @@ describe('Zephyr Codemod CLI', () => {
       );
     });
 
+    it('should bootstrap React Native CLI publication commands', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          devDependencies: {
+            '@react-native-community/cli': '^19.0.0',
+            '@module-federation/metro': '^2.9.0',
+            'zephyr-metro-plugin': '^1.3.0',
+          },
+        })
+      );
+      fs.writeFileSync(
+        'metro.config.js',
+        "module.exports = require('@react-native/metro-config').getDefaultConfig(__dirname);"
+      );
+
+      const output = runCodemod();
+      const cliConfig = fs.readFileSync('react-native.config.js', 'utf8');
+
+      expect(output).toContain('Created react-native.config.js');
+      expect(output).toContain(
+        'Publish the first bundle with: npx react-native bundle-mf-remote --platform ios --dev false'
+      );
+      expect(cliConfig).toContain('module.exports = zephyrMetroReactNativeCli()');
+    });
+
+    it('should bootstrap every unique nested Metro project', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          devDependencies: {
+            '@module-federation/metro': '^2.9.0',
+            'zephyr-metro-plugin': '^1.3.0',
+          },
+        })
+      );
+      for (const project of ['apps/host', 'apps/remote']) {
+        fs.mkdirSync(project, { recursive: true });
+        fs.writeFileSync(
+          path.join(project, 'package.json'),
+          JSON.stringify({
+            devDependencies: { '@react-native-community/cli': '^19.0.0' },
+          })
+        );
+        fs.writeFileSync(
+          path.join(project, 'metro.config.js'),
+          'module.exports = { resolver: {} };\n'
+        );
+      }
+
+      const output = runCodemod();
+
+      expect(output).toContain('Created apps/host/react-native.config.js');
+      expect(output).toContain('Created apps/remote/react-native.config.js');
+      expect(fs.existsSync('apps/host/react-native.config.js')).toBe(true);
+      expect(fs.existsSync('apps/remote/react-native.config.js')).toBe(true);
+    });
+
     it('should transform nuxt config by appending zephyr-nuxt-module', () => {
       const originalContent = `
         export default defineNuxtConfig({
@@ -542,6 +601,54 @@ describe('Zephyr Codemod CLI', () => {
 
       const output = runCodemod('--dry-run');
       expect(output).not.toContain('📦 Packages that would be installed');
+    });
+
+    it('should pin the Metro companion package in dry-run output', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          devDependencies: {
+            '@react-native-community/cli': '^19.0.0',
+            'zephyr-metro-plugin': '^1.3.0',
+          },
+        })
+      );
+      fs.writeFileSync('metro.config.js', 'module.exports = { resolver: {} };\n');
+
+      const output = runCodemod('--dry-run');
+
+      expect(output).toContain('@module-federation/metro@^2.9.0');
+    });
+
+    it('should count dependency installation failures in the summary', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          devDependencies: {
+            '@react-native-community/cli': '^19.0.0',
+            'zephyr-metro-plugin': '^1.3.0',
+          },
+        })
+      );
+      fs.writeFileSync(
+        'metro.config.js',
+        `const { withZephyr } = require("zephyr-metro-plugin");\nmodule.exports = withZephyr()({ resolver: {} });\n`
+      );
+      const fakeBin = path.join(tempDir, 'fake-bin');
+      fs.mkdirSync(fakeBin);
+      const fakePnpm = path.join(fakeBin, 'pnpm');
+      fs.writeFileSync(fakePnpm, '#!/bin/sh\nexit 1\n');
+      fs.chmodSync(fakePnpm, 0o755);
+      fs.writeFileSync(path.join(fakeBin, 'pnpm.cmd'), '@exit /b 1\r\n');
+
+      const output = runCodemod('', true, {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        npm_config_user_agent: 'pnpm/11.0.0',
+      });
+
+      expect(output).toContain('Failed to install dependencies from package.json');
+      expect(output).toContain('✗ Errors: 1');
+      expect(output).not.toContain('Publish the first bundle with:');
     });
   });
 

--- a/libs/with-zephyr/src/tests/codemod.test.ts
+++ b/libs/with-zephyr/src/tests/codemod.test.ts
@@ -46,6 +46,15 @@ describe('Zephyr Codemod CLI', () => {
       throw error;
     }
   };
+  const compatibleMetroPeers = {
+    '@babel/types': '^7.25.0',
+    react: '^19.0.0',
+    metro: '^0.82.1',
+    'metro-config': '^0.82.1',
+    'metro-file-map': '^0.82.1',
+    'metro-resolver': '^0.82.1',
+    'metro-source-map': '^0.82.1',
+  };
 
   describe('CLI Options', () => {
     it('should show help when --help is provided', () => {
@@ -446,7 +455,7 @@ describe('Zephyr Codemod CLI', () => {
           devDependencies: {
             '@react-native-community/cli': '^19.0.0',
             '@module-federation/metro': '^2.9.0',
-            metro: '^0.82.0',
+            ...compatibleMetroPeers,
             'zephyr-metro-plugin': '^1.4.0',
           },
         })
@@ -470,19 +479,28 @@ describe('Zephyr Codemod CLI', () => {
       fs.writeFileSync('package.json', JSON.stringify({ private: true }));
       const fakeBin = path.join(tempDir, 'fake-bin');
       fs.mkdirSync(fakeBin);
+      const fakeScript = path.join(fakeBin, 'fake-pnpm.js');
+      fs.writeFileSync(
+        fakeScript,
+        `const fs = require("node:fs"); const path = require("node:path"); if (["host", "remote"].includes(path.basename(process.cwd()))) { for (const [name, version] of [["zephyr-metro-plugin", "1.4.2"], ["@module-federation/metro", "2.9.1"]]) { const dir = path.join(process.cwd(), "node_modules", ...name.split("/")); fs.mkdirSync(dir, { recursive: true }); fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, version })); } }\n`
+      );
       const fakePnpm = path.join(fakeBin, 'pnpm');
-      fs.writeFileSync(fakePnpm, '#!/bin/sh\nexit 0\n');
+      fs.writeFileSync(fakePnpm, `#!/bin/sh\n"${process.execPath}" "${fakeScript}"\n`);
       fs.chmodSync(fakePnpm, 0o755);
-      fs.writeFileSync(path.join(fakeBin, 'pnpm.cmd'), '@exit /b 0\r\n');
+      fs.writeFileSync(
+        path.join(fakeBin, 'pnpm.cmd'),
+        `@"${process.execPath}" "${fakeScript}"\r\n`
+      );
       for (const project of ['apps/host', 'apps/remote']) {
         fs.mkdirSync(project, { recursive: true });
         fs.writeFileSync(
           path.join(project, 'package.json'),
           JSON.stringify({
+            packageManager: 'pnpm@11.0.0',
             dependencies: { 'react-native': '^0.79.0' },
             devDependencies: {
               '@react-native-community/cli': '^19.0.0',
-              metro: '^0.82.0',
+              ...compatibleMetroPeers,
             },
           })
         );
@@ -635,11 +653,12 @@ describe('Zephyr Codemod CLI', () => {
       fs.writeFileSync(
         'package.json',
         JSON.stringify({
+          packageManager: 'pnpm@11.0.0',
           dependencies: { 'react-native': '^0.79.0' },
           devDependencies: {
             '@react-native-community/cli': '^19.0.0',
             'zephyr-metro-plugin': '^1.3.0',
-            metro: '^0.82.0',
+            ...compatibleMetroPeers,
           },
         })
       );
@@ -661,7 +680,7 @@ describe('Zephyr Codemod CLI', () => {
           dependencies: { 'react-native': '^0.79.0' },
           devDependencies: {
             '@react-native-community/cli': '^19.0.0',
-            metro: '^0.82.0',
+            ...compatibleMetroPeers,
             'zephyr-metro-plugin': '^1.4.0',
           },
         })
@@ -687,6 +706,111 @@ describe('Zephyr Codemod CLI', () => {
       expect(output).not.toContain('Publish the first bundle with:');
     });
 
+    it('should fail when a successful nested install leaves requirements unresolved', () => {
+      fs.writeFileSync('package.json', JSON.stringify({ private: true }));
+      const projectDirectory = path.join(tempDir, 'apps', 'standalone');
+      fs.mkdirSync(projectDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDirectory, 'package.json'),
+        JSON.stringify({
+          packageManager: 'pnpm@11.0.0',
+          dependencies: { 'react-native': '^0.79.0' },
+          devDependencies: {
+            '@react-native-community/cli': '^19.0.0',
+            ...compatibleMetroPeers,
+          },
+        })
+      );
+      fs.writeFileSync(
+        path.join(projectDirectory, 'metro.config.js'),
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+      );
+      const fakeBin = path.join(tempDir, 'fake-bin');
+      fs.mkdirSync(fakeBin);
+      const fakeScript = path.join(fakeBin, 'fake-pnpm.js');
+      fs.writeFileSync(fakeScript, 'process.exit(0);\n');
+      const fakePnpm = path.join(fakeBin, 'pnpm');
+      fs.writeFileSync(fakePnpm, `#!/bin/sh\n"${process.execPath}" "${fakeScript}"\n`);
+      fs.chmodSync(fakePnpm, 0o755);
+      fs.writeFileSync(
+        path.join(fakeBin, 'pnpm.cmd'),
+        `@"${process.execPath}" "${fakeScript}"\r\n`
+      );
+
+      const output = runCodemod('', true, {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        npm_config_user_agent: 'pnpm/11.0.0',
+      });
+
+      expect(output).toContain(
+        'Installed dependencies in apps/standalone, but zephyr-metro-plugin, @module-federation/metro still cannot be resolved at compatible versions'
+      );
+      expect(output).toContain('✗ Errors: 2');
+      expect(output).not.toContain('Publish the first bundle with:');
+    });
+
+    it('should not reinstall a nested project covered by the root workspace', () => {
+      fs.writeFileSync('package.json', JSON.stringify({ private: true }));
+      for (const [packageName, version] of [
+        ['zephyr-metro-plugin', '1.4.2'],
+        ['@module-federation/metro', '2.9.1'],
+      ]) {
+        const packageDirectory = path.join(
+          tempDir,
+          'node_modules',
+          ...packageName.split('/')
+        );
+        fs.mkdirSync(packageDirectory, { recursive: true });
+        fs.writeFileSync(
+          path.join(packageDirectory, 'package.json'),
+          JSON.stringify({ name: packageName, version })
+        );
+      }
+      const projectDirectory = path.join(tempDir, 'apps', 'workspace-native');
+      fs.mkdirSync(projectDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDirectory, 'package.json'),
+        JSON.stringify({
+          dependencies: { 'react-native': '^0.79.0' },
+          devDependencies: {
+            '@react-native-community/cli': '^19.0.0',
+            ...compatibleMetroPeers,
+          },
+        })
+      );
+      fs.writeFileSync(
+        path.join(projectDirectory, 'metro.config.js'),
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+      );
+      const fakeBin = path.join(tempDir, 'fake-bin');
+      fs.mkdirSync(fakeBin);
+      const installsFile = path.join(tempDir, 'installs.txt');
+      const fakeScript = path.join(fakeBin, 'fake-pnpm.js');
+      fs.writeFileSync(
+        fakeScript,
+        `require("node:fs").appendFileSync(${JSON.stringify(installsFile)}, process.cwd() + "\\n");\n`
+      );
+      const fakePnpm = path.join(fakeBin, 'pnpm');
+      fs.writeFileSync(fakePnpm, `#!/bin/sh\n"${process.execPath}" "${fakeScript}"\n`);
+      fs.chmodSync(fakePnpm, 0o755);
+      fs.writeFileSync(
+        path.join(fakeBin, 'pnpm.cmd'),
+        `@"${process.execPath}" "${fakeScript}"\r\n`
+      );
+
+      runCodemod('', false, {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        npm_config_user_agent: 'pnpm/11.0.0',
+      });
+
+      const installDirectories = fs
+        .readFileSync(installsFile, 'utf8')
+        .trim()
+        .split(/\r?\n/);
+      expect(installDirectories).toHaveLength(1);
+      expect(path.basename(installDirectories[0]!)).toBe(path.basename(tempDir));
+    });
+
     it('should print Android for Android-only CLI projects', () => {
       fs.writeFileSync(
         'package.json',
@@ -696,7 +820,7 @@ describe('Zephyr Codemod CLI', () => {
             '@module-federation/metro': '^2.9.0',
             '@react-native-community/cli': '^19.0.0',
             '@react-native-community/cli-platform-android': '^19.0.0',
-            metro: '^0.82.0',
+            ...compatibleMetroPeers,
             'zephyr-metro-plugin': '^1.4.0',
           },
         })

--- a/libs/with-zephyr/src/tests/codemod.test.ts
+++ b/libs/with-zephyr/src/tests/codemod.test.ts
@@ -481,7 +481,7 @@ describe('Zephyr Codemod CLI', () => {
       );
       fs.writeFileSync(
         'metro.config.js',
-        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
       );
 
       const output = runCodemod();
@@ -492,6 +492,35 @@ describe('Zephyr Codemod CLI', () => {
         'Publish the first bundle with: npx react-native bundle-mf-remote --platform <platform> --dev false'
       );
       expect(cliConfig).toContain('module.exports = zephyrMetroReactNativeCli()');
+    });
+
+    it('should not print federation guidance after a successful Metro rerun', () => {
+      writeResolvedMetroCompanions();
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          dependencies: { 'react-native': '^0.79.0' },
+          devDependencies: {
+            '@react-native-community/cli': '^19.0.0',
+            '@module-federation/metro': '^2.9.0',
+            ...compatibleMetroPeers,
+            'zephyr-metro-plugin': '^1.4.0',
+          },
+        })
+      );
+      fs.writeFileSync(
+        'metro.config.js',
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
+      );
+
+      expect(runCodemod()).toContain('Created react-native.config.js');
+      const output = runCodemod();
+
+      expect(output).toContain(
+        'Skipping metro.config.js (already has Zephyr integration)'
+      );
+      expect(output).not.toContain('is not verifiably configured');
+      expect(output).not.toContain('Companion command config was left unchanged');
     });
 
     it('should bootstrap every unique nested Metro project', () => {
@@ -525,7 +554,7 @@ describe('Zephyr Codemod CLI', () => {
         );
         fs.writeFileSync(
           path.join(project, 'metro.config.js'),
-          `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+          `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
         );
       }
 
@@ -689,7 +718,7 @@ describe('Zephyr Codemod CLI', () => {
       );
       fs.writeFileSync(
         'metro.config.js',
-        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
       );
 
       const output = runCodemod('--dry-run');
@@ -712,7 +741,7 @@ describe('Zephyr Codemod CLI', () => {
       );
       fs.writeFileSync(
         'metro.config.js',
-        `const { withModuleFederation } = require("@module-federation/metro");\nconst { withZephyr } = require("zephyr-metro-plugin");\nmodule.exports = withZephyr()(withModuleFederation({ name: "app" })({}));\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nconst { withZephyr } = require("zephyr-metro-plugin");\nmodule.exports = withZephyr()(withModuleFederation({}, { name: "app" }));\n`
       );
       const fakeBin = path.join(tempDir, 'fake-bin');
       fs.mkdirSync(fakeBin);
@@ -747,7 +776,7 @@ describe('Zephyr Codemod CLI', () => {
       );
       fs.writeFileSync(
         'metro.config.js',
-        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
       );
       const fakeBin = path.join(tempDir, 'fake-bin');
       fs.mkdirSync(fakeBin);
@@ -786,7 +815,7 @@ describe('Zephyr Codemod CLI', () => {
       );
       fs.writeFileSync(
         'metro.config.js',
-        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
       );
       const fakeBin = path.join(tempDir, 'fake-bin');
       fs.mkdirSync(fakeBin);
@@ -830,7 +859,7 @@ describe('Zephyr Codemod CLI', () => {
       );
       fs.writeFileSync(
         path.join(projectDirectory, 'metro.config.js'),
-        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
       );
       const fakeBin = path.join(tempDir, 'fake-bin');
       fs.mkdirSync(fakeBin);
@@ -887,7 +916,7 @@ describe('Zephyr Codemod CLI', () => {
       );
       fs.writeFileSync(
         path.join(projectDirectory, 'metro.config.js'),
-        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
       );
       const fakeBin = path.join(tempDir, 'fake-bin');
       fs.mkdirSync(fakeBin);
@@ -935,7 +964,7 @@ describe('Zephyr Codemod CLI', () => {
       );
       fs.writeFileSync(
         'metro.config.js',
-        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
       );
 
       const output = runCodemod();

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -11,7 +11,7 @@ describe('bootstrapMetroCommands', () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zephyr-metro-bootstrap-'));
     fs.writeFileSync(
       path.join(tempDir, 'metro.config.js'),
-      `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+      `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
     );
   });
 
@@ -724,7 +724,7 @@ describe('bootstrapMetroCommands', () => {
     });
     fs.writeFileSync(
       path.join(tempDir, 'metro.config.js'),
-      `const { withModuleFederation } = require("@module-federation/metro");\nconst unused = withModuleFederation({ name: "app" })({});\nmodule.exports = { resolver: {} };\n`
+      `const { withModuleFederation } = require("@module-federation/metro");\nconst unused = withModuleFederation({}, { name: "app" });\nmodule.exports = { resolver: {} };\n`
     );
 
     const result = bootstrapMetroCommands(tempDir);
@@ -854,6 +854,7 @@ describe('bootstrapMetroCommands', () => {
     const packageJsonPath = path.join(tempDir, 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
     for (const packageName of [
+      '@babel/types',
       'metro',
       'metro-config',
       'metro-file-map',
@@ -864,18 +865,27 @@ describe('bootstrapMetroCommands', () => {
     }
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
 
-    const metroConfigDirectory = writeResolvedPackage(
+    const reactNativeMetroConfigDirectory = writeResolvedPackage(
       '@react-native/metro-config',
       '0.79.0'
     );
-    for (const packageName of [
-      'metro',
+    const metroConfigDirectory = writeResolvedPackage(
       'metro-config',
+      '0.82.1',
+      reactNativeMetroConfigDirectory
+    );
+    const metroDirectory = writeResolvedPackage('metro', '0.82.1', metroConfigDirectory);
+    for (const packageName of [
+      '@babel/types',
       'metro-file-map',
       'metro-resolver',
       'metro-source-map',
     ]) {
-      writeResolvedPackage(packageName, '0.82.1', metroConfigDirectory);
+      writeResolvedPackage(
+        packageName,
+        packageName === '@babel/types' ? '7.25.0' : '0.82.1',
+        metroDirectory
+      );
     }
 
     const result = bootstrapMetroCommands(tempDir);

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -81,6 +81,25 @@ describe('bootstrapMetroCommands', () => {
     });
   });
 
+  it('preserves production dependency placement when upgrading the adapter', () => {
+    writePackageJson({
+      dependencies: {
+        'react-native': '^0.79.0',
+        'zephyr-metro-plugin': '^1.3.0',
+      },
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.packageRequirements[0]).toEqual({
+      name: 'zephyr-metro-plugin',
+      isDev: false,
+      version: '^1.4.0',
+      projectDirectory: tempDir,
+    });
+  });
+
   it('preserves existing React Native CLI config and commands', () => {
     writePackageJson({
       devDependencies: { '@react-native-community/cli': '^19.0.0' },
@@ -553,6 +572,37 @@ describe('bootstrapMetroCommands', () => {
       'is not verifiably configured with @module-federation/metro'
     );
     expect(fs.readFileSync(companionPath, 'utf8')).toBe(companion);
+  });
+
+  it('rejects a federation call that does not produce the exported Metro config', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    fs.writeFileSync(
+      path.join(tempDir, 'metro.config.js'),
+      `const { withModuleFederation } = require("@module-federation/metro");\nconst unused = withModuleFederation({ name: "app" })({});\nmodule.exports = { resolver: {} };\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.packageRequirements).toEqual([]);
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
+  });
+
+  it('recognizes an aliased federation wrapper through an exported identifier', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    fs.writeFileSync(
+      path.join(tempDir, 'metro.config.js'),
+      `const { withModuleFederation: withMF } = require("@module-federation/metro");\nconst config = withMF({ name: "app" })({});\nmodule.exports = config;\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('react-native-cli');
+    expect(result.createdFiles).toEqual(['react-native.config.js']);
   });
 
   it('rejects broad and protocol dependency declarations when unresolved', () => {

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -439,14 +439,16 @@ describe('bootstrapMetroCommands', () => {
     const configPath = path.join(tempDir, 'react-native.config.js');
     fs.writeFileSync(
       configPath,
-      '// zephyrMetroReactNativeCli() is added below by the codemod\nmodule.exports = { assets: [] };\n'
+      '// const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\n// zephyrMetroReactNativeCli() is added below by the codemod\nmodule.exports = { assets: [] };\n'
     );
 
     const result = bootstrapMetroCommands(tempDir);
 
     expect(result.updatedFiles).toEqual(['react-native.config.js']);
-    expect(fs.readFileSync(configPath, 'utf8')).toContain(
-      '...zephyrMetroReactNativeCli().commands'
+    const content = fs.readFileSync(configPath, 'utf8');
+    expect(content).toContain('...zephyrMetroReactNativeCli().commands');
+    expect(content).toContain(
+      '\nconst { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\n'
     );
   });
 

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -78,6 +78,7 @@ describe('bootstrapMetroCommands', () => {
       isDev: true,
       version: '^1.4.0',
       projectDirectory: tempDir,
+      requireResolved: true,
     });
   });
 
@@ -97,6 +98,7 @@ describe('bootstrapMetroCommands', () => {
       isDev: false,
       version: '^1.4.0',
       projectDirectory: tempDir,
+      requireResolved: true,
     });
   });
 

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -752,6 +752,23 @@ describe('bootstrapMetroCommands', () => {
     expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
   });
 
+  it('rejects federation setup replaced by a later CommonJS Metro export', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    fs.writeFileSync(
+      path.join(tempDir, 'metro.config.js'),
+      `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\nmodule.exports = { resolver: {} };\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.packageRequirements).toEqual([]);
+    expect(result.manualGuidance[0]).toContain('is not verifiably configured');
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
+  });
+
   it('recognizes an aliased federation wrapper through an exported identifier', () => {
     writePackageJson({
       devDependencies: { '@react-native-community/cli': '^19.0.0' },

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -385,6 +385,20 @@ describe('bootstrapMetroCommands', () => {
     expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
   });
 
+  it('recognizes adapter results referenced by the exported commands', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    const content = `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\nconst adapter = zephyrMetroReactNativeCli();\nmodule.exports = { commands: adapter.commands };\n`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
   it('does not treat an unused local RNEF plugin call as registration', () => {
     writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
     const configPath = path.join(tempDir, 'rnef.config.js');
@@ -403,6 +417,18 @@ describe('bootstrapMetroCommands', () => {
     writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
     const configPath = path.join(tempDir, 'rnef.config.mjs');
     const content = `import { zephyrMetroRNEFPlugin } from "zephyr-metro-plugin";\nconst base = { plugins: [] };\nexport default { ...base, plugins: [...base.plugins, zephyrMetroRNEFPlugin({ platforms: {} })] };\n`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('recognizes RNEF plugin results referenced by the exported plugins', () => {
+    writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
+    const configPath = path.join(tempDir, 'rnef.config.js');
+    const content = `const { zephyrMetroRNEFPlugin } = require("zephyr-metro-plugin");\nconst plugin = zephyrMetroRNEFPlugin();\nmodule.exports = { plugins: [plugin] };\n`;
     fs.writeFileSync(configPath, content);
 
     const result = bootstrapMetroCommands(tempDir);
@@ -536,6 +562,25 @@ describe('bootstrapMetroCommands', () => {
 
     expect(result.manualGuidance[0]).toContain('does not directly export an object');
     expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('preserves CommonJS shebangs and directive prologues when adding imports', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(
+      configPath,
+      '#!/usr/bin/env node\n// Keep this config strict.\n"use strict";\nmodule.exports = { commands: [] };\n'
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(result.updatedFiles).toEqual(['react-native.config.js']);
+    expect(content).toMatch(
+      /^#!\/usr\/bin\/env node\n\/\/ Keep this config strict\.\n"use strict";\nconst \{ zephyrMetroReactNativeCli \}/
+    );
   });
 
   it('leaves multiple active RNEF loader candidates untouched', () => {

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -25,11 +25,17 @@ describe('bootstrapMetroCommands', () => {
       JSON.stringify({
         ...value,
         dependencies: {
+          react: '^19.0.0',
           'react-native': '^0.79.0',
           ...(value['dependencies'] as Record<string, string> | undefined),
         },
         devDependencies: {
-          metro: '^0.82.0',
+          '@babel/types': '^7.25.0',
+          metro: '^0.82.1',
+          'metro-config': '^0.82.1',
+          'metro-file-map': '^0.82.1',
+          'metro-resolver': '^0.82.1',
+          'metro-source-map': '^0.82.1',
           ...(value['devDependencies'] as Record<string, string> | undefined),
         },
       })
@@ -326,6 +332,155 @@ describe('bootstrapMetroCommands', () => {
     );
   });
 
+  it('does not treat an unused local adapter call as command registration', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(
+      configPath,
+      `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\nconst unused = zephyrMetroReactNativeCli({ projectRoot: __dirname });\nmodule.exports = { commands: [] };\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual(['react-native.config.js']);
+    expect(fs.readFileSync(configPath, 'utf8')).toContain(
+      '...zephyrMetroReactNativeCli().commands'
+    );
+  });
+
+  it('recognizes adapter commands merged into the exported config', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    const content = `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\nconst base = { commands: [] };\nmodule.exports = { ...base, commands: [...base.commands, ...zephyrMetroReactNativeCli({ projectRoot: __dirname }).commands] };\n`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('does not treat an unused local RNEF plugin call as registration', () => {
+    writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
+    const configPath = path.join(tempDir, 'rnef.config.js');
+    fs.writeFileSync(
+      configPath,
+      `const { zephyrMetroRNEFPlugin } = require("zephyr-metro-plugin");\nconst unused = zephyrMetroRNEFPlugin({ platforms: {} });\nmodule.exports = { plugins: [] };\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual(['rnef.config.js']);
+    expect(fs.readFileSync(configPath, 'utf8')).toContain('zephyrMetroRNEFPlugin()');
+  });
+
+  it('recognizes RNEF plugins merged into the exported config', () => {
+    writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
+    const configPath = path.join(tempDir, 'rnef.config.mjs');
+    const content = `import { zephyrMetroRNEFPlugin } from "zephyr-metro-plugin";\nconst base = { plugins: [] };\nexport default { ...base, plugins: [...base.plugins, zephyrMetroRNEFPlugin({ platforms: {} })] };\n`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('recognizes quoted and computed React Native command keys', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const cjsPath = path.join(tempDir, 'react-native.config.cjs');
+    const cjsContent = `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\nmodule.exports = { "commands": zephyrMetroReactNativeCli().commands };\n`;
+    fs.writeFileSync(cjsPath, cjsContent);
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual([]);
+    expect(fs.readFileSync(cjsPath, 'utf8')).toBe(cjsContent);
+
+    fs.rmSync(cjsPath);
+    const esmPath = path.join(tempDir, 'react-native.config.mjs');
+    const esmContent = `import { zephyrMetroReactNativeCli } from "zephyr-metro-plugin";\nexport default { ["commands"]: [...zephyrMetroReactNativeCli().commands] };\n`;
+    fs.writeFileSync(esmPath, esmContent);
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual([]);
+    expect(fs.readFileSync(esmPath, 'utf8')).toBe(esmContent);
+  });
+
+  it('recognizes quoted and computed RNEF plugin keys', () => {
+    writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
+    const cjsPath = path.join(tempDir, 'rnef.config.js');
+    const cjsContent = `const { zephyrMetroRNEFPlugin } = require("zephyr-metro-plugin");\nmodule.exports = { ["plugins"]: [zephyrMetroRNEFPlugin()] };\n`;
+    fs.writeFileSync(cjsPath, cjsContent);
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual([]);
+    expect(fs.readFileSync(cjsPath, 'utf8')).toBe(cjsContent);
+
+    fs.rmSync(cjsPath);
+    const esmPath = path.join(tempDir, 'rnef.config.mjs');
+    const esmContent = `import { zephyrMetroRNEFPlugin } from "zephyr-metro-plugin";\nexport default { "plugins": [zephyrMetroRNEFPlugin()] };\n`;
+    fs.writeFileSync(esmPath, esmContent);
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual([]);
+    expect(fs.readFileSync(esmPath, 'utf8')).toBe(esmContent);
+  });
+
+  it('does not treat helpers nested in callbacks as registration', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(
+      configPath,
+      `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\nmodule.exports = { commands: [() => zephyrMetroReactNativeCli().commands] };\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual(['react-native.config.js']);
+    expect(fs.readFileSync(configPath, 'utf8')).toContain(
+      '...zephyrMetroReactNativeCli().commands'
+    );
+
+    fs.rmSync(configPath);
+    writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
+    const rnefPath = path.join(tempDir, 'rnef.config.js');
+    fs.writeFileSync(
+      rnefPath,
+      `const { zephyrMetroRNEFPlugin } = require("zephyr-metro-plugin");\nmodule.exports = { plugins: [() => zephyrMetroRNEFPlugin()] };\n`
+    );
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual(['rnef.config.js']);
+    expect(fs.readFileSync(rnefPath, 'utf8')).toContain('zephyrMetroRNEFPlugin(),');
+  });
+
+  it('recognizes configured identifier exports in CommonJS and ESM', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const cjsPath = path.join(tempDir, 'react-native.config.js');
+    const cjsContent = `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\nconst config = { commands: [...zephyrMetroReactNativeCli().commands] };\nmodule.exports = config;\n`;
+    fs.writeFileSync(cjsPath, cjsContent);
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual([]);
+    expect(fs.readFileSync(cjsPath, 'utf8')).toBe(cjsContent);
+
+    fs.rmSync(cjsPath);
+    writePackageJson({
+      type: 'module',
+      devDependencies: { '@rnef/cli': '^0.8.0' },
+    });
+    const esmPath = path.join(tempDir, 'rnef.config.mjs');
+    const esmContent = `import { zephyrMetroRNEFPlugin } from "zephyr-metro-plugin";\nconst config = { plugins: [zephyrMetroRNEFPlugin()] };\nexport default config;\n`;
+    fs.writeFileSync(esmPath, esmContent);
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual([]);
+    expect(fs.readFileSync(esmPath, 'utf8')).toBe(esmContent);
+  });
+
   for (const [name, exportedValue] of [
     ['function', '() => ({ commands: [] })'],
     ['promise', 'Promise.resolve({ commands: [] })'],
@@ -406,6 +561,7 @@ describe('bootstrapMetroCommands', () => {
       devDependencies: {
         '@react-native-community/cli': '^19.0.0',
         metro: '*',
+        'metro-config': '*',
       },
     });
 
@@ -416,6 +572,7 @@ describe('bootstrapMetroCommands', () => {
       expect.arrayContaining([
         expect.stringContaining('react-native declaration "workspace:*"'),
         expect.stringContaining('metro declaration "*"'),
+        expect.stringContaining('metro-config declaration "*"'),
       ])
     );
   });
@@ -470,7 +627,7 @@ describe('bootstrapMetroCommands', () => {
     });
     for (const [packageName, version] of [
       ['react-native', '0.79.2'],
-      ['metro', '0.82.1'],
+      ['metro', '0.82.2'],
     ]) {
       const packageDirectory = path.join(tempDir, 'node_modules', packageName);
       fs.mkdirSync(packageDirectory, { recursive: true });
@@ -504,6 +661,34 @@ describe('bootstrapMetroCommands', () => {
         expect.stringContaining('metro declaration "^0.81.0"'),
       ])
     );
+  });
+
+  it('rejects missing or incompatible Metro peer packages', () => {
+    writePackageJson({
+      dependencies: { react: '^18.0.0' },
+      devDependencies: {
+        '@react-native-community/cli': '^19.0.0',
+        'metro-file-map': '^0.83.0',
+      },
+    });
+    const packageJsonPath = path.join(tempDir, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    delete packageJson.devDependencies['metro-resolver'];
+    delete packageJson.devDependencies['@babel/types'];
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.manualGuidance).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('@babel/types could not be resolved'),
+        expect.stringContaining('react declaration "^18.0.0"'),
+        expect.stringContaining('metro-file-map declaration "^0.83.0"'),
+        expect.stringContaining('metro-resolver could not be resolved'),
+      ])
+    );
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
   });
 
   it('uses Android when it is the only direct CLI platform package', () => {

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -470,6 +470,22 @@ describe('bootstrapMetroCommands', () => {
     );
   });
 
+  it('rejects a registered adapter replaced by a later CommonJS export', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    const content =
+      'const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\nmodule.exports = zephyrMetroReactNativeCli();\nmodule.exports = { commands: [] };\n';
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.packageRequirements).toEqual([]);
+    expect(result.manualGuidance[0]).toContain('does not directly export an object');
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
   it('recognizes adapter commands merged into the exported config', () => {
     writePackageJson({
       devDependencies: { '@react-native-community/cli': '^19.0.0' },

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -317,6 +317,53 @@ describe('bootstrapMetroCommands', () => {
     expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
   });
 
+  it('detects React Native commands through a CommonJS namespace import', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    const content = `const zephyr = require("zephyr-metro-plugin");\nmodule.exports = { commands: [...zephyr.zephyrMetroReactNativeCli().commands] };\n`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('detects RNEF plugins through an ESM namespace import', () => {
+    writePackageJson({
+      type: 'module',
+      devDependencies: { '@rnef/cli': '^0.8.0' },
+    });
+    const configPath = path.join(tempDir, 'rnef.config.mjs');
+    const content = `import * as zephyr from "zephyr-metro-plugin";\nexport default { plugins: [zephyr.zephyrMetroRNEFPlugin()] };\n`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('reuses a namespace import when adding missing commands', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(
+      configPath,
+      `const zephyr = require("zephyr-metro-plugin");\nmodule.exports = { commands: [] };\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(result.updatedFiles).toEqual(['react-native.config.js']);
+    expect(content).toContain('...zephyr.zephyrMetroReactNativeCli().commands');
+    expect(content.match(/require\("zephyr-metro-plugin"\)/g)).toHaveLength(1);
+  });
+
   it('uses an existing CommonJS helper alias when adding commands', () => {
     writePackageJson({
       devDependencies: { '@react-native-community/cli': '^19.0.0' },

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -42,6 +42,24 @@ describe('bootstrapMetroCommands', () => {
     );
   }
 
+  function writeResolvedPackage(
+    packageName: string,
+    version: string,
+    directory = tempDir
+  ): string {
+    const packageDirectory = path.join(
+      directory,
+      'node_modules',
+      ...packageName.split('/')
+    );
+    fs.mkdirSync(packageDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDirectory, 'package.json'),
+      JSON.stringify({ name: packageName, version })
+    );
+    return packageDirectory;
+  }
+
   it('creates a CommonJS React Native CLI config and companion requirements', () => {
     writePackageJson({
       devDependencies: { '@react-native-community/cli': '^19.0.0' },
@@ -138,6 +156,38 @@ describe('bootstrapMetroCommands', () => {
     expect(content).toContain('import { zephyrMetroReactNativeCli }');
     expect(content).toContain('const __zephyrReactNativeConfig = {');
     expect(content).toContain('...zephyrMetroReactNativeCli().commands');
+  });
+
+  it('avoids temporary binding collisions in CommonJS and ESM configs', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const commonJsPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(
+      commonJsPath,
+      'const __zephyrReactNativeConfig = "existing";\nmodule.exports = { commands: [] };\n'
+    );
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual([
+      'react-native.config.js',
+    ]);
+    expect(fs.readFileSync(commonJsPath, 'utf8')).toContain(
+      'const __zephyrReactNativeConfig2 = module.exports;'
+    );
+
+    fs.rmSync(commonJsPath);
+    writePackageJson({
+      type: 'module',
+      devDependencies: { '@rnef/cli': '^0.8.0' },
+    });
+    const esmPath = path.join(tempDir, 'rnef.config.mjs');
+    fs.writeFileSync(
+      esmPath,
+      'const __zephyrRnefConfig = "existing";\nexport default { plugins: [] };\n'
+    );
+
+    expect(bootstrapMetroCommands(tempDir).updatedFiles).toEqual(['rnef.config.mjs']);
+    expect(fs.readFileSync(esmPath, 'utf8')).toContain('const __zephyrRnefConfig2 = {');
   });
 
   it('registers the existing RNEF plugin without replacing config', () => {
@@ -611,14 +661,14 @@ describe('bootstrapMetroCommands', () => {
     expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
   });
 
-  it('preserves CommonJS shebangs and directive prologues when adding imports', () => {
+  it('preserves CommonJS shebangs and commented directive prologues', () => {
     writePackageJson({
       devDependencies: { '@react-native-community/cli': '^19.0.0' },
     });
     const configPath = path.join(tempDir, 'react-native.config.js');
     fs.writeFileSync(
       configPath,
-      '#!/usr/bin/env node\n// Keep this config strict.\n"use strict";\nmodule.exports = { commands: [] };\n'
+      '#!/usr/bin/env node\n// Keep this config strict.\n"use strict"; // Retain strict behavior.\nmodule.exports = { commands: [] };\n'
     );
 
     const result = bootstrapMetroCommands(tempDir);
@@ -626,7 +676,7 @@ describe('bootstrapMetroCommands', () => {
 
     expect(result.updatedFiles).toEqual(['react-native.config.js']);
     expect(content).toMatch(
-      /^#!\/usr\/bin\/env node\n\/\/ Keep this config strict\.\n"use strict";\nconst \{ zephyrMetroReactNativeCli \}/
+      /^#!\/usr\/bin\/env node\n\/\/ Keep this config strict\.\n"use strict"; \/\/ Retain strict behavior\.\nconst \{ zephyrMetroReactNativeCli \}/
     );
   });
 
@@ -737,48 +787,95 @@ describe('bootstrapMetroCommands', () => {
     );
   });
 
-  it('prefers a compatible resolved Module Federation version', () => {
+  it('accepts a compatible resolved Module Federation workspace declaration', () => {
     writePackageJson({
       devDependencies: {
         '@module-federation/metro': 'workspace:*',
         '@react-native-community/cli': '^19.0.0',
       },
     });
-    const packageDirectory = path.join(
-      tempDir,
-      'node_modules',
-      '@module-federation',
-      'metro'
-    );
-    fs.mkdirSync(packageDirectory, { recursive: true });
-    fs.writeFileSync(
-      path.join(packageDirectory, 'package.json'),
-      JSON.stringify({ name: '@module-federation/metro', version: '2.9.1' })
-    );
+    writeResolvedPackage('@module-federation/metro', '2.9.1');
 
     const result = bootstrapMetroCommands(tempDir);
 
     expect(result.integration).toBe('react-native-cli');
   });
 
-  it('prefers compatible resolved versions over broad declarations', () => {
+  it('accepts compatible resolved versions for workspace declarations', () => {
     writePackageJson({
       dependencies: { 'react-native': 'workspace:*' },
       devDependencies: {
         '@react-native-community/cli': '^19.0.0',
-        metro: '*',
+        metro: 'workspace:*',
       },
     });
     for (const [packageName, version] of [
       ['react-native', '0.79.2'],
       ['metro', '0.82.2'],
     ]) {
-      const packageDirectory = path.join(tempDir, 'node_modules', packageName);
-      fs.mkdirSync(packageDirectory, { recursive: true });
-      fs.writeFileSync(
-        path.join(packageDirectory, 'package.json'),
-        JSON.stringify({ name: packageName, version })
-      );
+      writeResolvedPackage(packageName, version);
+    }
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('react-native-cli');
+    expect(result.createdFiles).toEqual(['react-native.config.js']);
+  });
+
+  it('rejects incompatible declarations despite compatible resolved versions', () => {
+    writePackageJson({
+      devDependencies: {
+        '@module-federation/metro': '^3.0.0',
+        '@react-native-community/cli': '^19.0.0',
+        metro: '^0.83.0',
+      },
+    });
+    writeResolvedPackage('@module-federation/metro', '2.9.1');
+    writeResolvedPackage('metro', '0.82.2');
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.manualGuidance).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('@module-federation/metro declaration "^3.0.0"'),
+        expect.stringContaining('metro declaration "^0.83.0"'),
+      ])
+    );
+  });
+
+  it('resolves Metro peers through the React Native Metro config dependency graph', () => {
+    writePackageJson({
+      devDependencies: {
+        '@react-native-community/cli': '^19.0.0',
+        '@react-native/metro-config': '^0.79.0',
+      },
+    });
+    const packageJsonPath = path.join(tempDir, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    for (const packageName of [
+      'metro',
+      'metro-config',
+      'metro-file-map',
+      'metro-resolver',
+      'metro-source-map',
+    ]) {
+      delete packageJson.devDependencies[packageName];
+    }
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+
+    const metroConfigDirectory = writeResolvedPackage(
+      '@react-native/metro-config',
+      '0.79.0'
+    );
+    for (const packageName of [
+      'metro',
+      'metro-config',
+      'metro-file-map',
+      'metro-resolver',
+      'metro-source-map',
+    ]) {
+      writeResolvedPackage(packageName, '0.82.1', metroConfigDirectory);
     }
 
     const result = bootstrapMetroCommands(tempDir);

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { bootstrapMetroCommands } from '../metro-bootstrap.js';
+
+describe('bootstrapMetroCommands', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zephyr-metro-bootstrap-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writePackageJson(value: Record<string, unknown>): void {
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(value));
+  }
+
+  it('creates a CommonJS React Native CLI config and companion requirements', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+
+    const result = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(path.join(tempDir, 'react-native.config.js'), 'utf8');
+
+    expect(result.integration).toBe('react-native-cli');
+    expect(result.createdFiles).toEqual(['react-native.config.js']);
+    expect(result.packageRequirements.map(({ name }) => name)).toEqual([
+      'zephyr-metro-plugin',
+      '@module-federation/metro',
+    ]);
+    expect(result.packageRequirements[1]?.version).toBe('^2.9.0');
+    expect(content).toContain('module.exports = zephyrMetroReactNativeCli()');
+  });
+
+  it('leaves an incompatible installed Metro command package untouched', () => {
+    writePackageJson({
+      devDependencies: {
+        '@react-native-community/cli': '^19.0.0',
+        '@module-federation/metro': '^2.8.0',
+      },
+    });
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.createdFiles).toEqual([]);
+    expect(result.manualGuidance[0]).toContain('Use ^2.9.0');
+  });
+
+  it('preserves existing React Native CLI config and commands', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(
+      configPath,
+      'module.exports = { assets: ["./assets"], commands: [customCommand] };\n'
+    );
+
+    const first = bootstrapMetroCommands(tempDir);
+    const second = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(first.updatedFiles).toEqual(['react-native.config.js']);
+    expect(second.updatedFiles).toEqual([]);
+    expect(content).toContain('assets: ["./assets"]');
+    expect(content).toContain('...(__zephyrReactNativeConfig.commands ?? [])');
+    expect(content.match(/zephyrMetroReactNativeCli\(\)\.commands/g)).toHaveLength(1);
+  });
+
+  it('updates an ESM React Native CLI config', () => {
+    writePackageJson({
+      type: 'module',
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(configPath, 'export default { assets: ["./assets"] };\n');
+
+    const result = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(result.updatedFiles).toEqual(['react-native.config.js']);
+    expect(content).toContain('import { zephyrMetroReactNativeCli }');
+    expect(content).toContain('const __zephyrReactNativeConfig = {');
+    expect(content).toContain('...zephyrMetroReactNativeCli().commands');
+  });
+
+  it('registers the existing RNEF plugin without replacing config', () => {
+    writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
+    const configPath = path.join(tempDir, 'rnef.config.mjs');
+    fs.writeFileSync(
+      configPath,
+      'const existingPlugin = () => ({});\nexport default { plugins: [existingPlugin()] };\n'
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(result.integration).toBe('rnef');
+    expect(result.updatedFiles).toEqual(['rnef.config.mjs']);
+    expect(content).toContain('plugins: [existingPlugin()]');
+    expect(content).toContain('...(__zephyrRnefConfig.plugins ?? [])');
+    expect(content).toContain('zephyrMetroRNEFPlugin()');
+  });
+
+  it('makes no changes during a dry run', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+
+    const result = bootstrapMetroCommands(tempDir, { dryRun: true });
+
+    expect(result.createdFiles).toEqual(['react-native.config.js']);
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
+  });
+
+  it('does not edit ambiguous projects and gives exact manual guidance', () => {
+    writePackageJson({
+      dependencies: { react: '^19.0.0' },
+    });
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.createdFiles).toEqual([]);
+    expect(result.updatedFiles).toEqual([]);
+    expect(result.packageRequirements).toEqual([]);
+    expect(result.manualGuidance).toEqual([
+      'No React Native command config was changed because the integration could not be updated safely.',
+      'React Native CLI: export commands: [...(config.commands ?? []), ...zephyrMetroReactNativeCli().commands] from react-native.config.js and import zephyrMetroReactNativeCli from zephyr-metro-plugin.',
+      'RNEF: add zephyrMetroRNEFPlugin() to the exported plugins array in rnef.config.* and import zephyrMetroRNEFPlugin from zephyr-metro-plugin.',
+    ]);
+  });
+
+  it('updates the existing React Native CLI filename instead of shadowing it', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.cjs');
+    fs.writeFileSync(configPath, 'module.exports = { assets: ["./assets"] };\n');
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual(['react-native.config.cjs']);
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
+    expect(fs.readFileSync(configPath, 'utf8')).toContain(
+      'zephyrMetroReactNativeCli().commands'
+    );
+  });
+
+  it('leaves multiple React Native CLI config candidates untouched', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const jsConfig = 'module.exports = { assets: ["js"] };\n';
+    const cjsConfig = 'module.exports = { assets: ["cjs"] };\n';
+    fs.writeFileSync(path.join(tempDir, 'react-native.config.js'), jsConfig);
+    fs.writeFileSync(path.join(tempDir, 'react-native.config.cjs'), cjsConfig);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(fs.readFileSync(path.join(tempDir, 'react-native.config.js'), 'utf8')).toBe(
+      jsConfig
+    );
+    expect(fs.readFileSync(path.join(tempDir, 'react-native.config.cjs'), 'utf8')).toBe(
+      cjsConfig
+    );
+  });
+
+  it('leaves unsupported React Native config candidates untouched', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const content = 'export default { assets: [] };\n';
+    fs.writeFileSync(path.join(tempDir, 'react-native.config.mts'), content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(fs.readFileSync(path.join(tempDir, 'react-native.config.mts'), 'utf8')).toBe(
+      content
+    );
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
+  });
+
+  it('gives explicit RNEF package signals precedence over CLI dependencies', () => {
+    writePackageJson({
+      devDependencies: {
+        '@react-native-community/cli': '^19.0.0',
+        '@rnef/cli': '^0.8.0',
+      },
+    });
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('rnef');
+    expect(result.createdFiles).toEqual(['rnef.config.js']);
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
+  });
+
+  it('gives an explicit RNEF config precedence over CLI dependencies', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'rnef.config.ts');
+    fs.writeFileSync(configPath, 'export default { plugins: [] };\n');
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('rnef');
+    expect(result.updatedFiles).toEqual(['rnef.config.ts']);
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
+  });
+
+  it('leaves genuinely conflicting companion configs untouched', () => {
+    writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
+    const reactNativeContent = 'module.exports = { commands: [] };\n';
+    const rnefContent = 'export default { plugins: [] };\n';
+    fs.writeFileSync(path.join(tempDir, 'react-native.config.js'), reactNativeContent);
+    fs.writeFileSync(path.join(tempDir, 'rnef.config.mjs'), rnefContent);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(fs.readFileSync(path.join(tempDir, 'react-native.config.js'), 'utf8')).toBe(
+      reactNativeContent
+    );
+    expect(fs.readFileSync(path.join(tempDir, 'rnef.config.mjs'), 'utf8')).toBe(
+      rnefContent
+    );
+  });
+
+  it('detects existing helper calls with arguments and whitespace', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.ts');
+    const content = `import { zephyrMetroReactNativeCli } from "zephyr-metro-plugin";\nexport default zephyrMetroReactNativeCli ( { projectRoot: process.cwd() } );\n`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual([]);
+    expect(result.packageRequirements).not.toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('detects existing calls through an aliased helper import', () => {
+    writePackageJson({
+      type: 'module',
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.mjs');
+    const content = `import { zephyrMetroReactNativeCli as zephyrCommands } from "zephyr-metro-plugin";\nexport default zephyrCommands();\n`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('uses an existing CommonJS helper alias when adding commands', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.cjs');
+    fs.writeFileSync(
+      configPath,
+      `const { zephyrMetroReactNativeCli: zephyrCommands } = require("zephyr-metro-plugin");\nmodule.exports = { assets: [] };\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(result.updatedFiles).toEqual(['react-native.config.cjs']);
+    expect(content).toContain('...zephyrCommands().commands');
+    expect(content).not.toContain('...zephyrMetroReactNativeCli().commands');
+  });
+
+  it('does not treat helper text in a comment as command registration', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(
+      configPath,
+      '// zephyrMetroReactNativeCli() is added below by the codemod\nmodule.exports = { assets: [] };\n'
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.updatedFiles).toEqual(['react-native.config.js']);
+    expect(fs.readFileSync(configPath, 'utf8')).toContain(
+      '...zephyrMetroReactNativeCli().commands'
+    );
+  });
+
+  for (const [name, exportedValue] of [
+    ['function', '() => ({ commands: [] })'],
+    ['promise', 'Promise.resolve({ commands: [] })'],
+    ['non-object', '"config"'],
+  ]) {
+    it(`leaves CommonJS ${name} exports unchanged`, () => {
+      writePackageJson({
+        devDependencies: { '@react-native-community/cli': '^19.0.0' },
+      });
+      const configPath = path.join(tempDir, 'react-native.config.js');
+      const content = `module.exports = ${exportedValue};\n`;
+      fs.writeFileSync(configPath, content);
+
+      const result = bootstrapMetroCommands(tempDir);
+
+      expect(result.manualGuidance[0]).toContain('does not directly export an object');
+      expect(result.packageRequirements).toEqual([]);
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+    });
+  }
+
+  it('leaves unsupported ESM exports unchanged', () => {
+    writePackageJson({
+      type: 'module',
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.mjs');
+    const content = 'export default getConfig();\n';
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.manualGuidance[0]).toContain('does not directly export an object');
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('leaves multiple active RNEF loader candidates untouched', () => {
+    writePackageJson({ devDependencies: { '@rnef/cli': '^0.8.0' } });
+    const jsContent = 'module.exports = { plugins: [] };\n';
+    const mjsContent = 'export default { plugins: [] };\n';
+    fs.writeFileSync(path.join(tempDir, 'rnef.config.js'), jsContent);
+    fs.writeFileSync(path.join(tempDir, 'rnef.config.mjs'), mjsContent);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(fs.readFileSync(path.join(tempDir, 'rnef.config.js'), 'utf8')).toBe(jsContent);
+    expect(fs.readFileSync(path.join(tempDir, 'rnef.config.mjs'), 'utf8')).toBe(
+      mjsContent
+    );
+  });
+});

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -9,6 +9,10 @@ describe('bootstrapMetroCommands', () => {
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zephyr-metro-bootstrap-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'metro.config.js'),
+      `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({ name: "app" })({});\n`
+    );
   });
 
   afterEach(() => {
@@ -16,7 +20,20 @@ describe('bootstrapMetroCommands', () => {
   });
 
   function writePackageJson(value: Record<string, unknown>): void {
-    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(value));
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        ...value,
+        dependencies: {
+          'react-native': '^0.79.0',
+          ...(value['dependencies'] as Record<string, string> | undefined),
+        },
+        devDependencies: {
+          metro: '^0.82.0',
+          ...(value['devDependencies'] as Record<string, string> | undefined),
+        },
+      })
+    );
   }
 
   it('creates a CommonJS React Native CLI config and companion requirements', () => {
@@ -34,22 +51,28 @@ describe('bootstrapMetroCommands', () => {
       '@module-federation/metro',
     ]);
     expect(result.packageRequirements[1]?.version).toBe('^2.9.0');
+    expect(result.packageRequirements[0]?.version).toBe('^1.4.0');
+    expect(result.packageRequirements[0]?.projectDirectory).toBe(tempDir);
     expect(content).toContain('module.exports = zephyrMetroReactNativeCli()');
   });
 
-  it('leaves an incompatible installed Metro command package untouched', () => {
+  it('requires an adapter-capable plugin upgrade', () => {
     writePackageJson({
       devDependencies: {
         '@react-native-community/cli': '^19.0.0',
-        '@module-federation/metro': '^2.8.0',
+        'zephyr-metro-plugin': '^1.3.0',
       },
     });
 
     const result = bootstrapMetroCommands(tempDir);
 
-    expect(result.integration).toBe('ambiguous');
-    expect(result.createdFiles).toEqual([]);
-    expect(result.manualGuidance[0]).toContain('Use ^2.9.0');
+    expect(result.integration).toBe('react-native-cli');
+    expect(result.packageRequirements[0]).toEqual({
+      name: 'zephyr-metro-plugin',
+      isDev: true,
+      version: '^1.4.0',
+      projectDirectory: tempDir,
+    });
   });
 
   it('preserves existing React Native CLI config and commands', () => {
@@ -132,8 +155,9 @@ describe('bootstrapMetroCommands', () => {
     expect(result.packageRequirements).toEqual([]);
     expect(result.manualGuidance).toEqual([
       'No React Native command config was changed because the integration could not be updated safely.',
-      'React Native CLI: export commands: [...(config.commands ?? []), ...zephyrMetroReactNativeCli().commands] from react-native.config.js and import zephyrMetroReactNativeCli from zephyr-metro-plugin.',
-      'RNEF: add zephyrMetroRNEFPlugin() to the exported plugins array in rnef.config.* and import zephyrMetroRNEFPlugin from zephyr-metro-plugin.',
+      'React Native CLI: export commands: [...(config.commands ?? []), ...zephyrMetroReactNativeCli().commands] from the active react-native.config.* file and import zephyrMetroReactNativeCli from zephyr-metro-plugin.',
+      'RNEF: add zephyrMetroRNEFPlugin() to the exported plugins array in the active rnef.config.* file and import zephyrMetroRNEFPlugin from zephyr-metro-plugin.',
+      'Publish with --platform <platform> after registration.',
     ]);
   });
 
@@ -351,6 +375,154 @@ describe('bootstrapMetroCommands', () => {
     expect(fs.readFileSync(path.join(tempDir, 'rnef.config.js'), 'utf8')).toBe(jsContent);
     expect(fs.readFileSync(path.join(tempDir, 'rnef.config.mjs'), 'utf8')).toBe(
       mjsContent
+    );
+  });
+
+  it('leaves plain non-federated Metro projects untouched', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    fs.writeFileSync(
+      path.join(tempDir, 'metro.config.js'),
+      'module.exports = { resolver: {} };\n'
+    );
+    const companionPath = path.join(tempDir, 'react-native.config.js');
+    const companion = 'module.exports = { commands: [] };\n';
+    fs.writeFileSync(companionPath, companion);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.packageRequirements).toEqual([]);
+    expect(result.manualGuidance[0]).toContain(
+      'is not verifiably configured with @module-federation/metro'
+    );
+    expect(fs.readFileSync(companionPath, 'utf8')).toBe(companion);
+  });
+
+  it('rejects broad and protocol dependency declarations when unresolved', () => {
+    writePackageJson({
+      dependencies: { 'react-native': 'workspace:*' },
+      devDependencies: {
+        '@react-native-community/cli': '^19.0.0',
+        metro: '*',
+      },
+    });
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.manualGuidance).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('react-native declaration "workspace:*"'),
+        expect.stringContaining('metro declaration "*"'),
+      ])
+    );
+  });
+
+  it('rejects an unresolved broad Module Federation declaration', () => {
+    writePackageJson({
+      devDependencies: {
+        '@module-federation/metro': 'workspace:*',
+        '@react-native-community/cli': '^19.0.0',
+      },
+    });
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.manualGuidance[0]).toContain(
+      '@module-federation/metro declaration "workspace:*"'
+    );
+  });
+
+  it('prefers a compatible resolved Module Federation version', () => {
+    writePackageJson({
+      devDependencies: {
+        '@module-federation/metro': 'workspace:*',
+        '@react-native-community/cli': '^19.0.0',
+      },
+    });
+    const packageDirectory = path.join(
+      tempDir,
+      'node_modules',
+      '@module-federation',
+      'metro'
+    );
+    fs.mkdirSync(packageDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDirectory, 'package.json'),
+      JSON.stringify({ name: '@module-federation/metro', version: '2.9.1' })
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('react-native-cli');
+  });
+
+  it('prefers compatible resolved versions over broad declarations', () => {
+    writePackageJson({
+      dependencies: { 'react-native': 'workspace:*' },
+      devDependencies: {
+        '@react-native-community/cli': '^19.0.0',
+        metro: '*',
+      },
+    });
+    for (const [packageName, version] of [
+      ['react-native', '0.79.2'],
+      ['metro', '0.82.1'],
+    ]) {
+      const packageDirectory = path.join(tempDir, 'node_modules', packageName);
+      fs.mkdirSync(packageDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, 'package.json'),
+        JSON.stringify({ name: packageName, version })
+      );
+    }
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('react-native-cli');
+    expect(result.createdFiles).toEqual(['react-native.config.js']);
+  });
+
+  it('rejects incompatible React Native and Metro versions', () => {
+    writePackageJson({
+      dependencies: { 'react-native': '^0.78.0' },
+      devDependencies: {
+        '@react-native-community/cli': '^19.0.0',
+        metro: '^0.81.0',
+      },
+    });
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.manualGuidance).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('react-native declaration "^0.78.0"'),
+        expect.stringContaining('metro declaration "^0.81.0"'),
+      ])
+    );
+  });
+
+  it('uses Android when it is the only direct CLI platform package', () => {
+    writePackageJson({
+      devDependencies: {
+        '@react-native-community/cli': '^19.0.0',
+        '@react-native-community/cli-platform-android': '^19.0.0',
+      },
+    });
+    fs.writeFileSync(
+      path.join(tempDir, 'metro.config.js'),
+      'module.exports = { resolver: {} };\n'
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.platformArgument).toBe('android');
+    expect(result.manualGuidance).toContain(
+      'Publish with --platform android after registration.'
     );
   });
 });

--- a/libs/with-zephyr/src/tests/package-manager.test.ts
+++ b/libs/with-zephyr/src/tests/package-manager.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {
+  addToPackageJson,
   buildAddCommand,
   buildInstallCommand,
   detectPackageManager,
@@ -324,6 +325,17 @@ describe('Package Manager Utils', () => {
 
     it('should build install command for pnpm', () => {
       expect(buildInstallCommand('pnpm')).toBe('pnpm install');
+    });
+
+    it('should preserve an explicit package version range', () => {
+      fs.writeFileSync('package.json', '{}');
+
+      expect(addToPackageJson(tempDir, '@module-federation/metro', '^2.9.0', true)).toBe(
+        true
+      );
+      const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+      expect(packageJson.devDependencies['@module-federation/metro']).toBe('^2.9.0');
     });
   });
 });

--- a/libs/with-zephyr/src/tests/package-manager.test.ts
+++ b/libs/with-zephyr/src/tests/package-manager.test.ts
@@ -8,8 +8,9 @@ import {
   buildInstallCommand,
   detectPackageManager,
   getResolvedPackageVersion,
-  isPackageRequirementSatisfied,
   isPackageInstalled,
+  isPackageRequirementSatisfied,
+  isResolvedPackageRequirementSatisfied,
   isSafelyConstrainedVersion,
 } from '../package-manager.js';
 
@@ -55,6 +56,11 @@ describe('Package Manager Utils', () => {
       expect(detectPackageManager(tempDir)).toBe('bun');
     });
 
+    it('should detect bun from bun.lock', () => {
+      fs.writeFileSync('bun.lock', 'lockfileVersion = 1');
+      expect(detectPackageManager(tempDir)).toBe('bun');
+    });
+
     it('should detect npm from package-lock.json', () => {
       fs.writeFileSync('package-lock.json', '{"lockfileVersion": 2}');
       expect(detectPackageManager(tempDir)).toBe('npm');
@@ -70,6 +76,13 @@ describe('Package Manager Utils', () => {
       fs.writeFileSync('package-lock.json', '{"lockfileVersion": 2}');
 
       expect(detectPackageManager(tempDir)).toBe('pnpm');
+    });
+
+    it('should detect a nested project manager without the invoking user agent', () => {
+      process.env.npm_config_user_agent = 'pnpm/11.0.0';
+      fs.writeFileSync('yarn.lock', '# Yarn lockfile');
+
+      expect(detectPackageManager(tempDir, { ignoreUserAgent: true })).toBe('yarn');
     });
 
     it('should prioritize yarn over npm when both exist', () => {
@@ -353,12 +366,20 @@ describe('Package Manager Utils', () => {
       expect(isSafelyConstrainedVersion('>=2.9.0', '2.9.0', '3.0.0')).toBe(false);
       expect(isSafelyConstrainedVersion('>=2.9.0 <3.0.0', '2.9.0', '3.0.0')).toBe(true);
       expect(isSafelyConstrainedVersion('^3.0.0', '2.9.0', '3.0.0')).toBe(false);
+      expect(isSafelyConstrainedVersion('^0.82.1', '0.82.1', '0.83.0')).toBe(true);
+      expect(isSafelyConstrainedVersion('^0.83.0', '0.82.1', '0.83.0')).toBe(false);
     });
 
     it('should require the declared adapter-capable plugin range', () => {
       fs.writeFileSync(
         'package.json',
         JSON.stringify({ devDependencies: { 'zephyr-metro-plugin': '^1.3.0' } })
+      );
+      const packageDirectory = path.join(tempDir, 'node_modules', 'zephyr-metro-plugin');
+      fs.mkdirSync(packageDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, 'package.json'),
+        JSON.stringify({ name: 'zephyr-metro-plugin', version: '1.4.2' })
       );
 
       expect(isPackageRequirementSatisfied('zephyr-metro-plugin', tempDir, '1.4.0')).toBe(
@@ -393,6 +414,35 @@ describe('Package Manager Utils', () => {
 
       expect(getResolvedPackageVersion('react-native', tempDir)).toBeUndefined();
       expect(getResolvedPackageVersion('metro', tempDir)).toBeUndefined();
+    });
+
+    it('should detect requirements resolved from a workspace root', () => {
+      fs.writeFileSync('package.json', '{}');
+      const projectDirectory = path.join(tempDir, 'apps', 'native');
+      fs.mkdirSync(projectDirectory, { recursive: true });
+      fs.writeFileSync(path.join(projectDirectory, 'package.json'), '{}');
+      const packageDirectory = path.join(tempDir, 'node_modules', 'zephyr-metro-plugin');
+      fs.mkdirSync(packageDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, 'package.json'),
+        JSON.stringify({ name: 'zephyr-metro-plugin', version: '1.4.2' })
+      );
+
+      expect(
+        isResolvedPackageRequirementSatisfied(
+          'zephyr-metro-plugin',
+          projectDirectory,
+          '1.4.0'
+        )
+      ).toBe(true);
+      expect(
+        isResolvedPackageRequirementSatisfied(
+          '@module-federation/metro',
+          projectDirectory,
+          '2.9.0',
+          '3.0.0'
+        )
+      ).toBe(false);
     });
   });
 });

--- a/libs/with-zephyr/src/tests/package-manager.test.ts
+++ b/libs/with-zephyr/src/tests/package-manager.test.ts
@@ -7,7 +7,10 @@ import {
   buildAddCommand,
   buildInstallCommand,
   detectPackageManager,
+  getResolvedPackageVersion,
+  isPackageRequirementSatisfied,
   isPackageInstalled,
+  isSafelyConstrainedVersion,
 } from '../package-manager.js';
 
 describe('Package Manager Utils', () => {
@@ -336,6 +339,60 @@ describe('Package Manager Utils', () => {
       const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
       expect(packageJson.devDependencies['@module-federation/metro']).toBe('^2.9.0');
+    });
+
+    it('should conservatively validate complete version declarations', () => {
+      expect(isSafelyConstrainedVersion('^0.82.0', '0.82.0')).toBe(true);
+      expect(isSafelyConstrainedVersion('>=0.82.0 <1.0.0', '0.82.0')).toBe(true);
+      expect(isSafelyConstrainedVersion('^0.81.0', '0.82.0')).toBe(false);
+      expect(isSafelyConstrainedVersion('workspace:^0.82.0', '0.82.0')).toBe(false);
+      expect(isSafelyConstrainedVersion('*', '0.82.0')).toBe(false);
+      expect(isSafelyConstrainedVersion('latest', '0.82.0')).toBe(false);
+      expect(isSafelyConstrainedVersion('0.82.0 || >=1.0.0', '0.82.0')).toBe(false);
+      expect(isSafelyConstrainedVersion('^2.9.0', '2.9.0', '3.0.0')).toBe(true);
+      expect(isSafelyConstrainedVersion('>=2.9.0', '2.9.0', '3.0.0')).toBe(false);
+      expect(isSafelyConstrainedVersion('>=2.9.0 <3.0.0', '2.9.0', '3.0.0')).toBe(true);
+      expect(isSafelyConstrainedVersion('^3.0.0', '2.9.0', '3.0.0')).toBe(false);
+    });
+
+    it('should require the declared adapter-capable plugin range', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({ devDependencies: { 'zephyr-metro-plugin': '^1.3.0' } })
+      );
+
+      expect(isPackageRequirementSatisfied('zephyr-metro-plugin', tempDir, '1.4.0')).toBe(
+        false
+      );
+    });
+
+    it('should accept a compatible resolved package behind a workspace declaration', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({ devDependencies: { '@module-federation/metro': 'workspace:*' } })
+      );
+      const packageDirectory = path.join(
+        tempDir,
+        'node_modules',
+        '@module-federation',
+        'metro'
+      );
+      fs.mkdirSync(packageDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, 'package.json'),
+        JSON.stringify({ name: '@module-federation/metro', version: '2.9.1' })
+      );
+
+      expect(
+        isPackageRequirementSatisfied('@module-federation/metro', tempDir, '2.9.0')
+      ).toBe(true);
+    });
+
+    it('should not resolve packages outside the target project', () => {
+      fs.writeFileSync('package.json', '{}');
+
+      expect(getResolvedPackageVersion('react-native', tempDir)).toBeUndefined();
+      expect(getResolvedPackageVersion('metro', tempDir)).toBeUndefined();
     });
   });
 });

--- a/libs/with-zephyr/src/tests/package-manager.test.ts
+++ b/libs/with-zephyr/src/tests/package-manager.test.ts
@@ -354,6 +354,24 @@ describe('Package Manager Utils', () => {
       expect(packageJson.devDependencies['@module-federation/metro']).toBe('^2.9.0');
     });
 
+    it('should preserve production placement and remove a conflicting dev entry', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          dependencies: { 'zephyr-metro-plugin': '^1.3.0' },
+          devDependencies: { 'zephyr-metro-plugin': '^1.2.0' },
+        })
+      );
+
+      expect(addToPackageJson(tempDir, 'zephyr-metro-plugin', '^1.4.0', false)).toBe(
+        true
+      );
+      const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+      expect(packageJson.dependencies['zephyr-metro-plugin']).toBe('^1.4.0');
+      expect(packageJson.devDependencies['zephyr-metro-plugin']).toBeUndefined();
+    });
+
     it('should conservatively validate complete version declarations', () => {
       expect(isSafelyConstrainedVersion('^0.82.0', '0.82.0')).toBe(true);
       expect(isSafelyConstrainedVersion('>=0.82.0 <1.0.0', '0.82.0')).toBe(true);

--- a/libs/zephyr-metro-plugin/README.md
+++ b/libs/zephyr-metro-plugin/README.md
@@ -20,16 +20,16 @@ Installing the `zephyr-metro-plugin` for your React Native application:
 
 ```bash
 # npm
-npm install --save-dev zephyr-metro-plugin
+npm install --save-dev zephyr-metro-plugin @module-federation/metro
 
 # yarn
-yarn add --dev zephyr-metro-plugin
+yarn add --dev zephyr-metro-plugin @module-federation/metro
 
 # pnpm
-pnpm add --dev zephyr-metro-plugin
+pnpm add --dev zephyr-metro-plugin @module-federation/metro
 
 # bun
-bun add --dev zephyr-metro-plugin
+bun add --dev zephyr-metro-plugin @module-federation/metro
 ```
 
 ## Usage
@@ -41,6 +41,9 @@ The Metro plugin provides two main integration points depending on your setup:
 #### 1. Using `withZephyr` Config Wrapper
 
 For Metro configuration file integration:
+
+`withZephyr` is configuration-only. It does not register a CLI command or upload
+artifacts by itself. Register one of the command integrations below to publish.
 
 ```javascript
 // metro.config.js
@@ -62,7 +65,27 @@ module.exports = (async () => {
 })();
 ```
 
-#### 2. Using Command Wrapper
+#### 2. React Native CLI commands
+
+Register `bundle-mf-host` and `bundle-mf-remote` while preserving existing CLI
+configuration:
+
+```javascript
+// react-native.config.js
+const { zephyrMetroReactNativeCli } = require('zephyr-metro-plugin');
+
+module.exports = {
+  commands: [...zephyrMetroReactNativeCli().commands],
+};
+```
+
+Run a publication command with the target platform, for example:
+
+```bash
+npx react-native bundle-mf-remote --platform ios
+```
+
+#### 3. Using Command Wrapper
 
 For CLI-level integration with custom bundling commands:
 
@@ -85,6 +108,15 @@ RNEF plugin:
 
 ```bash
 pnpm add --save-dev @module-federation/metro@2.9.0
+```
+
+```javascript
+// rnef.config.mjs
+import { zephyrMetroRNEFPlugin } from 'zephyr-metro-plugin';
+
+export default {
+  plugins: [zephyrMetroRNEFPlugin()],
+};
 ```
 
 ### Module Federation Configuration
@@ -223,6 +255,11 @@ my-react-native-app/
 - **Metro**: 0.80 or higher
 - **Node.js**: 18 or higher
 - **Zephyr Cloud account**: Sign up at [zephyr-cloud.io](https://zephyr-cloud.io)
+
+The `bundle-mf-host` and `bundle-mf-remote` publication commands additionally
+require React Native 0.79 or higher, Metro 0.82.1 or higher, and
+`@module-federation/metro@^2.9.0`. The configuration-only `withZephyr` wrapper
+does not require those command-integration minimums.
 
 ## Advanced Configuration
 

--- a/libs/zephyr-metro-plugin/README.md
+++ b/libs/zephyr-metro-plugin/README.md
@@ -82,7 +82,7 @@ module.exports = {
 Run a publication command with the target platform, for example:
 
 ```bash
-npx react-native bundle-mf-remote --platform ios
+npx react-native bundle-mf-remote --platform <platform>
 ```
 
 #### 3. Using Command Wrapper

--- a/libs/zephyr-metro-plugin/README.md
+++ b/libs/zephyr-metro-plugin/README.md
@@ -64,9 +64,9 @@ module.exports = withZephyr({
     SharedComponents: 'SharedComponents@http://localhost:9000/remoteEntry.js',
   },
 })(
-  withModuleFederation({
+  withModuleFederation(baseConfig, {
     name: 'MyApp',
-  })(baseConfig)
+  })
 );
 ```
 

--- a/libs/zephyr-metro-plugin/README.md
+++ b/libs/zephyr-metro-plugin/README.md
@@ -52,22 +52,22 @@ artifacts by itself. Register one of the command integrations below to publish.
 
 ```javascript
 // metro.config.js
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const { getDefaultConfig } = require('@react-native/metro-config');
+const { withModuleFederation } = require('@module-federation/metro');
 const { withZephyr } = require('zephyr-metro-plugin');
 
 const baseConfig = getDefaultConfig(__dirname);
 
-module.exports = (async () => {
-  const zephyrConfig = await withZephyr({
+module.exports = withZephyr({
+  target: 'ios', // or 'android'
+  remotes: {
+    SharedComponents: 'SharedComponents@http://localhost:9000/remoteEntry.js',
+  },
+})(
+  withModuleFederation({
     name: 'MyApp',
-    target: 'ios', // or 'android'
-    remotes: {
-      SharedComponents: 'SharedComponents@http://localhost:9000/remoteEntry.js',
-    },
-  })(baseConfig);
-
-  return mergeConfig(baseConfig, zephyrConfig);
-})();
+  })(baseConfig)
+);
 ```
 
 #### 2. React Native CLI commands
@@ -262,7 +262,7 @@ my-react-native-app/
 - **Zephyr Cloud account**: Sign up at [zephyr-cloud.io](https://zephyr-cloud.io)
 
 The `bundle-mf-host` and `bundle-mf-remote` publication commands additionally
-require React Native 0.79 or higher, Metro 0.82.1 or higher, and
+require React Native 0.79 or higher, Metro `>=0.82.1 <0.83.0`, and
 `@module-federation/metro@^2.9.0`. The configuration-only `withZephyr` wrapper
 does not require those command-integration minimums.
 

--- a/libs/zephyr-metro-plugin/README.md
+++ b/libs/zephyr-metro-plugin/README.md
@@ -34,6 +34,11 @@ bun add --dev zephyr-metro-plugin @module-federation/metro
 
 ## Usage
 
+Publication commands using `@module-federation/metro@2.9.0` require React 19,
+React Native 0.79 or newer, `@babel/types` at `>=7.25.0 <8.0.0`, and `metro`,
+`metro-config`, `metro-file-map`, `metro-resolver`, and `metro-source-map`
+versions `>=0.82.1 <0.83.0`.
+
 ### Basic Configuration
 
 The Metro plugin provides two main integration points depending on your setup:

--- a/libs/zephyr-metro-plugin/package.json
+++ b/libs/zephyr-metro-plugin/package.json
@@ -81,13 +81,7 @@
     "typescript": "catalog:typescript"
   },
   "peerDependencies": {
-    "@module-federation/metro": "catalog:peer-compat",
     "metro": "catalog:peer-compat",
     "react-native": "catalog:peer-compat"
-  },
-  "peerDependenciesMeta": {
-    "@module-federation/metro": {
-      "optional": true
-    }
   }
 }

--- a/libs/zephyr-metro-plugin/package.json
+++ b/libs/zephyr-metro-plugin/package.json
@@ -81,7 +81,13 @@
     "typescript": "catalog:typescript"
   },
   "peerDependencies": {
+    "@module-federation/metro": "catalog:peer-compat",
     "metro": "catalog:peer-compat",
     "react-native": "catalog:peer-compat"
+  },
+  "peerDependenciesMeta": {
+    "@module-federation/metro": {
+      "optional": true
+    }
   }
 }

--- a/libs/zephyr-metro-plugin/src/index.ts
+++ b/libs/zephyr-metro-plugin/src/index.ts
@@ -15,6 +15,14 @@ export {
   type MetroFederationConfig,
 } from './lib/zephyr-metro-command-wrapper';
 
+// React Native CLI adapter for Module Federation host/remote publication commands
+export {
+  zephyrMetroReactNativeCli,
+  type ReactNativeCliCommand,
+  type ZephyrMetroReactNativeCliAdapter,
+  type ZephyrMetroReactNativeCliConfig,
+} from './lib/zephyr-metro-react-native-cli';
+
 // RNEF plugin export for Module Federation host/remote bundling commands
 export {
   zephyrMetroRNEFPlugin,

--- a/libs/zephyr-metro-plugin/src/lib/__test__/index-exports.spec.ts
+++ b/libs/zephyr-metro-plugin/src/lib/__test__/index-exports.spec.ts
@@ -9,6 +9,10 @@ rs.mock('../zephyr-metro-command-wrapper', () => ({
   zephyrCommandWrapper: rs.fn(),
 }));
 
+rs.mock('../zephyr-metro-react-native-cli', () => ({
+  zephyrMetroReactNativeCli: rs.fn(),
+}));
+
 rs.mock('../zephyr-metro-rnef-plugin', () => ({
   zephyrMetroRNEFPlugin: rs.fn(),
 }));
@@ -24,5 +28,10 @@ describe('package root exports', () => {
   it('exports zephyrMetroRNEFPlugin for RNEF integrations', () => {
     expect(zephyrMetroPlugin).toHaveProperty('zephyrMetroRNEFPlugin');
     expect(typeof zephyrMetroPlugin.zephyrMetroRNEFPlugin).toBe('function');
+  });
+
+  it('exports the React Native CLI adapter', () => {
+    expect(zephyrMetroPlugin).toHaveProperty('zephyrMetroReactNativeCli');
+    expect(typeof zephyrMetroPlugin.zephyrMetroReactNativeCli).toBe('function');
   });
 });

--- a/libs/zephyr-metro-plugin/src/lib/__test__/with-zephyr.integration.spec.ts
+++ b/libs/zephyr-metro-plugin/src/lib/__test__/with-zephyr.integration.spec.ts
@@ -83,12 +83,16 @@ describe('withZephyr integration', () => {
     });
 
     it('should return enhanced Metro config', async () => {
+      const { ze_log } = await import('zephyr-agent');
       const enhancer = withZephyr({ name: 'TestApp' });
       const result = await enhancer(baseMetroConfig);
 
       expect(result).toBeDefined();
       expect(result.resolver).toBeDefined();
       expect(result.server).toBeDefined();
+      expect(ze_log.app).toHaveBeenCalledWith(
+        'Zephyr Metro configured; no artifacts were uploaded'
+      );
     });
 
     it('should add zephyr to resolver main fields', async () => {

--- a/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-command-wrapper.spec.ts
+++ b/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-command-wrapper.spec.ts
@@ -218,7 +218,30 @@ describe('zephyrCommandWrapper', () => {
   });
 
   describe('mode handling', () => {
-    it('should set development mode when mode is truthy', async () => {
+    for (const [dev, expectedMode] of [
+      [true, 'development'],
+      [false, 'production'],
+    ] as const) {
+      it(`derives ${expectedMode} mode from dev=${dev}`, async () => {
+        const { ZephyrMetroPlugin } = require('../zephyr-metro-plugin');
+        const wrapper = await zephyrCommandWrapper(
+          mockBundleFederatedRemote,
+          mockLoadMetroConfig,
+          mockUpdateManifest
+        );
+        const args = createMockArgs({ configOptions: {}, mode: undefined });
+        args[0][0] = { dev, platform: 'ios' };
+
+        await wrapper(...args);
+
+        expect(ZephyrMetroPlugin).toHaveBeenCalledWith(
+          expect.objectContaining({ mode: expectedMode })
+        );
+        expect(mockBundleFederatedRemote).toHaveBeenCalledWith(...args);
+      });
+    }
+
+    it('keeps RNEF development mode as development', async () => {
       const { ZephyrMetroPlugin } = require('../zephyr-metro-plugin');
 
       const wrapper = await zephyrCommandWrapper(
@@ -236,7 +259,7 @@ describe('zephyrCommandWrapper', () => {
       );
     });
 
-    it('should set production mode when mode is falsy', async () => {
+    it('keeps RNEF production mode as production without changing upstream arguments', async () => {
       const { ZephyrMetroPlugin } = require('../zephyr-metro-plugin');
 
       const wrapper = await zephyrCommandWrapper(
@@ -245,13 +268,15 @@ describe('zephyrCommandWrapper', () => {
         mockUpdateManifest
       );
 
-      await wrapper(...createMockArgs({ mode: '' }));
+      const args = createMockArgs({ mode: 'production' });
+      await wrapper(...args);
 
       expect(ZephyrMetroPlugin).toHaveBeenCalledWith(
         expect.objectContaining({
           mode: 'production',
         })
       );
+      expect(mockBundleFederatedRemote).toHaveBeenCalledWith(...args);
     });
   });
 

--- a/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-react-native-cli.spec.ts
+++ b/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-react-native-cli.spec.ts
@@ -1,13 +1,19 @@
 import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+import { resolve } from 'node:path';
 
-const { runtimeRequire, wrappedCommand, zephyrCommandWrapper } = rs.hoisted(() => ({
-  runtimeRequire: rs.fn(),
-  wrappedCommand: rs.fn(),
-  zephyrCommandWrapper: rs.fn(),
-}));
+const { createRequire, runtimeRequire, wrappedCommand, zephyrCommandWrapper } =
+  rs.hoisted(() => {
+    const runtimeRequire = rs.fn();
+    return {
+      createRequire: rs.fn(() => runtimeRequire),
+      runtimeRequire,
+      wrappedCommand: rs.fn(),
+      zephyrCommandWrapper: rs.fn(),
+    };
+  });
 
 rs.mock('node:module', () => ({
-  createRequire: () => runtimeRequire,
+  createRequire,
 }));
 
 rs.mock('../zephyr-metro-command-wrapper', () => ({
@@ -62,6 +68,12 @@ describe('zephyrMetroReactNativeCli', () => {
       expect.objectContaining({ name: '--config-cmd [string]' }),
     ]);
     expect(adapter.commands[1]?.options).toEqual([{ name: '--remote-option' }]);
+  });
+
+  it('resolves a relative project root before creating the runtime loader', () => {
+    zephyrMetroReactNativeCli({ projectRoot: './apps/mobile' });
+
+    expect(createRequire).toHaveBeenCalledWith(resolve('./apps/mobile/package.json'));
   });
 
   it('uses the existing Metro command wrapper and manifest globals', async () => {

--- a/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-react-native-cli.spec.ts
+++ b/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-react-native-cli.spec.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+
+const { runtimeRequire, wrappedCommand, zephyrCommandWrapper } = rs.hoisted(() => ({
+  runtimeRequire: rs.fn(),
+  wrappedCommand: rs.fn(),
+  zephyrCommandWrapper: rs.fn(),
+}));
+
+rs.mock('node:module', () => ({
+  createRequire: () => runtimeRequire,
+}));
+
+rs.mock('../zephyr-metro-command-wrapper', () => ({
+  zephyrCommandWrapper,
+}));
+
+rs.mock('zephyr-agent', () => ({
+  ZephyrError: Error,
+  ZeErrors: { ERR_UNKNOWN: 'ERR_UNKNOWN' },
+}));
+
+import { zephyrMetroReactNativeCli } from '../zephyr-metro-react-native-cli';
+
+describe('zephyrMetroReactNativeCli', () => {
+  const updateManifest = rs.fn();
+  const bundleFederatedHost = rs.fn();
+  const bundleFederatedRemote = rs.fn();
+  const loadMetroConfig = rs.fn();
+
+  beforeEach(() => {
+    rs.clearAllMocks();
+    runtimeRequire.mockImplementation((request: string) => {
+      if (request === '@module-federation/metro') {
+        return { updateManifest };
+      }
+      if (request === '@module-federation/metro/commands') {
+        return {
+          default: {
+            bundleFederatedHost,
+            bundleFederatedHostOptions: [{ name: '--host-option' }],
+            bundleFederatedRemote,
+            bundleFederatedRemoteOptions: [{ name: '--remote-option' }],
+            loadMetroConfig,
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    wrappedCommand.mockResolvedValue(undefined);
+    zephyrCommandWrapper.mockResolvedValue(wrappedCommand);
+  });
+
+  it('registers host and remote commands with the upstream options', () => {
+    const adapter = zephyrMetroReactNativeCli({ projectRoot: '/app' });
+
+    expect(adapter.commands.map(({ name }) => name)).toEqual([
+      'bundle-mf-host',
+      'bundle-mf-remote',
+    ]);
+    expect(adapter.commands[0]?.options).toEqual([
+      { name: '--host-option' },
+      expect.objectContaining({ name: '--config-cmd [string]' }),
+    ]);
+    expect(adapter.commands[1]?.options).toEqual([{ name: '--remote-option' }]);
+  });
+
+  it('uses the existing Metro command wrapper and manifest globals', async () => {
+    const command = zephyrMetroReactNativeCli().commands[1]!;
+    const config = {
+      root: '/app',
+      platforms: {},
+      reactNativePath: '/app/node_modules/react-native',
+    };
+    const args = { mode: 'production', platform: 'ios' };
+    (globalThis as any).__METRO_FEDERATION_MANIFEST_PATH = '/app/manifest.json';
+    (globalThis as any).__METRO_FEDERATION_CONFIG = { name: 'remote' };
+
+    await command.func([], config, args);
+    const updateManifestCallback = zephyrCommandWrapper.mock.calls[0]?.[2];
+    updateManifestCallback();
+
+    expect(zephyrCommandWrapper).toHaveBeenCalledWith(
+      bundleFederatedRemote,
+      loadMetroConfig,
+      expect.any(Function)
+    );
+    expect(wrappedCommand).toHaveBeenCalledWith([args], config, args);
+    expect(updateManifest).toHaveBeenCalledWith('/app/manifest.json', {
+      name: 'remote',
+    });
+  });
+
+  it('prints success only after publication completes', async () => {
+    let completePublication!: () => void;
+    wrappedCommand.mockImplementation(
+      () => new Promise<void>((resolve) => (completePublication = resolve))
+    );
+    const info = rs.spyOn(console, 'info').mockImplementation(() => undefined);
+    const command = zephyrMetroReactNativeCli().commands[0]!;
+
+    const publication = command.func(
+      [],
+      { root: '/app', platforms: {}, reactNativePath: '/react-native' },
+      { platform: 'android' }
+    );
+    await Promise.resolve();
+
+    expect(info).not.toHaveBeenCalledWith('Success.');
+    completePublication();
+    await publication;
+    expect(info).toHaveBeenLastCalledWith('Success.');
+  });
+
+  it('does not print success when publication fails', async () => {
+    wrappedCommand.mockRejectedValue(new Error('upload failed'));
+    const info = rs.spyOn(console, 'info').mockImplementation(() => undefined);
+    const command = zephyrMetroReactNativeCli().commands[0]!;
+
+    await expect(
+      command.func(
+        [],
+        { root: '/app', platforms: {}, reactNativePath: '/react-native' },
+        { platform: 'android' }
+      )
+    ).rejects.toThrow('upload failed');
+    expect(info).not.toHaveBeenCalledWith('Success.');
+  });
+});

--- a/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-react-native-cli.spec.ts
+++ b/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-react-native-cli.spec.ts
@@ -90,6 +90,23 @@ describe('zephyrMetroReactNativeCli', () => {
     });
   });
 
+  for (const dev of [true, false]) {
+    it(`passes dev=${dev} to the wrapper without synthesizing mode`, async () => {
+      const command = zephyrMetroReactNativeCli().commands[1]!;
+      const config = {
+        root: '/app',
+        platforms: {},
+        reactNativePath: '/app/node_modules/react-native',
+      };
+      const args = { dev, platform: 'android' };
+
+      await command.func([], config, args);
+
+      expect(wrappedCommand).toHaveBeenCalledWith([args], config, args);
+      expect(args).not.toHaveProperty('mode');
+    });
+  }
+
   it('prints success only after publication completes', async () => {
     let completePublication!: () => void;
     wrappedCommand.mockImplementation(

--- a/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-rnef-plugin.spec.ts
+++ b/libs/zephyr-metro-plugin/src/lib/__test__/zephyr-metro-rnef-plugin.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+
+const { hostFunc, remoteFunc, zephyrMetroReactNativeCli } = rs.hoisted(() => ({
+  hostFunc: rs.fn(),
+  remoteFunc: rs.fn(),
+  zephyrMetroReactNativeCli: rs.fn(),
+}));
+
+rs.mock('../zephyr-metro-react-native-cli', () => ({
+  zephyrMetroReactNativeCli,
+}));
+
+import { zephyrMetroRNEFPlugin } from '../zephyr-metro-rnef-plugin';
+
+describe('zephyrMetroRNEFPlugin', () => {
+  beforeEach(() => {
+    rs.clearAllMocks();
+    zephyrMetroReactNativeCli.mockReturnValue({
+      commands: [
+        {
+          name: 'bundle-mf-host',
+          description: 'host',
+          func: hostFunc,
+          options: [{ name: '--host', description: 'host option' }],
+        },
+        {
+          name: 'bundle-mf-remote',
+          description: 'remote',
+          func: remoteFunc,
+          options: [{ name: '--remote', description: 'remote option' }],
+        },
+      ],
+    });
+  });
+
+  it('keeps registering both adapter commands with the RNEF API', async () => {
+    const registered: any[] = [];
+    const api = {
+      registerCommand: (command: any) => registered.push(command),
+      getProjectRoot: () => '/app',
+      getPlatforms: () => ({ ios: {} }),
+      getReactNativePath: () => '/app/node_modules/react-native',
+    };
+
+    const plugin = zephyrMetroRNEFPlugin({ platforms: { custom: {} } })(api);
+    const args = { platform: 'ios', mode: 'production' };
+    await registered[0].action(args);
+
+    expect(plugin.name).toBe('zephyr-metro-rnef-plugin');
+    expect(registered.map(({ name }) => name)).toEqual([
+      'bundle-mf-host',
+      'bundle-mf-remote',
+    ]);
+    expect(hostFunc).toHaveBeenCalledWith(
+      [],
+      {
+        root: '/app',
+        reactNativePath: '/app/node_modules/react-native',
+        platforms: { custom: {} },
+      },
+      args
+    );
+  });
+});

--- a/libs/zephyr-metro-plugin/src/lib/with-zephyr.ts
+++ b/libs/zephyr-metro-plugin/src/lib/with-zephyr.ts
@@ -34,7 +34,7 @@ export interface ZephyrModuleFederationConfig {
   shared?: Record<string, any>;
 }
 
-/** Metro plugin configuration function for Zephyr */
+/** Configure Metro for Zephyr. Publication commands must be registered separately. */
 export function withZephyr(zephyrOptions: ZephyrMetroOptions = {}) {
   assertConfiguredMetroTarget(zephyrOptions.target);
 
@@ -151,7 +151,7 @@ async function applyZephyrToMetroConfig(
       ze_log.error(errorMessage);
     }
 
-    ze_log.app('Zephyr Metro plugin configured successfully');
+    ze_log.app('Zephyr Metro configured; no artifacts were uploaded');
 
     return enhancedConfig;
   } finally {

--- a/libs/zephyr-metro-plugin/src/lib/zephyr-metro-command-wrapper.ts
+++ b/libs/zephyr-metro-plugin/src/lib/zephyr-metro-command-wrapper.ts
@@ -11,7 +11,8 @@ export type MetroConfig = Record<string, unknown>;
 export type MetroFederationConfig = Pick<ZephyrPluginOptions, 'mfConfig'>['mfConfig'];
 
 interface MetroBundleOptions {
-  mode: string;
+  dev?: boolean;
+  mode?: string | boolean;
   platform: MetroNativeBuildTarget;
 }
 
@@ -43,7 +44,18 @@ export async function zephyrCommandWrapper(
     let wrapperOwnsRollback = false;
     try {
       // before build
-      const isDev = args[0][0].mode;
+      const requestedDev = args[0][0].dev;
+      const requestedMode = args[0][0].mode;
+      const mode =
+        typeof requestedDev === 'boolean'
+          ? requestedDev
+            ? 'development'
+            : 'production'
+          : requestedMode === 'production'
+            ? 'production'
+            : requestedMode === 'development' || Boolean(requestedMode)
+              ? 'development'
+              : 'production';
 
       const context = args[1].root;
 
@@ -59,7 +71,7 @@ export async function zephyrCommandWrapper(
 
       zephyrMetroPlugin = new ZephyrMetroPlugin({
         platform,
-        mode: isDev ? 'development' : 'production',
+        mode,
         context,
         outDir: 'dist',
         mfConfig: (global as any).__METRO_FEDERATION_CONFIG,

--- a/libs/zephyr-metro-plugin/src/lib/zephyr-metro-react-native-cli.ts
+++ b/libs/zephyr-metro-plugin/src/lib/zephyr-metro-react-native-cli.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { resolve } from 'node:path';
 import { ZephyrError, ZeErrors } from 'zephyr-agent';
 import { zephyrCommandWrapper } from './zephyr-metro-command-wrapper';
 
@@ -50,7 +50,7 @@ export function zephyrMetroReactNativeCli(
   adapterConfig: ZephyrMetroReactNativeCliConfig = {}
 ): ZephyrMetroReactNativeCliAdapter {
   const projectRoot = adapterConfig.projectRoot ?? process.cwd();
-  const runtimeRequire = createRequire(join(projectRoot, 'package.json'));
+  const runtimeRequire = createRequire(resolve(projectRoot, 'package.json'));
 
   try {
     const { updateManifest } = runtimeRequire('@module-federation/metro') as {

--- a/libs/zephyr-metro-plugin/src/lib/zephyr-metro-react-native-cli.ts
+++ b/libs/zephyr-metro-plugin/src/lib/zephyr-metro-react-native-cli.ts
@@ -4,6 +4,7 @@ import { ZephyrError, ZeErrors } from 'zephyr-agent';
 import { zephyrCommandWrapper } from './zephyr-metro-command-wrapper';
 
 interface ReactNativeCliCommandOptions {
+  dev?: boolean;
   mode?: string;
   platform: string;
   maxWorkers?: number;
@@ -83,11 +84,7 @@ export function zephyrMetroReactNativeCli(
           }
         );
 
-        await bundleWithZephyr(
-          [{ mode: args.mode ?? 'production', ...args } as any],
-          config as any,
-          args as any
-        );
+        await bundleWithZephyr([args as any], config as any, args as any);
         console.info('Bundle artifacts uploaded to Zephyr.');
         console.info('Success.');
       },

--- a/libs/zephyr-metro-plugin/src/lib/zephyr-metro-react-native-cli.ts
+++ b/libs/zephyr-metro-plugin/src/lib/zephyr-metro-react-native-cli.ts
@@ -1,0 +1,130 @@
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { ZephyrError, ZeErrors } from 'zephyr-agent';
+import { zephyrCommandWrapper } from './zephyr-metro-command-wrapper';
+
+interface ReactNativeCliCommandOptions {
+  mode?: string;
+  platform: string;
+  maxWorkers?: number;
+  resetCache?: boolean;
+  config?: string;
+  [key: string]: unknown;
+}
+
+interface ReactNativeCliConfig {
+  root: string;
+  platforms: Record<string, object>;
+  reactNativePath: string;
+  [key: string]: unknown;
+}
+
+interface ReactNativeCliCommandOption {
+  name: string;
+  description: string;
+  default?: string | boolean | number;
+  parse?: (value: string) => unknown;
+}
+
+export interface ReactNativeCliCommand {
+  name: string;
+  description: string;
+  func: (
+    argv: string[],
+    config: ReactNativeCliConfig,
+    args: ReactNativeCliCommandOptions
+  ) => Promise<void>;
+  options: ReactNativeCliCommandOption[];
+}
+
+export interface ZephyrMetroReactNativeCliConfig {
+  projectRoot?: string;
+}
+
+export interface ZephyrMetroReactNativeCliAdapter {
+  commands: ReactNativeCliCommand[];
+}
+
+export function zephyrMetroReactNativeCli(
+  adapterConfig: ZephyrMetroReactNativeCliConfig = {}
+): ZephyrMetroReactNativeCliAdapter {
+  const projectRoot = adapterConfig.projectRoot ?? process.cwd();
+  const runtimeRequire = createRequire(join(projectRoot, 'package.json'));
+
+  try {
+    const { updateManifest } = runtimeRequire('@module-federation/metro') as {
+      updateManifest: (manifestPath: string, mfConfig: unknown) => void;
+    };
+    const { default: commands } = runtimeRequire('@module-federation/metro/commands') as {
+      default: Record<string, any>;
+    };
+
+    const createCommand = (
+      name: 'bundle-mf-host' | 'bundle-mf-remote',
+      commandName: 'bundleFederatedHost' | 'bundleFederatedRemote',
+      optionsName: 'bundleFederatedHostOptions' | 'bundleFederatedRemoteOptions'
+    ): ReactNativeCliCommand => ({
+      name,
+      description: `Bundles a Module Federation ${name.endsWith('host') ? 'host' : 'remote'} with Zephyr Cloud`,
+      func: async (argv, config, args) => {
+        console.info(
+          `Bundling Module Federation ${name.endsWith('host') ? 'host' : 'remote'} for platform ${args.platform} with Zephyr Cloud`
+        );
+
+        const bundleWithZephyr = await zephyrCommandWrapper(
+          commands[commandName],
+          commands['loadMetroConfig'],
+          () => {
+            const globalState = globalThis as any;
+            updateManifest(
+              globalState.__METRO_FEDERATION_MANIFEST_PATH,
+              globalState.__METRO_FEDERATION_CONFIG
+            );
+          }
+        );
+
+        await bundleWithZephyr(
+          [{ mode: args.mode ?? 'production', ...args } as any],
+          config as any,
+          args as any
+        );
+        console.info('Bundle artifacts uploaded to Zephyr.');
+        console.info('Success.');
+      },
+      options: commands[optionsName] ?? [],
+    });
+
+    const hostCommand = createCommand(
+      'bundle-mf-host',
+      'bundleFederatedHost',
+      'bundleFederatedHostOptions'
+    );
+    hostCommand.options = [
+      ...hostCommand.options,
+      {
+        name: '--config-cmd [string]',
+        description:
+          '[Internal] Pass-through for Xcode build script - matches the stock RNEF plugin.',
+      },
+    ];
+
+    return {
+      commands: [
+        hostCommand,
+        createCommand(
+          'bundle-mf-remote',
+          'bundleFederatedRemote',
+          'bundleFederatedRemoteOptions'
+        ),
+      ],
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ZephyrError(ZeErrors.ERR_UNKNOWN, {
+      message:
+        'zephyrMetroReactNativeCli requires @module-federation/metro. ' +
+        'Install it in your app devDependencies to use this integration. ' +
+        `Original error: ${detail}`,
+    });
+  }
+}

--- a/libs/zephyr-metro-plugin/src/lib/zephyr-metro-rnef-plugin.ts
+++ b/libs/zephyr-metro-plugin/src/lib/zephyr-metro-rnef-plugin.ts
@@ -1,7 +1,4 @@
-import { createRequire } from 'node:module';
-import { join } from 'node:path';
-import { ZephyrError, ZeErrors } from 'zephyr-agent';
-import { zephyrCommandWrapper } from './zephyr-metro-command-wrapper';
+import { zephyrMetroReactNativeCli } from './zephyr-metro-react-native-cli';
 
 export interface ZephyrMetroRNEFPluginConfig {
   platforms?: Record<string, object>;
@@ -38,118 +35,26 @@ export interface RNEFPluginApi {
 export const zephyrMetroRNEFPlugin =
   (pluginConfig: ZephyrMetroRNEFPluginConfig = {}) =>
   (api: RNEFPluginApi) => {
-    const loadRuntimeDeps = () => {
-      const runtimeRequire = createRequire(join(api.getProjectRoot(), 'package.json'));
-      try {
-        const { updateManifest } = runtimeRequire('@module-federation/metro') as {
-          updateManifest: (manifestPath: string, mfConfig: unknown) => void;
-        };
-        const { default: commands } = runtimeRequire(
-          '@module-federation/metro/commands'
-        ) as {
-          default: Record<string, any>;
-        };
-        const logger = { info: (message: string) => console.info(message) };
-        const color = { cyan: (value: string) => value };
-        const outro = (message: string) => console.info(message);
-        return { updateManifest, commands, color, logger, outro };
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        throw new ZephyrError(ZeErrors.ERR_UNKNOWN, {
-          message:
-            'zephyrMetroRNEFPlugin requires @module-federation/metro. ' +
-            'Install it in your app devDependencies to use this integration. ' +
-            `Original error: ${detail}`,
-        });
-      }
-    };
+    const adapter = zephyrMetroReactNativeCli({ projectRoot: api.getProjectRoot() });
 
-    const deps = loadRuntimeDeps();
-
-    api.registerCommand({
-      name: 'bundle-mf-host',
-      description: 'Bundles a Module Federation host with Zephyr Cloud',
-      action: async (args: RNEFCommandArgv) => {
-        const { updateManifest, commands, color, logger, outro } = deps;
-        const commandConfig = {
-          root: api.getProjectRoot(),
-          platforms: api.getPlatforms(),
-          reactNativePath: api.getReactNativePath(),
-          ...pluginConfig,
-        };
-
-        logger.info(
-          `Bundling Module Federation host for platform ${color.cyan(args.platform)} with Zephyr Cloud`
-        );
-
-        const bundleZephyrHostCommand = await zephyrCommandWrapper(
-          commands['bundleFederatedHost'],
-          commands['loadMetroConfig'],
-          () => {
-            const globalState = globalThis as any;
-            updateManifest(
-              globalState.__METRO_FEDERATION_MANIFEST_PATH,
-              globalState.__METRO_FEDERATION_CONFIG
-            );
-          }
-        );
-
-        await bundleZephyrHostCommand(
-          [{ mode: args.mode ?? 'production', ...args } as any],
-          commandConfig,
-          args as any
-        );
-        logger.info('Bundle artifacts uploaded to Zephyr.');
-        outro('Success.');
-      },
-      options: [
-        ...(deps.commands['bundleFederatedHostOptions'] ?? []),
-        {
-          name: '--config-cmd [string]',
-          description:
-            '[Internal] Pass-through for Xcode build script - matches the stock RNEF plugin.',
-        },
-      ],
-    });
-
-    api.registerCommand({
-      name: 'bundle-mf-remote',
-      description: 'Bundles a Module Federation remote with Zephyr Cloud',
-      action: async (args: RNEFCommandArgv) => {
-        const { updateManifest, commands, color, logger, outro } = deps;
-        const commandConfig = {
-          root: api.getProjectRoot(),
-          platforms: api.getPlatforms(),
-          reactNativePath: api.getReactNativePath(),
-          ...pluginConfig,
-        };
-
-        logger.info(
-          `Bundling Module Federation remote for platform ${color.cyan(args.platform)} with Zephyr Cloud`
-        );
-
-        const bundleZephyrRemoteCommand = await zephyrCommandWrapper(
-          commands['bundleFederatedRemote'],
-          commands['loadMetroConfig'],
-          () => {
-            const globalState = globalThis as any;
-            updateManifest(
-              globalState.__METRO_FEDERATION_MANIFEST_PATH,
-              globalState.__METRO_FEDERATION_CONFIG
-            );
-          }
-        );
-
-        await bundleZephyrRemoteCommand(
-          [{ mode: args.mode ?? 'production', ...args } as any],
-          commandConfig,
-          args as any
-        );
-        logger.info('Bundle artifacts uploaded to Zephyr.');
-        outro('Success.');
-      },
-      options: deps.commands['bundleFederatedRemoteOptions'] ?? [],
-    });
+    for (const command of adapter.commands) {
+      api.registerCommand({
+        name: command.name,
+        description: command.description,
+        action: (args: RNEFCommandArgv) =>
+          command.func(
+            [],
+            {
+              root: api.getProjectRoot(),
+              platforms: api.getPlatforms(),
+              reactNativePath: api.getReactNativePath(),
+              ...pluginConfig,
+            },
+            args
+          ),
+        options: command.options,
+      });
+    }
 
     return {
       name: 'zephyr-metro-rnef-plugin',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,9 +290,6 @@ catalogs:
       specifier: ^2.16.4
       version: 2.16.4
   peer-compat:
-    '@module-federation/metro':
-      specifier: ^2.9.0
-      version: 2.9.0
     react-native:
       specifier: '>=0.60.0'
       version: 0.87.1
@@ -1999,9 +1996,6 @@ importers:
 
   libs/zephyr-metro-plugin:
     dependencies:
-      '@module-federation/metro':
-        specifier: catalog:peer-compat
-        version: 2.9.0(@babel/types@7.29.8)(metro-config@0.87.0(supports-color@10.2.2))(metro-file-map@0.87.0(supports-color@10.2.2))(metro-resolver@0.87.0)(metro-source-map@0.87.0(supports-color@10.2.2))(metro@0.87.0(supports-color@10.2.2))(react-native@0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)(typescript@7.0.2)
       react-native:
         specifier: catalog:peer-compat
         version: 0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
@@ -3918,11 +3912,6 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@expo/metro-runtime@5.0.5':
-    resolution: {integrity: sha512-P8UFTi+YsmiD1BmdTdiIQITzDMcZgronsA3RTQ4QKJjHM3bas11oGzLQOnFaIZnlEV8Rrr3m1m+RHxvnpL+t/A==}
-    peerDependencies:
-      react-native: '*'
-
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -4895,23 +4884,6 @@ packages:
 
   '@module-federation/manifest@2.9.0':
     resolution: {integrity: sha512-Zhm9luVOw9XPou50eTwsvdgr208CszoQ6cGORQDCPAMhjpGb5oYFtilJ+LKW7hQ1LktD15bEZmGhC1anvgXEiQ==}
-
-  '@module-federation/metro@2.9.0':
-    resolution: {integrity: sha512-IkTbg5eNaEfl+pTFxu9d0JUySmPRGByMQCVmZ2ivI/J/ivHYGYM2KwNQR1iI2pJr6zPHSLFA45fozRnFjvk9ww==}
-    peerDependencies:
-      '@babel/types': ^7.25.0
-      metro: ^0.82.1
-      metro-config: ^0.82.1
-      metro-file-map: ^0.82.1
-      metro-resolver: ^0.82.1
-      metro-source-map: ^0.82.1
-      react: '>=19.0.0'
-      react-native: '>=0.79.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-native:
-        optional: true
 
   '@module-federation/node@2.7.50':
     resolution: {integrity: sha512-mbpQRdafyeWgsmYoJfdhOQf76zS6onOGpC2X1ELpWXB1Y4BcZGloL0CLjNMNon9m3ucfpc99tOGAQqFzQVkSBQ==}
@@ -17602,10 +17574,6 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@expo/metro-runtime@5.0.5(react-native@0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
-    dependencies:
-      react-native: 0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
-
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -18798,27 +18766,6 @@ snapshots:
       '@module-federation/dts-plugin': 2.9.0(typescript@7.0.2)
       '@module-federation/managers': 2.9.0
       '@module-federation/sdk': 2.9.0
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
-  '@module-federation/metro@2.9.0(@babel/types@7.29.8)(metro-config@0.87.0(supports-color@10.2.2))(metro-file-map@0.87.0(supports-color@10.2.2))(metro-resolver@0.87.0)(metro-source-map@0.87.0(supports-color@10.2.2))(metro@0.87.0(supports-color@10.2.2))(react-native@0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)(typescript@7.0.2)':
-    dependencies:
-      '@babel/types': 7.29.8
-      '@expo/metro-runtime': 5.0.5(react-native@0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
-      '@module-federation/dts-plugin': 2.9.0(typescript@7.0.2)
-      '@module-federation/runtime': 2.9.0
-      '@module-federation/sdk': 2.9.0
-      metro: 0.87.0(supports-color@10.2.2)
-      metro-config: 0.87.0(supports-color@10.2.2)
-      metro-file-map: 0.87.0(supports-color@10.2.2)
-      metro-resolver: 0.87.0
-      metro-source-map: 0.87.0(supports-color@10.2.2)
-    optionalDependencies:
-      react: 19.2.8
-      react-native: 0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     transitivePeerDependencies:
       - bufferutil
       - typescript

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ catalogs:
       specifier: ^2.16.4
       version: 2.16.4
   peer-compat:
+    '@module-federation/metro':
+      specifier: ^2.9.0
+      version: 2.9.0
     react-native:
       specifier: '>=0.60.0'
       version: 0.87.1
@@ -1996,6 +1999,9 @@ importers:
 
   libs/zephyr-metro-plugin:
     dependencies:
+      '@module-federation/metro':
+        specifier: catalog:peer-compat
+        version: 2.9.0(@babel/types@7.29.8)(metro-config@0.87.0(supports-color@10.2.2))(metro-file-map@0.87.0(supports-color@10.2.2))(metro-resolver@0.87.0)(metro-source-map@0.87.0(supports-color@10.2.2))(metro@0.87.0(supports-color@10.2.2))(react-native@0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)(typescript@7.0.2)
       react-native:
         specifier: catalog:peer-compat
         version: 0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
@@ -3912,6 +3918,11 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@expo/metro-runtime@5.0.5':
+    resolution: {integrity: sha512-P8UFTi+YsmiD1BmdTdiIQITzDMcZgronsA3RTQ4QKJjHM3bas11oGzLQOnFaIZnlEV8Rrr3m1m+RHxvnpL+t/A==}
+    peerDependencies:
+      react-native: '*'
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -4884,6 +4895,23 @@ packages:
 
   '@module-federation/manifest@2.9.0':
     resolution: {integrity: sha512-Zhm9luVOw9XPou50eTwsvdgr208CszoQ6cGORQDCPAMhjpGb5oYFtilJ+LKW7hQ1LktD15bEZmGhC1anvgXEiQ==}
+
+  '@module-federation/metro@2.9.0':
+    resolution: {integrity: sha512-IkTbg5eNaEfl+pTFxu9d0JUySmPRGByMQCVmZ2ivI/J/ivHYGYM2KwNQR1iI2pJr6zPHSLFA45fozRnFjvk9ww==}
+    peerDependencies:
+      '@babel/types': ^7.25.0
+      metro: ^0.82.1
+      metro-config: ^0.82.1
+      metro-file-map: ^0.82.1
+      metro-resolver: ^0.82.1
+      metro-source-map: ^0.82.1
+      react: '>=19.0.0'
+      react-native: '>=0.79.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-native:
+        optional: true
 
   '@module-federation/node@2.7.50':
     resolution: {integrity: sha512-mbpQRdafyeWgsmYoJfdhOQf76zS6onOGpC2X1ELpWXB1Y4BcZGloL0CLjNMNon9m3ucfpc99tOGAQqFzQVkSBQ==}
@@ -17574,6 +17602,10 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
+  '@expo/metro-runtime@5.0.5(react-native@0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
+    dependencies:
+      react-native: 0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -18766,6 +18798,27 @@ snapshots:
       '@module-federation/dts-plugin': 2.9.0(typescript@7.0.2)
       '@module-federation/managers': 2.9.0
       '@module-federation/sdk': 2.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
+  '@module-federation/metro@2.9.0(@babel/types@7.29.8)(metro-config@0.87.0(supports-color@10.2.2))(metro-file-map@0.87.0(supports-color@10.2.2))(metro-resolver@0.87.0)(metro-source-map@0.87.0(supports-color@10.2.2))(metro@0.87.0(supports-color@10.2.2))(react-native@0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)(typescript@7.0.2)':
+    dependencies:
+      '@babel/types': 7.29.8
+      '@expo/metro-runtime': 5.0.5(react-native@0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
+      '@module-federation/dts-plugin': 2.9.0(typescript@7.0.2)
+      '@module-federation/runtime': 2.9.0
+      '@module-federation/sdk': 2.9.0
+      metro: 0.87.0(supports-color@10.2.2)
+      metro-config: 0.87.0(supports-color@10.2.2)
+      metro-file-map: 0.87.0(supports-color@10.2.2)
+      metro-resolver: 0.87.0
+      metro-source-map: 0.87.0(supports-color@10.2.2)
+    optionalDependencies:
+      react: 19.2.8
+      react-native: 0.87.1(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     transitivePeerDependencies:
       - bufferutil
       - typescript


### PR DESCRIPTION
### What is added in this PR?

- Add `zephyrMetroReactNativeCli()` with `bundle-mf-host` and `bundle-mf-remote` publication commands.
- Reuse the adapter from the existing RNEF plugin.
- Keep `withZephyr()` configuration-only and clarify that it uploads no artifacts.
- Bootstrap safe React Native CLI or RNEF companion configuration from the Metro codemod.
- Preserve existing commands/plugins, support CJS and ESM object exports, avoid speculative edits, and keep reruns/dry runs idempotent.
- Pin the compatible `@module-federation/metro@^2.9.0` command surface and reject incompatible preinstalled versions.
- Print the first publication command only after dependency installation succeeds.
- Ignore `.playwright-mcp/` local browser artifacts.

#### Screenshots

Not applicable.

### What issue or discussion is related to this PR?

Automatic Metro setup previously wrapped `metro.config.*` but did not register a post-bundle publication command. A setup could therefore appear successful while no artifacts were uploaded and no application version was created.

### What are the steps to test this PR?

1. Run `pnpm --filter zephyr-metro-plugin test`.
2. Run `pnpm --filter zephyr-metro-plugin typecheck`.
3. Run `pnpm --filter zephyr-metro-plugin build`.
4. Run `pnpm --filter with-zephyr test`.
5. Run `pnpm --filter with-zephyr typecheck`.
6. Run `pnpm --filter with-zephyr build`.

All commands pass locally. Repository pre-commit hooks also passed all affected tests and lint.

### Documentation update for this PR

- https://github.com/ZephyrCloudIO/zephyr-documentation/pull/243

### What is left to be done?

- Publish `zephyr-metro-plugin` and `with-zephyr` before merging the documentation PR.

### What is the potential risk and how is it mitigated?

The codemod touches companion CLI configuration only when project type and direct object exports are unambiguous. Unsupported, conflicting, or incompatible projects remain unchanged and receive exact manual guidance. Existing bundler transforms are otherwise unchanged.

### Pre-PR/Merge checklist

- [x] Opened a documentation PR for the new behavior
- [x] Added an explanation of the changes
- [x] Added regression tests
- [x] Tested CJS, ESM, RNEF, nested projects, idempotency, dry runs, dependency failure, and package exports
- [x] Ran package tests, typechecks, builds, formatting, lint, and affected pre-commit tests