### PR TITLE
fix(metro): harden codemod binding resolution

### DIFF
--- a/libs/with-zephyr/src/engine/ast-grep.ts
+++ b/libs/with-zephyr/src/engine/ast-grep.ts
@@ -176,6 +176,15 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
       }
     }
 
+    const isTopLevelDeclaration = (declaration: SgNode): boolean => {
+      const container = declaration.parent()?.parent();
+      return Boolean(
+        container?.id() === root.id() ||
+        (container?.kind() === 'export_statement' &&
+          container.parent()?.id() === root.id())
+      );
+    };
+
     const isExportedObject = (object: SgNode | null): boolean => {
       const parent = object?.parent();
       if (!parent) return false;
@@ -186,7 +195,7 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
         return true;
       }
       if (parent.kind() !== 'variable_declarator') return false;
-      if (parent.parent()?.parent()?.id() !== root.id()) return false;
+      if (!isTopLevelDeclaration(parent)) return false;
       const identifier = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(parent.text())?.[1];
       return Boolean(identifier && exportedIdentifiers.has(identifier));
     };
@@ -224,10 +233,7 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
         if (parent.kind() === 'variable_declarator') {
           const identifier = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(parent.text())?.[1];
           if (!identifier) return false;
-          if (
-            parent.parent()?.parent()?.id() === root.id() &&
-            exportedIdentifiers.has(identifier)
-          ) {
+          if (isTopLevelDeclaration(parent) && exportedIdentifiers.has(identifier)) {
             return true;
           }
 
@@ -311,7 +317,7 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
 
       const declaration = call.parent();
       if (declaration?.kind() !== 'variable_declarator') return false;
-      if (declaration.parent()?.parent()?.id() !== root.id()) return false;
+      if (!isTopLevelDeclaration(declaration)) return false;
       const bindingName = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(declaration.text())?.[1];
       if (!bindingName) return false;
 

--- a/libs/with-zephyr/src/engine/ast-grep.ts
+++ b/libs/with-zephyr/src/engine/ast-grep.ts
@@ -8,6 +8,7 @@ export type AstGrepLanguage = 'js' | 'ts' | 'json';
 export interface AstGrepRunOptions {
   filePath: string;
   pattern: string;
+  topLevel?: boolean;
   selector?: string;
   strictness?: 'cst' | 'smart' | 'ast' | 'relaxed' | 'signature' | 'template';
   language?: AstGrepLanguage;
@@ -139,8 +140,11 @@ export function searchWithAstGrep(options: AstGrepRunOptions): AstGrepResult {
     const language = options.language ?? detectLanguage(options.filePath);
     const source = fs.readFileSync(options.filePath, 'utf8');
     const { parse } = getAstGrepRuntime();
-    const root = parse(toNapiLanguage(language), source);
-    const match = root.root().find(buildMatcher(options));
+    const root = parse(toNapiLanguage(language), source).root();
+    const matcher = buildMatcher(options);
+    const match = options.topLevel
+      ? root.findAll(matcher).find((node) => node.parent()?.id() === root.id())
+      : root.find(matcher);
 
     return {
       status: match ? 'match' : 'no-match',
@@ -182,6 +186,7 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
         return true;
       }
       if (parent.kind() !== 'variable_declarator') return false;
+      if (parent.parent()?.parent()?.id() !== root.id()) return false;
       const identifier = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(parent.text())?.[1];
       return Boolean(identifier && exportedIdentifiers.has(identifier));
     };
@@ -219,7 +224,12 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
         if (parent.kind() === 'variable_declarator') {
           const identifier = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(parent.text())?.[1];
           if (!identifier) return false;
-          if (exportedIdentifiers.has(identifier)) return true;
+          if (
+            parent.parent()?.parent()?.id() === root.id() &&
+            exportedIdentifiers.has(identifier)
+          ) {
+            return true;
+          }
 
           const functionNode = parent
             .ancestors()
@@ -301,6 +311,7 @@ export function hasExportedConfigCall(options: ExportedConfigCallOptions): boole
 
       const declaration = call.parent();
       if (declaration?.kind() !== 'variable_declarator') return false;
+      if (declaration.parent()?.parent()?.id() !== root.id()) return false;
       const bindingName = /^\s*([A-Za-z_$][\w$]*)\s*=/.exec(declaration.text())?.[1];
       if (!bindingName) return false;
 

--- a/libs/with-zephyr/src/index.ts
+++ b/libs/with-zephyr/src/index.ts
@@ -26,7 +26,6 @@ import type { BundlerConfigs } from './types.js';
 import {
   addToPackageJson,
   detectPackageManager,
-  getDeclaredPackageVersion,
   getLatestVersion,
   installDependencies,
   installPackages as installPackagesDirect,
@@ -420,6 +419,38 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
       requireResolved: existing?.requireResolved || packageRequirement.requireResolved,
     });
   };
+  const getPackageDeclaration = (packageRequirement: PackageRequirement) => {
+    const projectDirectory = packageRequirement.projectDirectory ?? directory;
+    try {
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(projectDirectory, 'package.json'), 'utf8')
+      );
+      const depType = packageRequirement.isDev ? 'devDependencies' : 'dependencies';
+      const oppositeDepType = packageRequirement.isDev
+        ? 'dependencies'
+        : 'devDependencies';
+      const dependencies = packageJson[depType] ?? {};
+      const oppositeDependencies = packageJson[oppositeDepType] ?? {};
+      const inRequiredSection = Object.hasOwn(dependencies, packageRequirement.name);
+      const inOppositeSection = Object.hasOwn(
+        oppositeDependencies,
+        packageRequirement.name
+      );
+      return {
+        version: (inRequiredSection ? dependencies : oppositeDependencies)[
+          packageRequirement.name
+        ] as string | undefined,
+        inRequiredSection,
+        inOppositeSection,
+      };
+    } catch {
+      return {
+        version: undefined,
+        inRequiredSection: false,
+        inOppositeSection: false,
+      };
+    }
+  };
 
   for (const packageRequirement of nextJsBootstrap.packageRequirements) {
     addRequiredPackage(packageRequirement);
@@ -476,6 +507,7 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
 
   console.log(chalk.blue(`Found ${filteredConfigFiles.length} configuration file(s):\n`));
   const missingPackages: PackageRequirement[] = [];
+  const packagesToRelocate = new Set<PackageRequirement>();
   if (installPackages) {
     for (const packageRequirement of requiredPackages.values()) {
       const projectDirectory = packageRequirement.projectDirectory ?? directory;
@@ -494,7 +526,13 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
               minimumVersion
             )
           : isPackageInstalled(packageRequirement.name, projectDirectory);
-      if (!satisfied) {
+      const declaration = getPackageDeclaration(packageRequirement);
+      const correctlyPlaced =
+        declaration.inRequiredSection && !declaration.inOppositeSection;
+      if (!satisfied || !correctlyPlaced) {
+        if (satisfied && declaration.version !== undefined) {
+          packagesToRelocate.add(packageRequirement);
+        }
         missingPackages.push(packageRequirement);
       }
     }
@@ -503,10 +541,7 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
   if (installPackages && missingPackages.length > 0 && dryRun) {
     console.log(chalk.blue(`\n📦 Packages that would be installed:\n`));
     for (const packageRequirement of missingPackages) {
-      const declaration = getDeclaredPackageVersion(
-        packageRequirement.name,
-        packageRequirement.projectDirectory ?? directory
-      );
+      const declaration = getPackageDeclaration(packageRequirement).version;
       const version = /^(?:catalog:|workspace:)/.test(declaration ?? '')
         ? declaration
         : packageRequirement.version;
@@ -548,32 +583,25 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
       const projectDirectory = packageRequirement.projectDirectory ?? directory;
       const packageJsonPath = path.join(projectDirectory, 'package.json');
       if (fs.existsSync(packageJsonPath)) {
-        const declaration = getDeclaredPackageVersion(
-          packageRequirement.name,
-          projectDirectory
-        );
-        if (/^(?:catalog:|workspace:)/.test(declaration ?? '')) {
-          stagedPackages.push(packageRequirement);
-          console.log(
-            chalk.green(
-              `✓ Preserved ${packageRequirement.name}@${declaration} in ${normalizePathForOutput(path.relative(path.resolve(directory), packageJsonPath) || 'package.json')}`
-            )
-          );
-          continue;
-        }
+        const declaration = getPackageDeclaration(packageRequirement).version;
+        const isManagedDeclaration = /^(?:catalog:|workspace:)/.test(declaration ?? '');
+        const preserveDeclaration =
+          isManagedDeclaration || packagesToRelocate.has(packageRequirement);
         const version =
-          packageRequirement.version ?? getLatestVersion(packageRequirement.name);
+          (preserveDeclaration ? declaration : packageRequirement.version) ??
+          getLatestVersion(packageRequirement.name);
         const added = addToPackageJson(
           projectDirectory,
           packageRequirement.name,
           version,
-          packageRequirement.isDev
+          packageRequirement.isDev,
+          preserveDeclaration
         );
         if (added) {
           stagedPackages.push(packageRequirement);
           console.log(
             chalk.green(
-              `✓ Added ${packageRequirement.name} to ${normalizePathForOutput(path.relative(path.resolve(directory), packageJsonPath) || 'package.json')}`
+              `✓ ${preserveDeclaration ? `Preserved ${packageRequirement.name}@${declaration} in` : `Added ${packageRequirement.name} to`} ${normalizePathForOutput(path.relative(path.resolve(directory), packageJsonPath) || 'package.json')}`
             )
           );
         } else if (path.resolve(projectDirectory) === path.resolve(directory)) {

--- a/libs/with-zephyr/src/index.ts
+++ b/libs/with-zephyr/src/index.ts
@@ -26,6 +26,7 @@ import type { BundlerConfigs } from './types.js';
 import {
   addToPackageJson,
   detectPackageManager,
+  getDeclaredPackageVersion,
   getLatestVersion,
   installDependencies,
   installPackages as installPackagesDirect,
@@ -502,9 +503,16 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
   if (installPackages && missingPackages.length > 0 && dryRun) {
     console.log(chalk.blue(`\n📦 Packages that would be installed:\n`));
     for (const packageRequirement of missingPackages) {
+      const declaration = getDeclaredPackageVersion(
+        packageRequirement.name,
+        packageRequirement.projectDirectory ?? directory
+      );
+      const version = /^(?:catalog:|workspace:)/.test(declaration ?? '')
+        ? declaration
+        : packageRequirement.version;
       console.log(
         chalk.yellow(
-          `  - ${packageRequirement.name}${packageRequirement.version ? `@${packageRequirement.version}` : ''}${packageRequirement.projectDirectory && path.resolve(packageRequirement.projectDirectory) !== path.resolve(directory) ? ` (${normalizePathForOutput(path.relative(path.resolve(directory), packageRequirement.projectDirectory))})` : ''}`
+          `  - ${packageRequirement.name}${version ? `@${version}` : ''}${packageRequirement.projectDirectory && path.resolve(packageRequirement.projectDirectory) !== path.resolve(directory) ? ` (${normalizePathForOutput(path.relative(path.resolve(directory), packageRequirement.projectDirectory))})` : ''}`
         )
       );
     }
@@ -540,6 +548,19 @@ function runCodemod(directory: string, options: CodemodOptions = {}): void {
       const projectDirectory = packageRequirement.projectDirectory ?? directory;
       const packageJsonPath = path.join(projectDirectory, 'package.json');
       if (fs.existsSync(packageJsonPath)) {
+        const declaration = getDeclaredPackageVersion(
+          packageRequirement.name,
+          projectDirectory
+        );
+        if (/^(?:catalog:|workspace:)/.test(declaration ?? '')) {
+          stagedPackages.push(packageRequirement);
+          console.log(
+            chalk.green(
+              `✓ Preserved ${packageRequirement.name}@${declaration} in ${normalizePathForOutput(path.relative(path.resolve(directory), packageJsonPath) || 'package.json')}`
+            )
+          );
+          continue;
+        }
         const version =
           packageRequirement.version ?? getLatestVersion(packageRequirement.name);
         const added = addToPackageJson(

--- a/libs/with-zephyr/src/metro-bootstrap.ts
+++ b/libs/with-zephyr/src/metro-bootstrap.ts
@@ -95,6 +95,7 @@ function getVersionProblem(
   minimumVersion: string,
   options: {
     allowMissing?: boolean;
+    allowUnresolvedManagedDeclaration?: boolean;
     maximumVersionExclusive?: string;
     resolutionDirectories?: string[];
   } = {}
@@ -129,6 +130,10 @@ function getVersionProblem(
     )
       ? undefined
       : `${packageName} ${resolvedVersion} is installed, but ${expectedVersion} is required.`;
+  }
+
+  if (usesWorkspaceProtocol && options.allowUnresolvedManagedDeclaration) {
+    return undefined;
   }
 
   if (!declaration) {
@@ -229,7 +234,8 @@ function findImportedHelperExpression(
     for (const match of content.matchAll(pattern)) {
       if (
         !match[0] ||
-        searchWithAstGrep({ filePath, pattern: match[0] }).status !== 'match'
+        searchWithAstGrep({ filePath, pattern: match[0], topLevel: true }).status !==
+          'match'
       ) {
         continue;
       }
@@ -259,7 +265,8 @@ function findImportedHelperExpression(
       if (
         namespace &&
         match[0] &&
-        searchWithAstGrep({ filePath, pattern: match[0] }).status === 'match'
+        searchWithAstGrep({ filePath, pattern: match[0], topLevel: true }).status ===
+          'match'
       ) {
         return `${namespace}.${importName}`;
       }
@@ -281,7 +288,7 @@ function hasExportedHelperCall(
     'zephyr-metro-plugin',
     importName
   );
-  return [importName, localName]
+  return [localName]
     .filter((name): name is string => Boolean(name))
     .some((name) => {
       if (name.startsWith('$')) return false;
@@ -298,6 +305,7 @@ function addImport(
   filePath: string,
   content: string,
   importName: string,
+  localName: string,
   esm: boolean
 ): string {
   if (
@@ -307,8 +315,8 @@ function addImport(
   }
 
   const declaration = esm
-    ? `import { ${importName} } from "zephyr-metro-plugin";\n`
-    : `const { ${importName} } = require("zephyr-metro-plugin");\n`;
+    ? `import { ${importName}${localName === importName ? '' : ` as ${localName}`} } from "zephyr-metro-plugin";\n`
+    : `const { ${importName}${localName === importName ? '' : `: ${localName}`} } = require("zephyr-metro-plugin");\n`;
   let insertionIndex = content.startsWith('#!') ? content.indexOf('\n') + 1 : 0;
   if (insertionIndex === 0 && content.startsWith('#!')) {
     return `${content}\n${declaration}`;
@@ -338,7 +346,7 @@ function updateCommonJsConfig(
   }
   const localName =
     findImportedHelperExpression(filePath, content, 'zephyr-metro-plugin', importName) ??
-    importName;
+    getUniqueBindingName(content, importName);
   bindingName = getUniqueBindingName(content, bindingName);
   if (
     searchWithAstGrep({
@@ -349,7 +357,7 @@ function updateCommonJsConfig(
     return 'unsupported';
   }
 
-  const nextContent = `${addImport(filePath, content, importName, false).trimEnd()}
+  const nextContent = `${addImport(filePath, content, importName, localName, false).trimEnd()}
 
 const ${bindingName} = module.exports;
 module.exports = {
@@ -380,7 +388,7 @@ function updateEsmConfig(
   }
   const localName =
     findImportedHelperExpression(filePath, content, 'zephyr-metro-plugin', importName) ??
-    importName;
+    getUniqueBindingName(content, importName);
   bindingName = getUniqueBindingName(content, bindingName);
 
   const result = rewriteWithAstGrep({
@@ -402,7 +410,10 @@ export default {
 
   if (!dryRun) {
     const updatedContent = fs.readFileSync(filePath, 'utf8');
-    fs.writeFileSync(filePath, addImport(filePath, updatedContent, importName, true));
+    fs.writeFileSync(
+      filePath,
+      addImport(filePath, updatedContent, importName, localName, true)
+    );
   }
   return 'updated';
 }
@@ -484,6 +495,7 @@ export function bootstrapMetroCommands(
   const versionProblems = [
     getVersionProblem(directory, '@module-federation/metro', '2.9.0', {
       allowMissing: true,
+      allowUnresolvedManagedDeclaration: true,
       maximumVersionExclusive: '3.0.0',
     }),
     getVersionProblem(directory, '@babel/types', '7.25.0', {

--- a/libs/with-zephyr/src/package-manager.ts
+++ b/libs/with-zephyr/src/package-manager.ts
@@ -416,7 +416,8 @@ export function addToPackageJson(
   directory: string,
   packageName: string,
   version = 'latest',
-  isDev = true
+  isDev = true,
+  preserveVersion = false
 ): boolean {
   const packageJsonPath = path.join(directory, 'package.json');
   if (!fs.existsSync(packageJsonPath)) {
@@ -433,9 +434,10 @@ export function addToPackageJson(
     }
 
     delete packageJson[oppositeDepType]?.[packageName];
-    packageJson[depType][packageName] = /^[~^<>=*]|\s|\|\|/.test(version)
-      ? version
-      : `^${version}`;
+    packageJson[depType][packageName] =
+      preserveVersion || /^(?:catalog:|workspace:|[~^<>=*])|\s|\|\|/.test(version)
+        ? version
+        : `^${version}`;
 
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
     return true;

--- a/libs/with-zephyr/src/tests/codemod.test.ts
+++ b/libs/with-zephyr/src/tests/codemod.test.ts
@@ -842,6 +842,50 @@ describe('Zephyr Codemod CLI', () => {
       expect(packageJson.devDependencies['zephyr-metro-plugin']).toBeUndefined();
     });
 
+    it('should preserve managed Metro companion declarations during install', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          packageManager: 'pnpm@11.0.0',
+          dependencies: { 'react-native': '^0.79.0' },
+          devDependencies: {
+            '@module-federation/metro': 'catalog:',
+            '@react-native-community/cli': '^19.0.0',
+            ...compatibleMetroPeers,
+            'zephyr-metro-plugin': 'workspace:*',
+          },
+        })
+      );
+      fs.writeFileSync(
+        'metro.config.js',
+        `const { withModuleFederation } = require("@module-federation/metro");\nmodule.exports = withModuleFederation({}, { name: "app" });\n`
+      );
+      const fakeBin = path.join(tempDir, 'fake-bin');
+      fs.mkdirSync(fakeBin);
+      const fakeScript = path.join(fakeBin, 'fake-pnpm.js');
+      fs.writeFileSync(
+        fakeScript,
+        `const fs = require("node:fs"); const path = require("node:path"); for (const [name, version] of [["zephyr-metro-plugin", "1.4.2"], ["@module-federation/metro", "2.9.1"]]) { const dir = path.join(process.cwd(), "node_modules", ...name.split("/")); fs.mkdirSync(dir, { recursive: true }); fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, version })); }\n`
+      );
+      const fakePnpm = path.join(fakeBin, 'pnpm');
+      fs.writeFileSync(fakePnpm, `#!/bin/sh\n"${process.execPath}" "${fakeScript}"\n`);
+      fs.chmodSync(fakePnpm, 0o755);
+      fs.writeFileSync(
+        path.join(fakeBin, 'pnpm.cmd'),
+        `@"${process.execPath}" "${fakeScript}"\r\n`
+      );
+
+      const output = runCodemod('', false, {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        npm_config_user_agent: 'pnpm/11.0.0',
+      });
+      const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+      expect(packageJson.devDependencies['zephyr-metro-plugin']).toBe('workspace:*');
+      expect(packageJson.devDependencies['@module-federation/metro']).toBe('catalog:');
+      expect(output).toContain('Publish the first bundle with:');
+    });
+
     it('should fail when a successful nested install leaves requirements unresolved', () => {
       fs.writeFileSync('package.json', JSON.stringify({ private: true }));
       const projectDirectory = path.join(tempDir, 'apps', 'standalone');

--- a/libs/with-zephyr/src/tests/codemod.test.ts
+++ b/libs/with-zephyr/src/tests/codemod.test.ts
@@ -233,6 +233,52 @@ describe('Zephyr Codemod CLI', () => {
       expect(updatedPackageJson.scripts.build).toBe('vinext build');
       expect(updatedPackageJson.scripts.start).toBe('vinext start');
     });
+
+    it('should move existing declarations to their required dependency sections', () => {
+      fs.writeFileSync(
+        'package.json',
+        JSON.stringify({
+          name: '@acme/next-app',
+          packageManager: 'pnpm@11.0.0',
+          dependencies: {
+            next: '^15.0.0',
+            vite: '^8.1.4',
+          },
+          devDependencies: {
+            vinext: 'workspace:*',
+            '@vitejs/plugin-rsc': '0.5.19',
+            'vite-plugin-vinext-zephyr': 'catalog:',
+            '@cloudflare/vite-plugin': 'catalog:',
+            vite: 'catalog:',
+            wrangler: 'catalog:',
+          },
+        })
+      );
+      const fakeBin = path.join(tempDir, 'fake-bin');
+      fs.mkdirSync(fakeBin);
+      const fakeScript = path.join(fakeBin, 'fake-pnpm.js');
+      fs.writeFileSync(fakeScript, 'process.exit(0);\n');
+      const fakePnpm = path.join(fakeBin, 'pnpm');
+      fs.writeFileSync(fakePnpm, `#!/bin/sh\n"${process.execPath}" "${fakeScript}"\n`);
+      fs.chmodSync(fakePnpm, 0o755);
+      fs.writeFileSync(
+        path.join(fakeBin, 'pnpm.cmd'),
+        `@"${process.execPath}" "${fakeScript}"\r\n`
+      );
+
+      runCodemod('.', false, {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        npm_config_user_agent: 'pnpm/11.0.0',
+      });
+      const updatedPackageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+      expect(updatedPackageJson.dependencies.vinext).toBe('workspace:*');
+      expect(updatedPackageJson.devDependencies.vinext).toBeUndefined();
+      expect(updatedPackageJson.dependencies['@vitejs/plugin-rsc']).toBe('0.5.19');
+      expect(updatedPackageJson.devDependencies['@vitejs/plugin-rsc']).toBeUndefined();
+      expect(updatedPackageJson.devDependencies.vite).toBe('catalog:');
+      expect(updatedPackageJson.dependencies.vite).toBeUndefined();
+    });
   });
 
   describe('Slidev Scaffold', () => {

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -80,6 +80,22 @@ describe('bootstrapMetroCommands', () => {
     expect(content).toContain('module.exports = zephyrMetroReactNativeCli()');
   });
 
+  it('recognizes Module Federation in an exported top-level declaration', () => {
+    writePackageJson({
+      type: 'module',
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    fs.writeFileSync(
+      path.join(tempDir, 'metro.config.js'),
+      `import { withModuleFederation } from "@module-federation/metro";\nexport const config = withModuleFederation({}, { name: "app" });\nexport default config;\n`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('react-native-cli');
+    expect(result.createdFiles).toEqual(['react-native.config.js']);
+  });
+
   it('requires an adapter-capable plugin upgrade', () => {
     writePackageJson({
       devDependencies: {

--- a/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
+++ b/libs/with-zephyr/src/tests/metro-bootstrap.test.ts
@@ -446,9 +446,9 @@ describe('bootstrapMetroCommands', () => {
 
     expect(result.updatedFiles).toEqual(['react-native.config.js']);
     const content = fs.readFileSync(configPath, 'utf8');
-    expect(content).toContain('...zephyrMetroReactNativeCli().commands');
+    expect(content).toContain('...zephyrMetroReactNativeCli2().commands');
     expect(content).toContain(
-      '\nconst { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");\n'
+      '\nconst { zephyrMetroReactNativeCli: zephyrMetroReactNativeCli2 } = require("zephyr-metro-plugin");\n'
     );
   });
 
@@ -468,6 +468,101 @@ describe('bootstrapMetroCommands', () => {
     expect(fs.readFileSync(configPath, 'utf8')).toContain(
       '...zephyrMetroReactNativeCli().commands'
     );
+  });
+
+  it('does not confuse a nested config binding with the exported config', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    const content = `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");
+const config = { commands: [] };
+function unused() {
+  const config = { commands: [...zephyrMetroReactNativeCli().commands] };
+  return config;
+}
+module.exports = config;
+`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.packageRequirements).toEqual([]);
+    expect(result.manualGuidance[0]).toContain('does not directly export an object');
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+  });
+
+  it('does not let a nested package import authorize an unrelated adapter call', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    fs.writeFileSync(
+      configPath,
+      `function loadZephyrAdapter() {
+  const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");
+  return zephyrMetroReactNativeCli();
+}
+function zephyrMetroReactNativeCli() { return { commands: [] }; }
+module.exports = { commands: [...zephyrMetroReactNativeCli().commands] };
+`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(result.updatedFiles).toEqual(['react-native.config.js']);
+    expect(content).toContain(
+      'const { zephyrMetroReactNativeCli: zephyrMetroReactNativeCli2 } = require("zephyr-metro-plugin");'
+    );
+    expect(content).toContain('...zephyrMetroReactNativeCli2().commands');
+  });
+
+  it('aliases an ESM adapter import that collides with a local binding', () => {
+    writePackageJson({
+      type: 'module',
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.mjs');
+    fs.writeFileSync(
+      configPath,
+      `function zephyrMetroReactNativeCli() { return { commands: [] }; }
+export default { commands: [...zephyrMetroReactNativeCli().commands] };
+`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(result.updatedFiles).toEqual(['react-native.config.mjs']);
+    expect(content).toContain(
+      'import { zephyrMetroReactNativeCli as zephyrMetroReactNativeCli2 } from "zephyr-metro-plugin";'
+    );
+    expect(content).toContain('...zephyrMetroReactNativeCli2().commands');
+  });
+
+  it('does not match a nested helper result to an exported top-level binding', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    const configPath = path.join(tempDir, 'react-native.config.js');
+    const content = `const { zephyrMetroReactNativeCli } = require("zephyr-metro-plugin");
+const adapter = { commands: [] };
+function unused() {
+  const zephyrMetroReactNativeCli = () => ({ commands: [] });
+  const adapter = zephyrMetroReactNativeCli();
+  return adapter;
+}
+module.exports = { commands: adapter.commands };
+`;
+    fs.writeFileSync(configPath, content);
+
+    const result = bootstrapMetroCommands(tempDir);
+    const updatedContent = fs.readFileSync(configPath, 'utf8');
+
+    expect(result.updatedFiles).toEqual(['react-native.config.js']);
+    expect(updatedContent).toContain('...zephyrMetroReactNativeCli().commands');
+    expect(updatedContent).not.toBe(content);
   });
 
   it('rejects a registered adapter replaced by a later CommonJS export', () => {
@@ -769,6 +864,30 @@ describe('bootstrapMetroCommands', () => {
     expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
   });
 
+  it('does not confuse a nested federation binding with the exported config', () => {
+    writePackageJson({
+      devDependencies: { '@react-native-community/cli': '^19.0.0' },
+    });
+    fs.writeFileSync(
+      path.join(tempDir, 'metro.config.js'),
+      `const { withModuleFederation } = require("@module-federation/metro");
+const config = {};
+function unused() {
+  const config = withModuleFederation({}, { name: "app" });
+  return config;
+}
+module.exports = config;
+`
+    );
+
+    const result = bootstrapMetroCommands(tempDir);
+
+    expect(result.integration).toBe('ambiguous');
+    expect(result.packageRequirements).toEqual([]);
+    expect(result.manualGuidance[0]).toContain('is not verifiably configured');
+    expect(fs.existsSync(path.join(tempDir, 'react-native.config.js'))).toBe(false);
+  });
+
   it('recognizes an aliased federation wrapper through an exported identifier', () => {
     writePackageJson({
       devDependencies: { '@react-native-community/cli': '^19.0.0' },
@@ -806,7 +925,7 @@ describe('bootstrapMetroCommands', () => {
     );
   });
 
-  it('rejects an unresolved broad Module Federation declaration', () => {
+  it('defers an unresolved managed Module Federation declaration to install', () => {
     writePackageJson({
       devDependencies: {
         '@module-federation/metro': 'workspace:*',
@@ -816,9 +935,14 @@ describe('bootstrapMetroCommands', () => {
 
     const result = bootstrapMetroCommands(tempDir);
 
-    expect(result.integration).toBe('ambiguous');
-    expect(result.manualGuidance[0]).toContain(
-      '@module-federation/metro declaration "workspace:*"'
+    expect(result.integration).toBe('react-native-cli');
+    expect(result.manualGuidance).toEqual([]);
+    expect(result.packageRequirements).toContainEqual(
+      expect.objectContaining({
+        name: '@module-federation/metro',
+        requireResolved: true,
+        version: '^2.9.0',
+      })
     );
   });
 


### PR DESCRIPTION
### What is added in this PR?

- Scope exported config and helper-result detection to top-level lexical declarations.
- Require adapter calls to originate from verified top-level `zephyr-metro-plugin` imports or requires.
- Generate collision-free CommonJS and ESM aliases when an adapter name is already occupied.
- Preserve unresolved `workspace:` and `catalog:` declarations through package installation and post-install compatibility checks.
- Add regressions for nested binding collisions, shadowed imports/results, CJS/ESM aliases, and managed dependency protocols.

#### Screenshots

Not applicable.

### What issue or discussion is related to this PR?

Closes #613. Immediate follow-up to #611 and its final Codex P2 findings.

### What are the steps to test this PR?

1. Run `pnpm --filter with-zephyr test`.
2. Run `pnpm --filter with-zephyr typecheck`.
3. Run `pnpm --filter with-zephyr build`.
4. Run `pnpm exec oxlint libs/with-zephyr/src/engine/ast-grep.ts libs/with-zephyr/src/metro-bootstrap.ts libs/with-zephyr/src/index.ts libs/with-zephyr/src/tests/metro-bootstrap.test.ts libs/with-zephyr/src/tests/codemod.test.ts`.
5. Run `pnpm exec oxfmt --check libs/with-zephyr/src/engine/ast-grep.ts libs/with-zephyr/src/metro-bootstrap.ts libs/with-zephyr/src/index.ts libs/with-zephyr/src/tests/metro-bootstrap.test.ts libs/with-zephyr/src/tests/codemod.test.ts`.

All 174 `with-zephyr` tests pass locally. Build, type-check, lint, formatting, and diff checks pass.

### Documentation update for this PR

No documentation change required; this hardens existing codemod behavior.

### What is left to be done?

- CI and review.

### What is the potential risk and how is it mitigated?

The AST checks are intentionally more conservative and may leave unusual nested configurations for manual setup rather than guessing. Existing top-level CJS/ESM, namespace, alias, rerun, and publication bootstrap paths remain covered. Managed dependency declarations are never rewritten, but resolved versions are still validated before publication guidance is emitted.